### PR TITLE
Reinstate build-common.xml changes overwritten by LRDOCS-429

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -158,32 +158,22 @@ directory to convert the userGuide into complete English markdown, html, odt, an
     </target>
 
     <target name="dist" depends="clean-lang, prepare-dist, concat-markdown-files" description="prepares document zip file for asset import">
+        <property file="./doc.properties" />
         <copy todir="${dist.dir}/${lang}">
 		    <fileset dir="${build.dir}/${lang}">
-                <include name="${lang}-${doc.dir}.markdown"/>
+                <include name="${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
             </fileset>
         </copy>
-        <zip destfile="${dist.dir}/${lang}/${lang}-${doc.dir}.zip">
+        <zip destfile="${dist.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.zip">
             <fileset dir="${dist.dir}/${lang}" includes="images/*.*"/>
             <fileset dir="${dist.dir}/${lang}" includes="${lang}-${doc.dir}.markdown"/>
         </zip>
     </target>
 
-    <target name="dist-win" depends="clean-lang, prepare-dist, concat-markdown-files" description="prepares document zip file for asset import on windows">
-        <copy todir="${dist.dir}/${lang}">
-            <fileset dir="${build.dir}/${lang}">
-                <include name="${lang}-${doc.dir}.markdown"/>
-            </fileset>
-        </copy>
-        <zip destfile="${dist.dir}/${lang}/${lang}-${doc.dir}.zip">
-            <fileset dir="${dist.dir}/${lang}" includes="images/*.*"/>
-            <fileset dir="${dist.dir}/${lang}" includes="${lang}-${doc.dir}.markdown"/>
-        </zip>
-    </target>
-
-    <target name="concat-markdown-files" depends="prepare" description="concatinates multiple markdown files into a single one">
-        <echo message="... concatinating markdown files for ${doc.dir} (${lang})"/>
-        <concat destfile="./${build.dir}/${lang}/${lang}-${doc.dir}.markdown" fixlastline = "yes">
+    <target name="concat-markdown-files" depends="prepare" description="concatenates multiple markdown files into a single one">
+        <property file="./doc.properties" />
+        <echo message="... concatenating markdown files for ${product.abbrev} ${product.version}-${doc.dir} (${lang})"/>
+        <concat destfile="./${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown" fixlastline = "yes">
             <fileset dir="./${lang}" casesensitive="yes">
                 <include name="**/*.markdown"/>
             </fileset>
@@ -191,7 +181,7 @@ directory to convert the userGuide into complete English markdown, html, odt, an
     </target>
 
     <target name="markdown-to-html" depends="check-images, add-markdown-metadata" description="converts markdown file to an html file">
-        <echo message="... converting ${doc.dir} (${lang}) to html"/>
+        <echo message="... converting ${product.abbrev} ${product.version}-${doc.dir} (${lang}) to html"/>
         <!-- pandoc -f markdown -t html -o test-guide.html  test-guide.markdown -->
         <exec executable="${pandoc.app}">
             <arg value="-f" />
@@ -203,13 +193,13 @@ directory to convert the userGuide into complete English markdown, html, odt, an
             <arg value="-RTS"/>
             <arg value="-smart"/>-->
             <arg value="-o"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.html"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.markdown"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.html"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
         </exec>      
     </target>
 
     <target name="markdown-to-html-win" depends="check-images, concat-markdown-files" description="converts markdown file to an html file on windows">
-        <echo message="... converting ${doc.dir} (${lang}) to html"/>
+        <echo message="... converting ${product.abbrev} ${product.version}-${doc.dir} (${lang}) to html"/>
         <!-- pandoc -f markdown -t html +RTS K64m -RTS -o 01-chapter-02.html  01-chapter-02.markdown -->
         <exec executable="cmd">
             <arg value="/C" />
@@ -223,13 +213,13 @@ directory to convert the userGuide into complete English markdown, html, odt, an
             <arg value="-RTS"/>-->
             <arg value="-smart"/>
             <arg value="-o"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.html"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.markdown"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.html"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
         </exec>      
     </target>
 
     <target name="markdown-to-odt" depends="add-markdown-metadata" description="converts markdown file to an odt file">
