### PR TITLE
LRDOCS-352: removed property and description (hasn't been used since 6.0...

### DIFF
--- a/userGuide/en/chapters/20-properties-reference.markdown
+++ b/userGuide/en/chapters/20-properties-reference.markdown
@@ -4458,13 +4458,9 @@ Set the name of a class that implements `com.liferay.portal.kernel.sanitizer.San
 
 ## Scheduler [](id=scheduler)
 
-Set this to `false` to disable all scheduler classes defined in `liferay-portlet.xml` and in the property `scheduler.classes`.
+Set this to `false` to disable all scheduler classes defined in `liferay-portlet.xml`.
 
 	scheduler.enabled=true
-
-Input a list of comma delimited class names that implement `com.liferay.portal.kernel.job.Scheduler`. These classes allow jobs to be scheduled on startup. These classes are not associated to any one portlet.
-
-	scheduler.classes=
 
 Set the maximum length of description, group name and job name fields.
 


### PR DESCRIPTION
Hi Rich,

Although the "Properties Reference" section of the User Guide has been dormant due to the upcoming converter for 6.2, I removed the "scheduler.classes" property and description because it has not been used since 6.0.x. Therefore, I removed it for the 6.1 User Guide.
