### PR TITLE
Use Global Time Zone calendar option clarification

### DIFF
--- a/discover/portal/articles/09-collaboration-suite/02-managing-events-and-calendar-resources.markdown
+++ b/discover/portal/articles/09-collaboration-suite/02-managing-events-and-calendar-resources.markdown
@@ -35,14 +35,15 @@ default. You can set the *Default View* to *Day*, *Week*, or *Month*. You can
 set *Week Starts On* to *Sunday*, *Monday*, or *Saturday*. For *Time Zone*, you
 can either specify a particular time zone like *Pacific Standard Time* or *China
 Standard Time* or you can check the *Use Global Time Zone* box. If you check
-*Use Global Time Zone*, your calendar uses the portal-wide time zone that an
-administrator can set via *Control Panel* &rarr; *Portal Settings* &rarr;
-*Display Settings* &rarr; *Time Zone*.
+*Use Global Time Zone*, the time displayed by the Calendar portlet depends on
+whether it's being viewed by a guest or a logged in user:
 
-**RSS:** You can enable and customize your RSS Subscriptions for your calendar
-from this screen. You have the following options: *Enable RSS Subscription*,
-*Maximum Items to Display*, *Display Style*, *Format*, and *Time Interval*.
-These options are explained in more detail in the Blogs section.
+-If a user is logged in to the portal, the Calendar portlet displays events using the
+time zone set for the user in *My Account* &rarr; *Display Settings* &rarr; *Time Zone*.
+-If the Calendar portlet is viewed by a guest, or by a user who is not logged
+in, the Calendar portlet displays events using the time zone set by the portal
+administrator in *Control Panel* &rarr; *Portal Settings* &rarr; *Display
+Settings* &rarr; *Time Zone*.
 
 Next, let's look at how to use the new Calendar portlet.
 

--- a/userGuide/en/chapters/09-collaboration-suite.markdown
+++ b/userGuide/en/chapters/09-collaboration-suite.markdown
@@ -347,9 +347,15 @@ default. You can set the *Default View* to *Day*, *Week*, or *Month*. You can
 set *Week Starts On* to *Sunday*, *Monday*, or *Saturday*. For *Time Zone*, you
 can either specify a particular time zone like *Pacific Standard Time* or *China
 Standard Time* or you can check the *Use Global Time Zone* box. If you check
-*Use Global Time Zone*, your calendar uses the portal-wide time zone that an
-administrator can set via *Control Panel* &rarr; *Portal Settings* &rarr;
-*Display Settings* &rarr; *Time Zone*.
+*Use Global Time Zone*, the time displayed by the Calendar portlet depends on
+whether it's being viewed by a guest or a logged in user:
+
+-If a user is logged in to the portal, the Calendar portlet displays events using the
+time zone set for the user in *My Account* &rarr; *Display Settings* &rarr; *Time Zone*.
+-If the Calendar portlet is viewed by a guest, or by a user who is not logged
+in, the Calendar portlet displays events using the time zone set by the portal
+administrator in *Control Panel* &rarr; *Portal Settings* &rarr; *Display
+Settings* &rarr; *Time Zone*.
 
 **RSS:** You can enable and customize your RSS Subscriptions for your calendar
 from this screen. You have the following options: *Enable RSS Subscription*,


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-1603, We did not have a clear description of the Calendar configuration option "Use Global Time Zone". I added some detail on how the Calendar portlet displays times when this op[ptions is selected, depending on whether its viewed by a guest or a logged in user