### PR TITLE
LRDOCS-848: Correct CATALINA_OPTS typo

### DIFF
--- a/devGuide/en/chapters/09-themes-and-layouts.markdown
+++ b/devGuide/en/chapters/09-themes-and-layouts.markdown
@@ -302,7 +302,7 @@ The following is an example of the `CATALINA_OPTS` variable lines with the
              =false
          -Duser.timezone=GMT
          -Xmx1024m
-         -XX:MaxPermSize=256m"
+         -XX:MaxPermSize=256m
          -Dexternal-properties=portal-developer.properties"
 
 ---


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-848

@jhinkey This was discovered by a user comment in the Dev Guide. Fixed trivial error accordingly.
