### PR TITLE
Modified .gitignore to ignore build.*.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ properties/
 /*.ipr
 /*.iws
 /*.patch
-/build.*.properties
+build.*.properties
 
 build/
 classes/


### PR DESCRIPTION
With the new directory structure, the .gitignore wasn't picking up build.[russell].properties. Removing the / seems to make it ignore the build.russell.properties thoughout the liferay-docs project.
