### PR TITLE
LRDOCS-848: Correct CATALINA_OPTS typo (6.1.x)

### DIFF
--- a/devGuide/en/chapters/05-theme-development.markdown
+++ b/devGuide/en/chapters/05-theme-development.markdown
@@ -251,7 +251,7 @@ The following is an example of the `CATALINA_OPTS` variable lines with the
              =false
          -Duser.timezone=GMT
          -Xmx1024m
-         -XX:MaxPermSize=256m"
+         -XX:MaxPermSize=256m
          -Dexternal-properties=portal-developer.properties"
 
 If you're already using the system property `external-properties` to load other


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-848
