### PR TITLE
https://issues.liferay.com/browse/LRDOCS-711

### DIFF
--- a/userGuide/en/chapters/15-installation-and-setup.markdown
+++ b/userGuide/en/chapters/15-installation-and-setup.markdown
@@ -2119,6 +2119,34 @@ resource root entry with that of your database driver.
 		
 Great! You have your `.jar` files ready for your domain.
 
+### Running Liferay on JBoss 7 in Standalone Mode vs. Domain Mode
+
+JBoss 7 can be launched in either *standalone* mode or *domain* mode. Running
+JBoss 7 in domain mode allows multiple application server instances to be
+managed from a single control point. A collection of such application servers is
+known as a *domain*. For more information on standalone mode vs. domain mode,
+please refer to the section on this topic in the [JBoss 7 User Guide](https://community.jboss.org/wiki/JBossAS7UserGuide?_sscc=t).
+Liferay fully supports JBoss 7 when it's run in standalone mode but not when
+it's run in domain mode.
+
+You can run Liferay on JBoss 7 when it's run in domain mode but this method is
+not fully supported. In particular, Liferay's hot-deploy does not work when
+JBoss 7 is run in domain mode since JBoss 7 cannot deploy non-exploded `.war`
+files in domain mode. This prevents many Liferay plugins from working as
+intended. For example, JSP hooks won't work on a Liferay running on a JBoss 7
+running in domain mode since Liferay's JSP override mechanism relies on the
+application server reloading customized JSP files from the exploded plugin
+`.war` file location. Other plugins, such as service or action hooks, should
+still work properly since they don't require JBoss to access anything (such as
+JSP files) from an exploded `.war` file on the file system. The best practice
+when running Liferay on JBoss 7 is to use standalone mode.
+
+Note: This does not prevent Liferay from running in a clustered environment on
+multiple JBoss servers. You can set up a cluster of Liferay instances running on
+JBoss 7 servers running in standalone mode. Please refer to the chapter of this
+guide on [Configuring Liferay for High Availability](https://www.liferay.com/documentation/liferay-portal/6.2/user-guide/-/ai/configuring-liferay-for-high-availabili-liferay-portal-6-2-user-guide-20-en)
+for information on setting up a Liferay cluster.
+
 ### Configuring JBoss [](id=configuring-jboss-liferay-portal-6-2-user-guide-15-en)
 
 Let's make some adjustments in your configuration to support using Liferay.


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-711

Added section on JBoss 7's standalone mode vs domain mode, explained that standalone is fully support while domain mode is not; in particular, JBoss 7 in domain mode does not support deploying non-exploded .war files
