### PR TITLE
LRDOCS-383 improve namespacing of dist ZIP files.

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -170,9 +170,9 @@ directory to convert the userGuide into complete English markdown, html, odt, an
         </zip>
     </target>
 
-    <target name="concat-markdown-files" depends="prepare" description="concatinates multiple markdown files into a single one">
+    <target name="concat-markdown-files" depends="prepare" description="concatenates multiple markdown files into a single one">
     <property file="./doc.properties" />
-        <echo message="... concatinating markdown files for ${product.abbrev} ${product.version}-${doc.dir} (${lang})"/>
+        <echo message="... concatenating markdown files for ${product.abbrev} ${product.version}-${doc.dir} (${lang})"/>
         <concat destfile="./${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown" fixlastline = "yes">
             <fileset dir="./${lang}" casesensitive="yes">
                 <include name="**/*.markdown"/>


### PR DESCRIPTION
This change is needed so that our 6.2 asset imports do not conflict with the 6.1 assets imports and future imports. Note, particularly, the image file folder is based on the zip file name.

Important: This change is for trunk only. It is NOT for the 6.1.x branch.

Thanks.

@codyhoag Thanks for doing this.
