### PR TITLE
Add message tag argument

### DIFF
--- a/develop/tutorials/articles/03-portlet-development/08-localizing-your-portlet.markdown
+++ b/develop/tutorials/articles/03-portlet-development/08-localizing-your-portlet.markdown
@@ -68,7 +68,7 @@ to the `welcome-x` language key in the "My Greeting" portlet.
 3.  Replace the current welcome message tag and exclamation point,
     `<liferay-ui:message key="welcome" />!`, in the JSP with the following:
 
-        <liferay-ui:message key="welcome-x" /> <%= user.getScreenName() %>
+        <liferay-ui:message key="welcome-x" arguments="<%= user.getScreenName() %>"/> 
 
 When you refesh your page, your "My Greeting" portlet greets you by your screen
 name!

--- a/develop/tutorials/articles/03-portlet-development/08-localizing-your-portlet.markdown
+++ b/develop/tutorials/articles/03-portlet-development/08-localizing-your-portlet.markdown
@@ -68,7 +68,7 @@ to the `welcome-x` language key in the "My Greeting" portlet.
 3.  Replace the current welcome message tag and exclamation point,
     `<liferay-ui:message key="welcome" />!`, in the JSP with the following:
 
-        <liferay-ui:message key="welcome-x" arguments="<%= user.getScreenName() %>"/> 
+        <liferay-ui:message arguments="<%= user.getScreenName() %>" key="welcome-x" /> 
 
 When you refesh your page, your "My Greeting" portlet greets you by your screen
 name!


### PR DESCRIPTION
This addition correctly uses the `welcome-x` key. The 6.2 docs already do it this way. Thanks!