### PR TITLE
BUG workaround: struts hook bug

### DIFF
--- a/devGuide/en/chapters/07-hooks.markdown
+++ b/devGuide/en/chapters/07-hooks.markdown
@@ -669,6 +669,46 @@ of `BaseStrutsAction`, but not the `execute(StrutsAction, HttpServletRequest,
 HttpServletResponse)` method. The original Struts action's `execute()` method
 is ignored. That's fine for our example.
 
+---
+
+![Tip](../../images/tip-pen-paper.png) **Warning:** Due to a known bug
+([LPS-52754](https://issues.liferay.com/browse/LPS-52754)), a problem can occur
+when overriding Struts actions with overlapping paths. Struts action paths
+overlap when one path is a substring of another path. The following example from
+Liferay's `struts-config.xml` file shows three Struts action paths. Notice that
+the first Struts action path is a substring of each of the last two.
+
+    <action path="/document_library/edit_file_entry" ...
+    </action>
+
+    <action path="/document_library/edit_file_entry_discussion" ...
+    </action>
+
+    <action path="/document_library/edit_file_entry_type" ...
+    </action>
+
+Suppose you create a hook plugin to override the
+`/document_library/edit_file_entry` path. Due to the bug mentioned above, your
+hook's new, custom action is triggered not only when the intended path is
+invoked, but also when one of the larger, containing paths (e.g.,
+`document_library/edit_file_entry_discussion`) is invoked!
+
+To work around this issue, please use the following steps:
+
+1. Find any Struts actions with paths that contain the path of the Struts
+action that you are overriding.
+
+2. If any offending paths are found, create a `<struts-action>` for them in
+your `liferay-hook.xml`.
+
+3. In the class you create for each Struts action, override only the
+`processAction`, `render`, and `serveResource` methods.
+
+4. In each overridden method, simply call the original Struts action's method
+(e.g., `originalStrutsPortletAction.processAction`).
+
+---
+
 **Best Practice**
 
 When overriding an existing Struts action, it's usually best to override the

--- a/devGuide/en/chapters/07-hooks.markdown
+++ b/devGuide/en/chapters/07-hooks.markdown
@@ -693,7 +693,7 @@ hook's new, custom action is triggered not only when the intended path is
 invoked, but also when one of the larger, containing paths (e.g.,
 `document_library/edit_file_entry_discussion`) is invoked!
 
-To work around this issue, please use the following steps:
+To work around this issue, use the following steps:
 
 1. Find any Struts actions with paths that contain the path of the Struts
 action that you are overriding.

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -186,20 +186,20 @@ Due to a known portal bug
 [LPS-52754](https://issues.liferay.com/browse/LPS-52754), overriding a Struts
 action whose path value is completely contained inside another Struts action's
 path (e.g., `/document_library/edit_file_entry`) causes the new, custom action
-to be triggered when the intended path is invoked, but also when one of the
-larger, containing paths (e.g., `document_library/edit_file_entry_discussion`)
-is invoked! So, not only would you be overriding the intended Struts action,
-but any whose paths completely contain the path of the Struts action you want
-to override!
+to be triggered not only when the intended path is invoked, but also when one of
+the larger, containing paths (e.g.,
+`document_library/edit_file_entry_discussion`) is invoked! So, not only would
+you be overriding the intended Struts action, but any whose paths completely
+contain the path of the Struts action you want to override.
 
 You can work around this bug with the following steps:
 1. Find any Struts actions with paths that contain the path of the Struts
 action you want to override.
 2. If any offending paths are found, create a `<struts-action>` for them in
 your `liferay-hook.xml`.
-3. In the class you create for each Struts action, overide only the
+3. In the class you create for each Struts action, override only the
 `processAction`, `render`, and `serveResource` methods.
-4. In each overridden method, simply call the original Struts action's methods
+4. In each overridden method, simply call the original Struts action's method
 (e.g., `originalStrutsPortletAction.processAction`).
 
 $$$

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -166,33 +166,29 @@ is ignored. That's fine for our example.
 
 +$$$
 
-**Warning:** Some Struts actions have overlapping path values, where the path
-value of one Struts action is completely contained within the path of another
-Struts action. See the following example from `struts-config.xml`, where the
-second two of the Struts action paths contain the complete path of the first
-one:
+**Warning:** Due to a known bug
+[LPS-52754](https://issues.liferay.com/browse/LPS-52754), a problem can occur
+when overriding Struts actions with overlapping paths. Struts action paths
+overlap when one path is a substring of another path. The following example from
+Liferay's `struts-config.xml` file shows three Struts action paths. Notice that
+the first Struts action path is a substring of each of the last two.
 
-    <action path="/document_library/edit_file_entry"...
+    <action path="/document_library/edit_file_entry" ...
     </action>
 
-    <action path="/document_library/edit_file_entry_discussion"...
+    <action path="/document_library/edit_file_entry_discussion" ...
     </action>
 
-    <action path="/document_library/edit_file_entry_type"...
+    <action path="/document_library/edit_file_entry_type" ...
     </action>
 
+Suppose you create a hook plugin to override the
+`/document_library/edit_file_entry` path. Due to the bug mentioned above, your
+hook's new, custom action is triggered not only when the intended path is
+invoked, but also when one of the larger, containing paths (e.g.,
+`document_library/edit_file_entry_discussion`) is invoked!
 
-Due to a known portal bug
-[LPS-52754](https://issues.liferay.com/browse/LPS-52754), overriding a Struts
-action whose path value is completely contained inside another Struts action's
-path (e.g., `/document_library/edit_file_entry`) causes the new, custom action
-to be triggered not only when the intended path is invoked, but also when one of
-the larger, containing paths (e.g.,
-`document_library/edit_file_entry_discussion`) is invoked! Not only would
-you be overriding the intended Struts action, but any whose paths completely
-contain the path of the Struts action you want to override.
-
-You can work around this bug with the following steps:
+To work around this issue, please use the following steps:
 
 1. Find any Struts actions with paths that contain the path of the Struts
 action you want to override.
@@ -208,16 +204,14 @@ your `liferay-hook.xml`.
 
 $$$
 
-**Best Practice**
-
-When overriding an existing Struts action, it's usually best to override the
-method that takes the original Struts action handle as a parameter and execute
-that original Struts action. Think of the original action as a servlet filter
-or aspect. If you override the method that *takes* the original action handle
-as a parameter and don't explicitly execute it, the original action won't be 
-executed. If you override the `execute` method that *does not take* the original
-action as a parameter, you are ignoring the original action and it won't be
-executed.
+**Best Practice:** When overriding an existing Struts action, it's usually best
+to override the method that takes the original Struts action handle as a
+parameter and execute that original Struts action. Think of the original action
+as a servlet filter or aspect. If you override the method that *takes* the
+original action handle as a parameter and don't explicitly execute it, the
+original action won't be executed. If you override the `execute` method that
+*does not take* the original action as a parameter, you are ignoring the
+original action and it won't be executed.
 
 +$$$
 

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -188,17 +188,20 @@ action whose path value is completely contained inside another Struts action's
 path (e.g., `/document_library/edit_file_entry`) causes the new, custom action
 to be triggered not only when the intended path is invoked, but also when one of
 the larger, containing paths (e.g.,
-`document_library/edit_file_entry_discussion`) is invoked! So, not only would
+`document_library/edit_file_entry_discussion`) is invoked! Not only would
 you be overriding the intended Struts action, but any whose paths completely
 contain the path of the Struts action you want to override.
 
 You can work around this bug with the following steps:
 1. Find any Struts actions with paths that contain the path of the Struts
 action you want to override.
+
 2. If any offending paths are found, create a `<struts-action>` for them in
 your `liferay-hook.xml`.
+
 3. In the class you create for each Struts action, override only the
 `processAction`, `render`, and `serveResource` methods.
+
 4. In each overridden method, simply call the original Struts action's method
 (e.g., `originalStrutsPortletAction.processAction`).
 

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -190,7 +190,7 @@ to be triggered when the intended path is invoked, but also when one of the
 larger, containing paths (e.g., `document_library/edit_file_entry_discussion`)
 is invoked! So, not only would you be overriding the intended Struts action,
 but any whose paths completely contain the path of the Struts action you want
-to override! This is not optimal, to say the least.
+to override!
 
 You can work around this bug with the following steps:
 1. Find any Struts actions with paths that contain the path of the Struts

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -193,6 +193,7 @@ you be overriding the intended Struts action, but any whose paths completely
 contain the path of the Struts action you want to override.
 
 You can work around this bug with the following steps:
+
 1. Find any Struts actions with paths that contain the path of the Struts
 action you want to override.
 

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -167,7 +167,7 @@ is ignored. That's fine for our example.
 +$$$
 
 **Warning:** Due to a known bug
-[LPS-52754](https://issues.liferay.com/browse/LPS-52754), a problem can occur
+([LPS-52754](https://issues.liferay.com/browse/LPS-52754)), a problem can occur
 when overriding Struts actions with overlapping paths. Struts action paths
 overlap when one path is a substring of another path. The following example from
 Liferay's `struts-config.xml` file shows three Struts action paths. Notice that
@@ -191,7 +191,7 @@ invoked, but also when one of the larger, containing paths (e.g.,
 To work around this issue, please use the following steps:
 
 1. Find any Struts actions with paths that contain the path of the Struts
-action you want to override.
+action that you are overriding.
 
 2. If any offending paths are found, create a `<struts-action>` for them in
 your `liferay-hook.xml`.

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -164,6 +164,46 @@ of `BaseStrutsAction`, but not the `execute(StrutsAction, HttpServletRequest,
 HttpServletResponse)` method. The original Struts action's `execute()` method
 is ignored. That's fine for our example.
 
++$$$
+
+**Warning:** Some Struts actions have overlapping path values, where the path
+value of one Struts action is completely contained within the path of another
+Struts action. See the following example from `struts-config.xml`, where the
+second two of the Struts action paths contain the complete path of the first
+one:
+
+    <action path="/document_library/edit_file_entry"...
+    </action>
+
+    <action path="/document_library/edit_file_entry_discussion"...
+    </action>
+
+    <action path="/document_library/edit_file_entry_type"...
+    </action>
+
+
+Due to a known portal bug
+[LPS-52754](https://issues.liferay.com/browse/LPS-52754), overriding a Struts
+action whose path value is completely contained inside another Struts action's
+path (e.g., `/document_library/edit_file_entry`) causes the new, custom action
+to be triggered when the intended path is invoked, but also when one of the
+larger, containing paths (e.g., `document_library/edit_file_entry_discussion`)
+is invoked! So, not only would you be overriding the intended Struts action,
+but any whose paths completely contain the path of the Struts action you want
+to override! This is not optimal, to say the least.
+
+You can work around this bug with the following steps:
+1. Find any Struts actions with paths that contain the path of the Struts
+action you want to override.
+2. If any offending paths are found, create a `<struts-action>` for them in
+your `liferay-hook.xml`.
+3. In the class you create for each Struts action, overide only the
+`processAction`, `render`, and `serveResource` methods.
+4. In each overridden method, simply call the original Struts action's methods
+(e.g., `originalStrutsPortletAction.processAction`).
+
+$$$
+
 **Best Practice**
 
 When overriding an existing Struts action, it's usually best to override the

--- a/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
+++ b/develop/tutorials/articles/07-hooks/07-overriding-and-adding-struts-actions.markdown
@@ -188,7 +188,7 @@ hook's new, custom action is triggered not only when the intended path is
 invoked, but also when one of the larger, containing paths (e.g.,
 `document_library/edit_file_entry_discussion`) is invoked!
 
-To work around this issue, please use the following steps:
+To work around this issue, use the following steps:
 
 1. Find any Struts actions with paths that contain the path of the Struts
 action that you are overriding.


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-1567

Overriding a Struts path that is contained in another Struts action path as a substring causes the custom action to run when either Struts path is invoked. 

Provided workaround for 6.1.x since that's the docs we linked to in the ticket. Will add note to 6.2 devGuide section as well. There is not currently a 6.2 tutorial, so noting it in the devGuide should ensure that when the tutorial is created, the workaround is included.