### PR TITLE
Ignore folders anywhere below current directory by using this pattern: folder/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,13 +15,11 @@ properties/
 /*.patch
 /build.*.properties
 
-**/build/**
-**/classes/**
-**/dist/**
+build/
+classes/
+dist/
 **nbproject**
-**/.ivy/*
-**/.sass-cache/**
-**/.DS_Store/*
+.ivy/
+.sass-cache/
+.DS_Store/
 *#
-/bin
-/classes/


### PR DESCRIPTION
I wanted to ignore the build/ and dist/ folders under use/social-office, so I fixed our patterns in the root .ignore file.