-        <echo message="... converting ${doc.dir} (${lang}) to odt"/>
+        <echo message="... converting ${product.abbrev} ${product.version}-${doc.dir} (${lang}) to odt"/>
         <!-- pandoc -f markdown -t odt -o test-guide.odt  test-guide.markdown -->
         <exec executable="${pandoc.app}" dir="${build.dir}/${lang}">
             <arg value="-f" />
@@ -241,13 +231,13 @@ directory to convert the userGuide into complete English markdown, html, odt, an
             <arg value="-RTS"/>
             <arg value="-smart"/>
             <arg value="-o"/>
-            <arg value="./${lang}-${doc.dir}.odt"/>
-            <arg value="./${lang}-${doc.dir}.markdown"/>
+            <arg value="./${lang}-${product.abbrev}-${product.version}-${doc.dir}.odt"/>
+            <arg value="./${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
         </exec>      
     </target>
 
     <target name="markdown-to-odt-win" depends="concat-markdown-files" description="converts markdown file to an ODT file on Windows">
-        <echo message="... converting ${doc.dir} (${lang}) to odt on windows"/>
+        <echo message="... converting ${product.abbrev} ${product.version}-${doc.dir} (${lang}) to odt on windows"/>
         <!-- pandoc -f markdown -t odt +RTS K64m -RTS -o 01-chapter-02.odt 01-chapter-02.markdown -->
         <exec executable="cmd">
             <arg value="/C" />
@@ -261,13 +251,13 @@ directory to convert the userGuide into complete English markdown, html, odt, an
             <arg value="-RTS"/>
             <arg value="-smart"/>
             <arg value="-o"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.odt"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.markdown"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.odt"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
         </exec>      
     </target>
 
     <target name="markdown-to-epub" depends="add-markdown-metadata" description="converts markdown file to an epub file">
-        <echo message="... converting ${doc.dir} (${lang}) to epub"/>
+        <echo message="... converting ${product.abbrev} ${product.version}-${doc.dir} (${lang}) to epub"/>
         <!-- pandoc -f markdown -t epub -o test-guide.epub  test-guide.markdown -->
         <exec executable="${pandoc.app}">
             <arg value="-f" />
@@ -279,13 +269,13 @@ directory to convert the userGuide into complete English markdown, html, odt, an
             <arg value="-RTS"/>
             <arg value="-smart"/>-->
             <arg value="-o"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.epub"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.markdown"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.epub"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
         </exec>      
     </target>
 
     <target name="markdown-to-epub-win" depends="concat-markdown-files" description="converts markdown file to an epub file on windows">
-        <echo message="... converting ${doc.dir} (${lang}) to epub"/>
+        <echo message="... converting ${product.abbrev} ${product.version}-${doc.dir} (${lang}) to epub"/>
         <exec executable="cmd">
             <arg value="/C" />
             <arg value="pandoc"/>
@@ -297,8 +287,8 @@ directory to convert the userGuide into complete English markdown, html, odt, an
             <arg value="-K64m"/>
             <arg value="-RTS"/>-->
             <arg value="-o"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.epub"/>
-            <arg value="${build.dir}/${lang}/${lang}-${doc.dir}.markdown"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.epub"/>
+            <arg value="${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
         </exec>      
     </target>
 
@@ -467,10 +457,10 @@ directory to convert the userGuide into complete English markdown, html, odt, an
 
  <!-- deprecated on Jan. 6, 2012 -->
     <target name="add-markdown-metadata" depends="concat-markdown-files" description="adds metadata to the top of a concatenated markdown file">
-        <echo message="... adding metadata to ${doc.dir} (${lang})"/>
+        <echo message="... adding metadata to ${product.abbrev} ${product.version}-${doc.dir} (${lang})"/>
         <java jar="../lib/liferay-doc-utils.jar" fork="true">
 	    <arg value="AddMarkdownMetadata"/>
-            <arg value="./${build.dir}/${lang}/${lang}-${doc.dir}.markdown"/>
+            <arg value="./${build.dir}/${lang}/${lang}-${product.abbrev}-${product.version}-${doc.dir}.markdown"/>
             <arg value="${title}"/>
             <arg value="${author}"/>
             <arg value="${date}"/>


### PR DESCRIPTION
Jesse overwrote this content by mistake. He said reinstating the original content that was overwritten would not adversely affect the indexer target.

This is for trunk only.
Thanks,
Jim
