### PR TITLE
Fix Friendly URL Learning Path Next Steps URLs

### DIFF
--- a/develop/learning-paths/mvc/articles/09-making-urls-friendly/01-creating-url-routes.markdown
+++ b/develop/learning-paths/mvc/articles/09-making-urls-friendly/01-creating-url-routes.markdown
@@ -115,7 +115,3 @@ could leave it at that, but using the `guestbookId` and `entryId` in the
 URL really isn't as friendly as it could be. The next step is to replace those
 IDs with the title of the Guestbook or Guestbook Entry.
 
-## Next Steps [](id=next-steps)
-
-[Removing the Primary Key from Portlet URLs](/develop/learning-paths/-/knowledge_base/removing-primary-keys-from-the-url)
-

--- a/develop/learning-paths/mvc/articles/09-making-urls-friendly/02-removing-the-primary-key-from-portlet-urls.markdown
+++ b/develop/learning-paths/mvc/articles/09-making-urls-friendly/02-removing-the-primary-key-from-portlet-urls.markdown
@@ -763,5 +763,5 @@ to create even friendlier URLs.
 
 ## Next Steps [](id=next-steps)
 
-[Creating Remote Services](/develop/learning-paths/-/knowledge_base/creating-remote-services)
+[Creating Remote Services](develop/learning-paths/-/knowledge_base/6-2/creating-web-services-for-your-application)
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-1631; The Friendly URLs Learning Path Next steps sections were incorrect. I removed the Next Steps section from the first Learning Path, and corrected the link to the Web Services Learning Path in the second article.