### PR TITLE
Fix - Remove LiferayFacesContext Reference

### DIFF
--- a/devGuide/en/chapters/04-developing-jsf-portlets.markdown
+++ b/devGuide/en/chapters/04-developing-jsf-portlets.markdown
@@ -425,19 +425,8 @@ response object from `externalContext.getResponse()` is cast to the
         }
     }
  
-The code listing above uses the singleton class `LiferayFacesContext`, which has
-methods `getPortletRequest()` and `getPortletResponse()`. You can leverage the
-`LiferayFacesContext` class in your JSF portlets on Liferay to get easy access
-to the portlet requests and responses. This class comes with Liferay Faces
-Portal, which we'll cover in detail in later sections. 
-
-<!-- I think more explanation here is necessary. There's no indication in the
-code that LiferayFacesContext is the implementation that's returned, and there's
-no explanation as to why you didn't use the getPortletRequest() and
-getPortletResponse() methods. I can assume from reading it that you didn't use
-them because you were going for a more generic, portlet container-friendly
-implementation in this first example, but I (and the reader) am not sure of
-that. -Rich -->
+Notice that you're able to retrieve the `ExternalContext` from the current
+`FacesContext` instance. 
 
 In the next section, we'll explain how to internationalize your JSF portlets. 
 

--- a/develop/tutorials/articles/liferay-faces/accessing-the-portlet-api-with-externalcontext-for-jsf-portlets.markdown
+++ b/develop/tutorials/articles/liferay-faces/accessing-the-portlet-api-with-externalcontext-for-jsf-portlets.markdown
@@ -35,24 +35,9 @@ response object from `externalContext.getResponse()` is cast to the
                 (PortletResponse) externalContext.getResponse();
         }
     }
- 
-The code listing above uses the singleton class `LiferayFacesContext`, which has
-methods `getPortletRequest()` and `getPortletResponse()`. You can leverage the
-`LiferayFacesContext` class in your JSF portlets on Liferay to get easy access
-to the portlet requests and responses. <!-- This class comes with Liferay Faces
-Portal, which can be covered in the [Liferay Faces Portal](www.liferay.com)
-tutorial. 
 
-Replace above link once Liferay Faces Portal tutorials are available. -Cody
--->
-
-<!-- I think more explanation here is necessary. There's no indication in the
-code that LiferayFacesContext is the implementation that's returned, and there's
-no explanation as to why you didn't use the getPortletRequest() and
-getPortletResponse() methods. I can assume from reading it that you didn't use
-them because you were going for a more generic, portlet container-friendly
-implementation in this first example, but I (and the reader) am not sure of
-that. -Rich -->
+Notice that you're able to retrieve the `ExternalContext` from the current
+`FacesContext` instance. 
 
 In this tutorial, you've explored requesting objects from the portlet API using
 `ExternalContext`. 


### PR DESCRIPTION
I spoke with Neil about a inconsistency in a Liferay Faces tutorial dealing with the `LiferayFacesContext` and `FacesContext` classes. He recommended we delete the `LiferayFacesContext` reference and use `FacesContext` in the tutorial's code snippet. He characterized the `LiferayFacesContext` class as "semi-deprecated" due to a controversial message in the Liferay Forums, so he'd like to steer away from encouraging the use of that class.

@jhinkey

https://issues.liferay.com/browse/LRDOCS-1520