### PR TITLE
LPS-40307 - Updating docs to remove incorrect information

### DIFF
--- a/userGuide/en/chapters/20-properties-reference.markdown
+++ b/userGuide/en/chapters/20-properties-reference.markdown
@@ -3867,7 +3867,6 @@ Set JGroups' system properties. System properties have higher priority than indi
 		#
 		\
 		jgroups.bind_addr:localhost,\
-		#jgroups.bind_interface:eth0,\
 		\
 		#
 		# Multicast


### PR DESCRIPTION
Hey Rich, Making a small correction to the docs. The configuration value doesn't work due to how a third party library works.
