### PR TITLE
remove recommendation of 2G max JVM memory

### DIFF
--- a/userGuide/en/chapters/21-configuring-for-high-availability.markdown
+++ b/userGuide/en/chapters/21-configuring-for-high-availability.markdown
@@ -1705,9 +1705,13 @@ available to the JVM.
 Note that there is a law of diminishing returns on memory, especially with 64
 bit systems. These systems allow you to create very large JVMs, but the larger
 the JVM, the more time it takes for garbage collection to take place. For this
-reason, you probably won't want to create JVMs of more than 2 GB in size. To
-take advantage of higher amounts of memory on a single system, run multiple JVMs
-of Liferay instead.
+reason, you probably won't want to drastically increase memory. You will have 
+to measure your portal's memory utilization and find a value that's large enough 
+to do real work besides garbage collection, but small enough so that garbage 
+collection is quick enough. If you have large amounts of memory on your server 
+*and* your portal is limited by memory (as opposed to CPU- or I/O-limited, it 
+might make sense to have multiple JVMs with Liferay on a single server. rather 
+than doubling the amount of memory above a certain threshold.
 
 Issues with PermGen space can also affect performance. PermGen space contains
 long-lived classes, anonymous classes and interned Strings (immutable String


### PR DESCRIPTION
The chapter stated an overly limited memory configuration that it shouldn't make (2G). There are portals that legitimately have more than 8G Heap, while 2G might be too much for others. The documentation shouldn't make an assumption about absolute maximum values. This is what I've replaced.

I stumbled upon this statement on https://stackoverflow.com/questions/27273104