### PR TITLE
Add links pointing to CDI configuration

### DIFF
--- a/discover/deployment/articles/01-installation-and-setup/14-installing-liferay-on-jboss-7.1.markdown
+++ b/discover/deployment/articles/01-installation-and-setup/14-installing-liferay-on-jboss-7.1.markdown
@@ -508,6 +508,12 @@ and copy it to the following location:
 
         <resource-root path="weld-core-1.1.10.Final.jar"/>
 
+You've successfully upgraded your Weld version. If you're interested in
+configuring CDI for your JSF portlets running on JBoss, you'll need to configure
+a few more things. For more information on configuring CDI, visit the
+[Configuring JSF Portlets to Use CDI](/develop/tutorials/-/knowledge_base/6-2/contexts-and-dependency-injection-for-jsf-portlets#configuring-jsf-portlets-to-use-cdi)
+section. 
+
 Now you're ready to deploy Liferay Portal. 
 
 ## Deploy Liferay [](id=deploy-liferay)

--- a/discover/deployment/articles/01-installation-and-setup/15-installing-liferay-on-tomcat-7.markdown
+++ b/discover/deployment/articles/01-installation-and-setup/15-installing-liferay-on-tomcat-7.markdown
@@ -425,8 +425,15 @@ To upgrade Tomcat's global classpath, follow the steps below:
             <scope>provided</scope>
         </dependency>
 
-You've officially added Mojarra to your application server. Now you can deploy
-Liferay. 
+You've officially added Mojarra to your application server. 
+
+If you're interested in configuring CDI for your JSF portlets running on Tomcat,
+you'll also need to configure Weld. For more information on configuring Weld for
+Tomcat, visit the
+[Configuring JSF Portlets to Use CDI](/develop/tutorials/-/knowledge_base/6-2/contexts-and-dependency-injection-for-jsf-portlets#configuring-jsf-portlets-to-use-cdi)
+section. 
+
+You're now all set to deploy Liferay. 
 
 ## Deploy Liferay [](id=deploy-liferay)
 

--- a/discover/deployment/articles/01-installation-and-setup/16-installing-liferay-on-oracle-weblogic-12c.markdown
+++ b/discover/deployment/articles/01-installation-and-setup/16-installing-liferay-on-oracle-weblogic-12c.markdown
@@ -337,6 +337,12 @@ dependencies.
     classpath, `jsf-api.jar` and `jsf-impl.jar` must not be included in
     `WEB-INF/lib`. 
 
+You've successfully upgraded your Mojarra version. If you're interested in
+configuring CDI for your JSF portlets running on WebLogic 12c, you'll need to
+configure a few more things. For more information on configuring CDI, visit the
+[Configuring JSF Portlets to Use CDI](/develop/tutorials/-/knowledge_base/6-2/contexts-and-dependency-injection-for-jsf-portlets#configuring-jsf-portlets-to-use-cdi)
+section. 
+
 Now it's the moment you've been waiting for: Liferay deployment! 
 
 ## Deploy Liferay [](id=deploy-liferay)


### PR DESCRIPTION
CC/ @jhinkey

As a side note, I've linked to the CDI configuration tutorial in the Tomcat, JBoss, and WebLogic 12c deployment sections. GlassFish 3 and Resin are other app servers we specify as being compatible to use CDI with Liferay 6.2, but neither are documented in our Deployment section. Thanks!

https://issues.liferay.com/browse/LRDOCS-1633