### PR TITLE
Failonerror to true for number header and site's article-to-html java tasks

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -303,6 +303,7 @@ English markdown, html, odt, and epub documents.
 		<java
 			classname="com.liferay.documentation.util.NumberHeadersTask"
 			classpathref="project.classpath"
+			failonerror="true"
 			fork="true"
 		>
 			<arg value="${doc.dir}"/>

--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -47,6 +47,7 @@
 		<java
 			classname="com.liferay.documentation.util.MarkdownToHtmlMain"
 			classpathref="project.classpath"
+			failonerror="true"
 			fork="true"
 		>
 			<arg value="${article}"/>
@@ -83,6 +84,7 @@
 		<java
 			classname="com.liferay.documentation.util.NumberHeadersSiteMain"
 			classpathref="project.classpath"
+			failonerror="true"
 			fork="true"
 		>
 			<arg value="${doc.dir}"/>


### PR DESCRIPTION
Unless number-headers fails the Ant build, it's hard to notice when we have conflicting header IDs.
