### PR TITLE
Fix - Update Maven Command Line tutorial

### DIFF
--- a/develop/learning-paths/mvc/articles/02-writing-a-data-driven-application/02-integrating-persistence-framework.markdown
+++ b/develop/learning-paths/mvc/articles/02-writing-a-data-driven-application/02-integrating-persistence-framework.markdown
@@ -70,7 +70,7 @@ Now you're ready to create a method that adds `Guestbook`s to the database.
 
     Most of this makes sense at the moment: you know that you want the ID of the
     user who is adding the guestbook, along with its name. But what's this
-    `ServiceContext` thing? [We're glad you asked](https://www-ldn.liferay.com/encyclopedia/-/wiki/Main/Service+Context).
+    `ServiceContext` thing? [We're glad you asked](/participate/liferaypedia/-/wiki/Main/Service+Context).
     Beyond the encyclopedia entry, `ServiceContext` is needed in order to pass
     information about the browsing session that triggered your method that adds a
     guestbook. Liferay uses the `ServiceContext` as a convenient container for

--- a/develop/tutorials/articles/customizing-liferay-portal/overriding-language-props-hook.markdown
+++ b/develop/tutorials/articles/customizing-liferay-portal/overriding-language-props-hook.markdown
@@ -52,7 +52,8 @@ property hook plugin for overriding Liferay's default text values with your own
 custom values. 
 
 1.  If you don't yet have a hook project, create one following the steps in the 
-    [Creating a Hook](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-a-hook-lp-6-2-develop-tutorial) tutorial.
+    [Creating a Hook](/develop/tutorials/-/knowledge_base/6-2/creating-a-hook-project-in-the-plugins-sdk)
+    tutorial.
 
 2.  In Liferay IDE, right click your hook project and select *New* &rarr;
 *Liferay Hook Configuration*. In the window that appears, select the *Language

--- a/develop/tutorials/articles/maven/creating-layout-templates-maven.markdown
+++ b/develop/tutorials/articles/maven/creating-layout-templates-maven.markdown
@@ -22,9 +22,9 @@ template plugin with Maven.
 ## Creating a Layout Template Plugin [](id=creating-a-layout-template-plugin)
 
 To create a Liferay layout template plugin project, follow the
-[Creating Liferay Maven Plugins from Liferay IDE](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
+[Creating Liferay Maven Plugins from Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
 tutorial or the 
-[Creating Liferay Maven Plugins from the Command Line](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
+[Creating Liferay Maven Plugins from the Command Line](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
 tutorial, making sure to select *Layout Template* as the plugin type. 
 
 +$$$

--- a/develop/tutorials/articles/maven/creating-liferay-hooks-maven.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-hooks-maven.markdown
@@ -8,9 +8,9 @@ the Liferay Maven hook plugin project's anatomy.
 ## Creating a Hook Plugin [](id=creating-a-hook-plugin)
 
 To create a Liferay hook plugin project, follow the steps outlined in the
-[Creating Liferay Maven Plugins from Liferay IDE](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
+[Creating Liferay Maven Plugins from Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
 tutorial or the
-[Creating Liferay Maven Plugins from the Command Line](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
+[Creating Liferay Maven Plugins from the Command Line](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
 tutorial, making sure to select *Hook* as the plugin type. 
 
 +$$$

--- a/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-command-line.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-command-line.markdown
@@ -10,6 +10,19 @@ Liferay plugin projects using the command line.
 
 Follow these steps to create a Liferay plugin from the command line:
 
+<!-- **Important:** Sometimes, after a new Liferay release, the Liferay CE and
+EE artifacts might only be available from
+[repository.liferay.com](repository.liferay.com). In this case, you must use the
+`-DarchetypeCatalog=...` option to access the Liferay Repository when generate
+Maven archetypes (e.g., mvn archetype:generate
+-DarchetypeCatalog=https://repository.liferay.com/nexus/content/groups/liferay-ce.
+You'll also need to configure a couple other files to ensure the generation
+command completes successfully. Please refer to the *Installing Artifacts from
+the Liferay Repository* section of the [Setting Up
+Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven) tutorial to
+configure Maven to access the Liferay Repository for Liferay CE and EE
+artifacts. -Cody -->
+
 1.  Open the command prompt or terminal and navigate to the parent directory in
     which you want to create the plugin project. Archetype create a
     sub-directory for each plugin project you create.
@@ -24,53 +37,14 @@ Follow these steps to create a Liferay plugin from the command line:
 
 $$$
 
-2.  Execute the command
+2.  Execute the following command: 
 
-        mvn archetype:generate -DarchetypeCatalog=https://repository.liferay.com/nexus/content/groups/liferay-ce
-
-+$$$
-
-**Important:** Sometimes, after a
-    new Liferay release, the Liferay CE and EE artifacts might only be available
-    from [repository.liferay.com](repository.liferay.com). In this case, you
-    must use the `-DarchetypeCatalog=...` option to access the Liferay
-    Repository.  You'll also need to configure a couple other files to ensure
-    the generation command completes successfully. Please refer to the
-    *Installing Artifacts from the Liferay Repository* section of the
-    [Setting Up Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
-    tutorial to configure Maven to access the Liferay Repository for Liferay CE
-    and EE artifacts. 
-
-$$$
-
-    <!-- Edit archetype generate command and remove above note when GA1 artifacts
-    are available from Maven Central. -Cody -->
+        mvn archetype:generate
 
     Archetype starts and lists the archetypes available to you. You're prompted
     to *choose* an archetype or *filter* archetypes by group / artifact ID. The
     output looks like this: 
 
-        ...
-        6: https://repository.liferay.com/nexus/content/groups/liferay-ce -> 
-        com.liferay.maven.archetypes:liferay-portlet-liferay-faces-alloy-archetype
-        (Provides an archetype to create Liferay Faces Alloy portlets.)
-        7: https://repository.liferay.com/nexus/content/groups/liferay-ce/ -> 
-        com.liferay.maven.archetypes:liferay-portlet-jsf-archetype
-        (Provides an archetype to create Liferay JSF portlets.)
-        8: https://repository.liferay.com/nexus/content/groups/liferay-ce/ ->
-        com.liferay.maven.archetypes:liferay-portlet-archetype
-        (Provides an archetype to create Liferay portlets.)
-        9: https://repository.liferay.com/nexus/content/groups/liferay-ce/ ->
-        com.liferay.maven.archetypes:liferay-layouttpl-archetype
-        (Provides an archetype to create Liferay layout templates.)
-        10: https://repository.liferay.com/nexus/content/groups/liferay-ce ->
-        com.liferay.maven.archetypes:liferay-hook-archetype
-        (Provides an archetype to create Liferay hooks.)
-        ...
-        Choose a number or apply filter (format: [groupId:]artifactId, case 
-        sensitive contains):
-        
-<!--
         ...
         39: remote -> com.liferay.maven.archetypes:liferay-hook-archetype
         (Provides an archetype to create Liferay hooks.)
@@ -85,25 +59,15 @@ $$$
         ...
         Choose a number or apply filter (format: [groupId:]artifactId,
         case sensitive contains):
--->
-<!-- Output will look similar to this once GA1 artifacts are officially
-available on Maven Central/ZIP files. Add similar output back, when available
--Cody -->
 
-3. Choose a Liferay portlet archetype by entering its number. If you're using
-the Liferay Repository, the newest archetype version is automatically selected.
-
-<!--
 3.  To find the right Liferay archetype for your project, you can either scroll
     up to find it or apply filters to narrow the set of results. Filtering on
     *liferay* as your group ID, and a plugin type (*portlet*, *hook*, *theme*,
     etc.) can help you focus on more applicable Liferay archetypes. 
 
     Entering `liferay:portlet` as a filter gives a listing of Liferay portlet
-    archetypes: -->
-<!-- Add back when filtering is relevant (using GA1 artifacts from Central -Cody
--->
-<!--
+    archetypes: 
+
         Choose a number or apply filter (format: [groupId:]artifactId, case
         sensitive contains): : liferay:portlet Choose archetype:
         1: remote -> com.liferay.maven.archetypes:liferay-portlet-archetype
@@ -125,10 +89,8 @@ the Liferay Repository, the newest archetype version is automatically selected.
         number or apply filter (format: [groupId:]artifactId, case sensitive co
         ntains): :
 
-4.  Choose an archetype by entering its number.-->
-<!-- Add back when step 3. is added back -->
+4.  Choose an archetype by entering its number. 
 
-<!--
 5.  You're prompted to choose the archetype version. Enter the number
     corresponding to the Liferay version for the archetype. However, you're not
     required to select the archetype version that corresponds with your Liferay
@@ -147,21 +109,20 @@ the Liferay Repository, the newest archetype version is automatically selected.
         9: 6.1.10
         10: 6.1.20
         11: 6.1.30
-        12: 6.2.0-B1
-        13: 6.2.0-B2
-        14: 6.2.0-B3
-        15: 6.2.0-M5
-        16: 6.2.0-M6
-        17: 6.2.0-RC1
-        18: 6.2.0-RC2
-        19: 6.2.0-RC3
-        20: 6.2.0-RC4
-        21: 6.2.0-RC5
-        Choose a number: 21:
--->
-<!-- Add back when GA1 artifacts are available from Central. --Cody -->
+        12: 6.1.30.1
+        ...
+        23: 6.2.1
+        24: 6.2.10.4
+        25: 6.2.10.5
+        26: 6.2.10.6
+        27: 6.2.10.7
+        28: 6.2.10.8
+        29: 6.2.10.9
+        30: 7.0.0-m1
+        31: 7.0.0-m2
+        Choose a number: 31:
 
-4.  Enter values for the *groupId*, *artifactId*, *version*, and *package*
+6.  Enter values for the *groupId*, *artifactId*, *version*, and *package*
     coordinates (properties) of your project. Here are some examples: 
 
         groupId: com.liferay.sample
@@ -176,7 +137,7 @@ the Liferay Repository, the newest archetype version is automatically selected.
     For more information on defining Maven coordinates, see
     [http://maven.apache.org/pom.html#Maven_Coordinates](http://maven.apache.org/pom.html#Maven_Coordinates).
 
-5.  Enter the letter *Y* to confirm your coordinates.
+7.  Enter the letter *Y* to confirm your coordinates.
 
     Maven's Archetype tool creates a Liferay plugin project directory with a new
     `pom.xml` file and source code. 

--- a/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-command-line.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-command-line.markdown
@@ -23,21 +23,20 @@ Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven) tutorial to
 configure Maven to access the Liferay Repository for Liferay CE and EE
 artifacts. -Cody -->
 
-1.  Open the command prompt or terminal and navigate to the parent directory in
-    which you want to create the plugin project. Archetype create a
-    sub-directory for each plugin project you create.
+1. Open the command prompt or terminal and navigate to the parent directory in
+   which you want to create the plugin project. Archetype create a sub-directory
+   for each plugin project you create.
 
-+$$$
+    +$$$
 
-**Note:** If you haven't already
-    created a parent project, you may want to consider creating one to share
-    common project information. See the
+    **Note:** If you haven't already created a parent project, you may want to
+    consider creating one to share common project information. See the
     [Using Liferay Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
     tutorial for details.
 
-$$$
+    $$$
 
-2.  Execute the following command: 
+2. Execute the following command: 
 
         mvn archetype:generate
 
@@ -60,10 +59,10 @@ $$$
         Choose a number or apply filter (format: [groupId:]artifactId,
         case sensitive contains):
 
-3.  To find the right Liferay archetype for your project, you can either scroll
-    up to find it or apply filters to narrow the set of results. Filtering on
-    *liferay* as your group ID, and a plugin type (*portlet*, *hook*, *theme*,
-    etc.) can help you focus on more applicable Liferay archetypes. 
+3. To find the right Liferay archetype for your project, you can either scroll
+   up to find it or apply filters to narrow the set of results. Filtering on
+   *liferay* as your group ID, and a plugin type (*portlet*, *hook*, *theme*,
+   etc.) can help you focus on more applicable Liferay archetypes. 
 
     Entering `liferay:portlet` as a filter gives a listing of Liferay portlet
     archetypes: 
@@ -89,13 +88,13 @@ $$$
         number or apply filter (format: [groupId:]artifactId, case sensitive co
         ntains): :
 
-4.  Choose an archetype by entering its number. 
+4. Choose an archetype by entering its number. 
 
-5.  You're prompted to choose the archetype version. Enter the number
-    corresponding to the Liferay version for the archetype. However, you're not
-    required to select the archetype version that corresponds with your Liferay
-    instance; older archetype versions are compatible with updated Liferay
-    bundles. 
+5. You're prompted to choose the archetype version. Enter the number
+   corresponding to the Liferay version for the archetype. However, you're not
+   required to select the archetype version that corresponds with your Liferay
+   instance; older archetype versions are compatible with updated Liferay
+   bundles. 
 
         Choose com.liferay.maven.archetypes:liferay-portlet-archetype version:
         1: 6.0.2
@@ -122,8 +121,8 @@ $$$
         31: 7.0.0-m2
         Choose a number: 31:
 
-6.  Enter values for the *groupId*, *artifactId*, *version*, and *package*
-    coordinates (properties) of your project. Here are some examples: 
+6. Enter values for the *groupId*, *artifactId*, *version*, and *package*
+   coordinates (properties) of your project. Here are some examples: 
 
         groupId: com.liferay.sample
         artifactId: sample-portlet
@@ -137,7 +136,7 @@ $$$
     For more information on defining Maven coordinates, see
     [http://maven.apache.org/pom.html#Maven_Coordinates](http://maven.apache.org/pom.html#Maven_Coordinates).
 
-7.  Enter the letter *Y* to confirm your coordinates.
+7. Enter the letter *Y* to confirm your coordinates.
 
     Maven's Archetype tool creates a Liferay plugin project directory with a new
     `pom.xml` file and source code. 

--- a/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-command-line.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-command-line.markdown
@@ -2,7 +2,7 @@
 
 To learn how to use Liferay IDE to create Liferay Maven plugins, please refer to
 the 
-[Creating Liferay Maven Plugins from the Command Line](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
+[Creating Liferay Maven Plugins from the Command Line](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
 tutorial. This tutorial explains how to use Maven archetypes to generate
 Liferay plugin projects using the command line.
 
@@ -19,7 +19,7 @@ Follow these steps to create a Liferay plugin from the command line:
 **Note:** If you haven't already
     created a parent project, you may want to consider creating one to share
     common project information. See the
-    [Using Liferay Maven Parent Plugin Projects](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
+    [Using Liferay Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
     tutorial for details.
 
 $$$
@@ -37,7 +37,7 @@ $$$
     Repository.  You'll also need to configure a couple other files to ensure
     the generation command completes successfully. Please refer to the
     *Installing Artifacts from the Liferay Repository* section of the
-    [Setting Up Maven](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
+    [Setting Up Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
     tutorial to configure Maven to access the Liferay Repository for Liferay CE
     and EE artifacts. 
 

--- a/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-liferay-ide.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-maven-plugins-from-liferay-ide.markdown
@@ -11,7 +11,7 @@ detailed below to generate Liferay plugin projects of any type.
 As a prerequisite to running Archetype, make sure Maven is installed and that
 its executable is in your `$PATH` environment variable. Maven must also be fully
 configured. To configure Maven, follow the steps in the
-[Setting Up Maven](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
+[Setting Up Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
 tutorial.
 
 There are two ways of creating Liferay plugins with Maven: using Liferay
@@ -48,7 +48,7 @@ Liferay plugin project using Liferay IDE:
     the plugin project, specify the parent plugin project directory for the
     Location. It's a best practice to create a parent project for your Maven
     plugins, so they can all share common project information. See the
-    [Using Liferay Maven Parent Plugin Projects](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
+    [Using Liferay Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
     tutorial for details. 
 
 4.  Specify the *Artifact version*. For example, you can specify `1.0-SNAPSHOT`
@@ -75,7 +75,7 @@ Liferay plugin project using Liferay IDE:
     deployable. You'll need to specify the necessary properties within the new
     profile; the *Configuring
     Your Liferay Maven Project* section of the 
-    [Using Maven From Liferay IDE](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/using-maven-from-liferay-ide)
+    [Using Maven From Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/using-maven-from-liferay-ide)
     tutorial demonstrates specifying these properties. 
 
     You also have the option to create a profile based on a Liferay runtime. To

--- a/develop/tutorials/articles/maven/creating-liferay-portlets-maven.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-portlets-maven.markdown
@@ -6,9 +6,9 @@ anatomy of the Liferay Maven portlet plugin project.
 ## Creating a Portlet Plugin [](id=creating-a-portlet-plugin)
 
 To create your Liferay portlet plugin project, just follow the
-[Creating Liferay Maven Plugins from Liferay IDE](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
+[Creating Liferay Maven Plugins from Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
 tutorial or the
-[Creating Liferay Maven Plugins from the Command Line](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
+[Creating Liferay Maven Plugins from the Command Line](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
 tutorial, making sure to select *Portlet* as the plugin type. 
 
 +$$$

--- a/develop/tutorials/articles/maven/creating-liferay-themes-maven.markdown
+++ b/develop/tutorials/articles/maven/creating-liferay-themes-maven.markdown
@@ -6,8 +6,7 @@ than Poe's original, so far we have you and your cat, Lenore II, sitting by a
 fire on a cold winter evening.
 
 So you're sitting in your armchair next to the fire, as the Maven tutorials
-section
-[introduction](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/maven)
+section [introduction](/develop/tutorials/-/knowledge_base/6-2/maven)
 described. Shadows dance on the tapestry-covered wall, and Lenore II (your cat)
 is purring atop the mantle. Yes, you're passing this cold winter's night in
 grand style (in front of your computer, of course). Now imagine yourself
@@ -23,14 +22,14 @@ who visits.
 
 Theme plugin creation with Maven is similar to portlet plugin creation with
 Maven. If you don't already have a parent Maven project, please refer to the
-[Using Liferay Maven Parent Plugin Projects](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
+[Using Liferay Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-liferay-maven-parent-plugin-projects)
 tutorial. That tutorial explains how to create a parent Maven project and its
 `pom.xml`. 
 
 To create your Liferay theme plugin project, just follow the
-[Creating Liferay Maven Plugins from Liferay IDE](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
+[Creating Liferay Maven Plugins from Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-liferay-ide)
 tutorial or the
-[Creating Liferay Maven Plugins from the Command Line](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
+[Creating Liferay Maven Plugins from the Command Line](/develop/tutorials/-/knowledge_base/6-2/creating-liferay-maven-plugins-from-the-command-lin)
 tutorial, making sure to select *Theme* instead of *Portlet* as the plugin type. 
 
 +$$$
@@ -119,7 +118,7 @@ The theme plugin project POM has two additional properties:
         </properties>
 
 To deploy your theme plugin, follow the instructions in the
-[Deploying Liferay Plugins with Maven](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/deploying-liferay-plugins-with-maven)
+[Deploying Liferay Plugins with Maven](/develop/tutorials/-/knowledge_base/6-2/deploying-liferay-plugins-with-maven)
 tutorial. 
 
 +$$$

--- a/develop/tutorials/articles/maven/deploying-liferay-plugins-with-maven.markdown
+++ b/develop/tutorials/articles/maven/deploying-liferay-plugins-with-maven.markdown
@@ -6,7 +6,7 @@ tutorial explain the process. Just follow these steps:
 1.  Make sure you've specified the Liferay specific properties (the properties
     starting with `liferay.`) in your plugin's (or your parent plugin's)
     `pom.xml`. See the 
-    [Using Maven Parent Plugin Projects](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/using-maven-parent-plugin-projects)
+    [Using Maven Parent Plugin Projects](/develop/tutorials/-/knowledge_base/6-2/using-maven-parent-plugin-projects)
     tutorial for descriptions of these Liferay properties. 
 
     Here's an example where these *properties* are specified for a Liferay

--- a/develop/tutorials/articles/maven/managing-liferay-maven-artifacts.markdown
+++ b/develop/tutorials/articles/maven/managing-liferay-maven-artifacts.markdown
@@ -79,7 +79,7 @@ If you're using Liferay CE and you want the latest pre-release artifacts from
 the Liferay CE source repository, you can get them--but you'll have to build
 them yourself. Don't worry, it's easy. If you're interesting in building the
 artifacts from Liferay's source code, please see the [Building Maven Artifacts
-from Source](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/building-maven-artifacts-from-source)
+from Source](/develop/tutorials/-/knowledge_base/6-2/building-maven-artifacts-from-source)
 tutorial. 
 
 Once you've downloaded Liferay release artifacts as a zip file or built them
@@ -120,13 +120,13 @@ Here's how you do it:
 
 1.  Make sure you've created a repository server to hold the Liferay Maven
     artifacts. If you haven't, see the *Managing Maven Repositories* section of
-    the [Setting Up Maven](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
+    the [Setting Up Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
     tutorial for instructions. 
 
 2.  Make sure the repository that will hold your Liferay artifacts is specified
     as a server in Maven's `settings.xml` file. If it isn't, see the
     *Configuring Local Maven Settings* section of the 
-    [Setting Up Maven](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
+    [Setting Up Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven)
     tutorial for instructions on adding an entry for the server. 
 
     Here's an example setting for a repository server named *liferay-releases*: 
@@ -160,7 +160,7 @@ Here's how you do it:
 
     Note: If you created a repository in Nexus, as demonstrated in the *Managing
     Maven Repositories* section of the
-    [Setting Up Maven](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/setting-up-maven) tutorial, you can specify
+    [Setting Up Maven](/develop/tutorials/-/knowledge_base/6-2/setting-up-maven) tutorial, you can specify
     that repository's ID and URL. 
 
 5.  To deploy to your release repository server, execute the following command: 

--- a/develop/tutorials/articles/maven/maven-parent-plugin-projects.markdown
+++ b/develop/tutorials/articles/maven/maven-parent-plugin-projects.markdown
@@ -194,7 +194,7 @@ Follow these steps to create a Liferay Maven parent plugin project:
     You can also specify these key properties in your global or user
     `settings.xml` file. To learn more about this method, visit the *Configuring
     Your Liferay Maven Project* section of the
-    [Using Maven From Liferay IDE](https://www-ldn.liferay.com/develop/tutorials/-/knowledge_base/6-2/using-maven-from-liferay-ide) 
+    [Using Maven From Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/using-maven-from-liferay-ide) 
     tutorial. 
 
     The Liferay plugins that you develop depend on several Liferay artifacts.


### PR DESCRIPTION
This tutorial was originally written with a workaround in place because for a long period of time, the GA1 artifacts for Liferay 6.2 were not available from Maven Central. Now that the artifacts are available, I tweaked the tutorial to upload archetypes form Maven Central, as we've shown in the past.

I also threw in a commit correcting old links I found throughout LDN. :link: 

https://issues.liferay.com/browse/LRDOCS-1526