### PR TITLE
link fixed with hard return and minor edits

### DIFF
--- a/devGuide/en/chapters/04-theme-development.markdown
+++ b/devGuide/en/chapters/04-theme-development.markdown
@@ -366,7 +366,8 @@ display the new footer containing the slogan.
  ![note](../../images/tip-pen-paper.png)**Note:** A language properties hook
  should be used to properly display configurable theme settings, such as the
  slogan text area and footer checkbox from the previous example. For details, 
- see the [Overriding a Language.properties File](http://www.liferay.com/documentation/liferay-portal/6.1/development/-/ai/overriding-a-<em>language-properties<-em>-fi-3) section found in the *Hooks* chapter of this guide.
+ see the [Overriding a *Language.properties* File](https://www.liferay.com/documentation/liferay-portal/6.1/development/-/ai/overriding-a-%3Cem%3Elanguage-properties-lt-em-gt-fi-1)
+ section found in the *Hooks* chapter of this guide.
 
 Next, we'll take a look at how to manage color schemes in your theme.
 


### PR DESCRIPTION
Hi Rich,

In the Dev guide, there was a formatting error that included text within a link. You can see the problem here (at the bottom of the "Settings" page):

https://www.liferay.com/documentation/liferay-portal/6.1/development/-/ai/settin-4

I updated the link to point to that exact section. Also, I gave a hard return to the text. The problem is now fixed with this commit.
