### PR TITLE
http://issues.liferay.com/browse/LRDOCS-723

### DIFF
--- a/userGuide/en/chapters/15-installation-and-setup.markdown
+++ b/userGuide/en/chapters/15-installation-and-setup.markdown
@@ -2237,7 +2237,7 @@ Then add the following `JAVA_OPTS` assignment one line above the
   replacing any matching attributes with the ones found in the assignment
   below:
 
-			JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=256m
+			JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=256m"
 		
 The prescribed script modifications are now complete for your Liferay
 installation on JBoss. Next we'll consider the database and mail configuration. 


### PR DESCRIPTION
http://issues.liferay.com/browse/LRDOCS-723

Added missing quotation mark symbol to the end of the JAVA_OPTS string in the JBoss installation section of the User Guide
