### PR TITLE
https://issues.liferay.com/browse/LRDOCS-768

### DIFF
--- a/userGuide/en/chapters/03-advanced-web-content-management.markdown
+++ b/userGuide/en/chapters/03-advanced-web-content-management.markdown
@@ -140,6 +140,20 @@ your structure, you can access the WebDAV URL by re-opening the structure or
 template and clicking the *Details* section. If you'd like the see WebDAV in
 action, visit the *Document Management* chapter's *WebDAV access* chapter.
 
+---
+
+ ![Note](../../images/01-tip.png) **Note:** Some operating systems require a
+ WebDAV server to be class level 2 before (i.e., to support file locking) before
+ allowing files to be read or written. For Liferay 6.2, the Documents and Media
+ library was upgraded to class level 2 but Web Content structures and templates
+ were not. This means that Liferay 6.2's Document and Media library supports
+ WebDAV file locking but Web Content structures and templates do not. However,
+ on operating systems which require WebDAV servers to be class level 2, it's
+ possible to avoid the restriction by using third-party WebDAV clients (e.g.,
+ [Cyberduck](http://cyberduck.ch).
+
+---
+
 Another method to edit your structure is switching to *Source* mode and manually
 customizing your structure by editing its XML file. You'll notice by default the
 *View* mode is selected. Click the *Source* tab to switch to Source mode. This


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-768

Added note that Web Content structures and templates don't support file locking while Documents and Media does. Added workaround for operating systems that require WebDAV file-locking: use a third-party WebDAV like Cyberduck to avoid the requirement.
