### PR TITLE
Remove markup (italics) from title since KB Display portlet does not render it correctly

### DIFF
--- a/develop/tutorials/articles/service-builder/18-configuring-service.properties.markdown
+++ b/develop/tutorials/articles/service-builder/18-configuring-service.properties.markdown
@@ -1,4 +1,4 @@
-# Configuring *service.properties* [](id=configuring-service-properties)
+# Configuring service.properties [](id=configuring-service-properties)
 
 Service Builder generates a `service.properties` file in your project's
 `docroot/WEB-INF/src` folder. Liferay Portal uses the properties in this file to


### PR DESCRIPTION
Remove markup (italics) from title since KB Display portlet does not render it correctly