### PR TITLE
Replace chapter references with links to LDN articles

### DIFF
--- a/discover/portal/articles/04-configuring-liferay-applications/01-look-and-feel.markdown
+++ b/discover/portal/articles/04-configuring-liferay-applications/01-look-and-feel.markdown
@@ -31,7 +31,7 @@ portlet URLs will point to the page you selected. The current page is the
 default. Note that you can use the Asset Publisher's View in a Specific Portlet
 feature and web content articles' Display Page attribute to achieve a more
 elegant solution for displaying the full view of web content articles on
-specific pages. Please see the Display Page section of chapter 5 for details.
+specific pages. Please see the [Setting Up Display Pages](discover/portal/-/knowledge_base/6-1/setting-up-display-pages) article for details.
 
 +$$$
 

--- a/discover/portal/articles/04-configuring-liferay-applications/02-export-import.markdown
+++ b/discover/portal/articles/04-configuring-liferay-applications/02-export-import.markdown
@@ -9,9 +9,10 @@ icon of your portlet and select *Export/Import*. Exporting portlet data produces
 a `.lar` file that you can save and import into another portlet application of
 the same type. To import portlet data, you must select a `.lar` file. Be careful
 not to confuse portlet-specific `.lar` files with site-specific `.lar` files.
-See the Backing up and Restoring Pages section of chapter 2 for a discussion of
-exporting and importing data across an entire site. Let's explore the export
-process first.
+See the section on [Creating and Managing Pages](discover/portal/-/knowledge_base/6-2/leveraging-liferays-multi-site-capabilities#creating-and-managing-pages) 
+for a discussion of exporting and importing site page data. 
+
+Let's explore the export process for portlets first.
 
 ![Figure 4.7: When exporting portlet data, you can choose what content to include.](../../images/portlet-export.png)
 

--- a/discover/portal/articles/08-personalization-and-customization/03-using-application-display-templates.markdown
+++ b/discover/portal/articles/08-personalization-and-customization/03-using-application-display-templates.markdown
@@ -102,7 +102,8 @@ access the XML source of your template. You can find these URLs by clicking the
 ADT from the menu and expanding the *Details* section. With the WebDAV URL, site
 administrators are capable of adding, browsing, editing, and deleting ADTs on a
 remote server. If you'd like to learn more about what the WebDAV URL can do,
-visit the *Document Management* chapter's *WebDAV access* chapter.
+visit the *Document Management* chapter's [WebDAV access](discover/portal/-/knowledge_base/6-2/automatic-previews-and-metadata#webdav-access)
+section.
 
 To enable your ADT for a portlet, navigate to the portlet you want to modify and
 open its *Configuration* menu. In the *Display Settings* sub-tab located within

--- a/discover/portal/articles/12-using-workflow/02-creating-new-workflow-definitions.markdown
+++ b/discover/portal/articles/12-using-workflow/02-creating-new-workflow-definitions.markdown
@@ -73,10 +73,10 @@ After that, you define your initial state.
 In this case, the state is simply that the asset has been created. States can
 contain actions and transitions. Actions can contain scripts. You can specify
 the language of the script with the `<script-language>` tag. Scripts can be
-written in Groovy, JavaScript, Ruby or Python (see chapter 18 for more
-information on leveraging scripts in workflow). For a state, the action is
-triggered automatically and then executes a transition. Transitions move you to
-a new state or task.
+written in Groovy, JavaScript, Ruby or Python (read [here](deployment/-/knowledge_base/6-2/using-scripting-for-advanced-flexibility)
+for more information on leveraging scripts in workflow). For a state, the
+action is triggered automatically and then executes a transition. Transitions
+move you to a new state or task.
 
     <state>
         <name>created</name>
@@ -505,7 +505,8 @@ were at their desk that hadn't reviewed content assigned to them.
 		</action>
     </timer-actions>
 
-For more information on using scripting in Liferay, please refer to chapter 18.
+For more information on using scripting in Liferay, please refer to the [Using Scripting for Advanced Flexibility](deployment/-/knowledge_base/6-2/using-scripting-for-advanced-flexibility)
+section of *Deployment*.
 
 Using workflows and approvals is necessary for virtually any organization and
 timers are an excellent way to help mitigate the potential headaches caused by

--- a/discover/portal/articles/14-liferay-utility-applications/00-liferay-utility-applications-intro.markdown
+++ b/discover/portal/articles/14-liferay-utility-applications/00-liferay-utility-applications-intro.markdown
@@ -2,8 +2,9 @@
 
 In this chapter we'll look at some Liferay utility applications that might be
 useful for you. The Software Catalog has been replaced by Liferay Marketplace
-but can still be installed as a plugin. Please see chapter 13 for information
-about Liferay Marketplace and managing Liferay plugins. The Reports,
+but can still be installed as a plugin. Refer to the chapter on 
+[Liferay Marketplace](discover/portal/-/knowledge_base/6-2/leveraging-the-liferay-marketplace) 
+for information on downloading and managing Liferay plugins. The Reports,
 JasperReports, and Knowledge Base applications are only available to EE
 customers. In this chapter we'll discuss following applications:
 

--- a/discover/portal/articles/14-liferay-utility-applications/01-capturing-web-sites-with-bookmarks-portlet.markdown
+++ b/discover/portal/articles/14-liferay-utility-applications/01-capturing-web-sites-with-bookmarks-portlet.markdown
@@ -50,8 +50,8 @@ into the list of general bookmarks that aren't associated with a folder. These
 are listed in the bookmarks section, below the folders, in the portlet.
 
 Below the Permissions there are additional options for Categorization and
-Related Assets, just like in other Liferay applications. Please see chapter 6 on
-the Asset Framework for further information about this.
+Related Assets, just like in other Liferay applications. Please see the [Displaying Content Dynamically](discover/portal/-/knowledge_base/6-2/displaying-content-dynamically)
+chapter for further information about this.
 
 Once you have added a new bookmark, it appears in the portlet. From here, you
 can manage your bookmark using familiar Liferay editing features. Collecting and

--- a/discover/portal/articles/14-liferay-utility-applications/03-shopping.markdown
+++ b/discover/portal/articles/14-liferay-utility-applications/03-shopping.markdown
@@ -252,8 +252,8 @@ with questions about their orders. Let's go over the orders next.
 On the Orders tab, there are fields for finding specific orders. Search for
 orders using the order number, order status, first or last name on the order, or
 by the email address associated with the account. For more information on
-searching in Liferay Portal, see the Faceted Search section in chapter 6 of this
-guide.
+searching in Liferay Portal, see the [Searching for Content in Liferay](/discover/portal/-/knowledge_base/6-2/searching-for-content-in-liferay)
+section.
 
 Below the search fields is the orders list. Orders can be deleted or edited
 using the *Actions* button. When you select an order from the Orders tab, or if 

--- a/discover/portal/articles/17-using-the-control-panel/05-server-administration.markdown
+++ b/discover/portal/articles/17-using-the-control-panel/05-server-administration.markdown
@@ -161,10 +161,10 @@ portal.
 Instead of using your Liferay server's `portal-ext.properties` file to configure
 a mail server, you can configure a mail server from the Mail tab of the Server
 Configuration section of the Control Panel. If your portal is to receive mail
-(see, for example, our coverage of the Message Boards portlet in chapter 8), you
-can connect a POP mail server. If your portal is to send mail, which is useful
-for sending notifications to users, you can connect to an SMTP server. We highly
-recommend setting up mail servers for your portal.
+(see, for example, our coverage of the [Message Boards portlet](discover/portal/-/knowledge_base/6-2/discuss-ask-and-answer-using-the-message-boards)
+), you can connect a POP mail server. If your portal is to send mail, which is
+useful for sending notifications to users, you can connect to an SMTP server.
+We highly recommend setting up mail servers for your portal.
 
 Note that if you configure mail server settings here in the Control Panel, these
 settings will override any mail server settings in your `portal-ext.properties`
@@ -182,7 +182,8 @@ LibreOffice, ImageMagick and Xuggler. With Liferay configured to use these
 tools, you can generate automatic previews for many types of files including text
 files, office suite files, PDFs, images, audio files and videos. Users will also
 be able to use the conversion functionality to download documents in a variety
-of formats. Please see chapter 4 on Documents and Media for more information.
+of formats. Please see the [Automatic Previews and Metadata](discover/portal/-/knowledge_base/6-2/automatic-previews-and-metadata)
+section for more information.
 
 LibreOffice is available here: [LibreOffice](http://www.libreoffice.org),
 ImageMagick is available here: [ImageMagick](http://www.imagemagick.org), and


### PR DESCRIPTION
Throughout discover/portal articles in my crossfunctional areas, I replaced specific references to chapters (e.g., "see chapter 3 for...") with links to articles on LDN and adjusted text as necessary.