### PR TITLE
LRDOCS-473 Add breaking changes document for 6.2, document image utility methods move

### DIFF
--- a/develop/reference/articles/02-breaking-changes/01-breaking-changes.markdown
+++ b/develop/reference/articles/02-breaking-changes/01-breaking-changes.markdown
@@ -71,7 +71,7 @@ in ascending chronological order.
 
 ## Breaking Changes List
 
-### Utility Methods Have Been Moved from [`ImageLocalServiceUtil`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/service/ImageLocalServiceUtil.html) to [`ImageTool`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/kernel/image/ImageTool.html)
+### Utility Methods Have Been Moved from [ImageLocalServiceUtil](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/service/ImageLocalServiceUtil.html) to [ImageTool](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/kernel/image/ImageTool.html)
 - **Date:** 2013-Jan-13
 - **JIRA Ticket:** LPS-31888
 

--- a/develop/reference/articles/02-breaking-changes/01-breaking-changes.markdown
+++ b/develop/reference/articles/02-breaking-changes/01-breaking-changes.markdown
@@ -20,8 +20,6 @@ feature or API will be dropped in an upcoming version.
 replaces an old API, in spite of the old API being kept in Liferay Portal for
 backwards compatibility.
 
-*This document has been reviewed through commit `5996ef5`.*
-
 ## Breaking Changes Contribution Guidelines
 
 Each change must have a brief descriptive title and contain the following
@@ -65,28 +63,36 @@ horizontal rule):
 **80 Columns Rule:** Text should not exceed 80 columns. Keeping text within 80
 columns makes it easier to see the changes made between different versions of
 the document. Titles, links, and tables are exempt from this rule. Code samples
-must follow the column rules specified in Liferay's [Development
-Style](http://www.liferay.com/community/wiki/-/wiki/Main/Liferay+development+style).
+must follow the column rules specified in Liferay's
+[Development Style](http://www.liferay.com/community/wiki/-/wiki/Main/Liferay+development+style).
 
 The remaining content of this document consists of the breaking changes listed
 in ascending chronological order.
 
 ## Breaking Changes List
 
-### Utility methods have been moved from ImageLocalService to ImageTool
+### Utility Methods Have Been Moved from [`ImageLocalServiceUtil`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/service/ImageLocalServiceUtil.html) to [`ImageTool`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/kernel/image/ImageTool.html)
 - **Date:** 2013-Jan-13
 - **JIRA Ticket:** LPS-31888
 
 #### What changed?
-Utility methods have been moved from ImageLocalService to ImageTool.
+Utility methods have been moved from
+[`ImageLocalServiceUtil`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/service/ImageLocalServiceUtil.html)
+to
+[`ImageTool`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/kernel/image/ImageTool.html).
 
 #### Who is affected?
-Developers using utility methods of ImageLocalService may find that the method
-they're using have been moved to ImageTool.
+Developers using utility methods of
+[`ImageLocalServiceUtil`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/service/ImageLocalServiceUtil.html)
+may find that the method they're using have been moved to
+[`ImageTool`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/kernel/image/ImageTool.html).
 
 #### How should I update my code?
-If you were using a method of ImageLocalService that's no longer there, use the
-corresponding method of ImageTool instead.
+If you were using a method of
+[`ImageLocalServiceUtil`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/service/ImageLocalServiceUtil.html)
+that's no longer there, use the corresponding method of
+[`ImageTool`](https://docs.liferay.com/portal/6.2/javadocs/com/liferay/portal/kernel/image/ImageTool.html)
+instead.
 
 #### Why was this change made?
 Utility methods should stay in utility classes rather than service classes to

--- a/develop/reference/articles/02-breaking-changes/01-breaking-changes.markdown
+++ b/develop/reference/articles/02-breaking-changes/01-breaking-changes.markdown
@@ -1,0 +1,95 @@
+# What are the Breaking Changes for Liferay 6.2?
+
+This document presents a chronological list of changes that break existing
+functionality, APIs, or contracts with third party Liferay developers or users.
+We try our best to minimize these disruptions, but sometimes they are
+unavoidable.
+
+Here are some of the types of changes documented in this file:
+
+* Functionality that is removed or replaced
+* API incompatibilities: Changes to public Java or JavaScript APIs
+* Changes to context variables available to templates
+* Changes in CSS classes available to Liferay themes and portlets
+* Configuration changes: Changes in configuration files, like
+ `portal.properties`, `system.properties`, etc.
+* Execution requirements: Java version, J2EE Version, browser versions, etc.
+* Deprecations or end of support: For example, warning that a certain
+feature or API will be dropped in an upcoming version.
+* Recommendations: For example, recommending using a newly introduced API that
+replaces an old API, in spite of the old API being kept in Liferay Portal for
+backwards compatibility.
+
+*This document has been reviewed through commit `5996ef5`.*
+
+## Breaking Changes Contribution Guidelines
+
+Each change must have a brief descriptive title and contain the following
+information:
+
+* **[Title]** Provide a brief descriptive title. Use past tense and follow
+the capitalization rules from
+<http://en.wikibooks.org/wiki/Basic_Book_Design/Capitalizing_Words_in_Titles>.
+* **Date:** Specify the date you submitted the change. Format the date as
+*YYYY-MMM* (e.g., 2014-Mar) or *YYYY-MMM-DD* (e.g., 2014-Feb-25).
+* **JIRA Ticket:** Reference the related JIRA ticket (e.g., LPS-123456)
+(Optional).
+* **What changed?** Identify the affected component and the type of change that
+was made.
+* **Who is affected?** Are end-users affected? Are developers affected? If the
+only affected people are those using a certain feature or API, say so.
+* **How should I update my code?** Explain any client code changes required.
+* **Why was this change made?** Explain the reason for the change. If
+applicable, justify why the breaking change was made instead of following a
+deprecation process.
+
+Here's the template to use for each breaking change (note how it ends with a
+horizontal rule):
+
+```
+### [Title]
+- **Date:**
+- **JIRA Ticket:**
+
+#### What changed?
+
+#### Who is affected?
+
+#### How should I update my code?
+
+#### Why was this change made?
+
+---------------------------------------
+```
+
+**80 Columns Rule:** Text should not exceed 80 columns. Keeping text within 80
+columns makes it easier to see the changes made between different versions of
+the document. Titles, links, and tables are exempt from this rule. Code samples
+must follow the column rules specified in Liferay's [Development
+Style](http://www.liferay.com/community/wiki/-/wiki/Main/Liferay+development+style).
+
+The remaining content of this document consists of the breaking changes listed
+in ascending chronological order.
+
+## Breaking Changes List
+
+### Utility methods have been moved from ImageLocalService to ImageTool
+- **Date:** 2013-Jan-13
+- **JIRA Ticket:** LPS-31888
+
+#### What changed?
+Utility methods have been moved from ImageLocalService to ImageTool.
+
+#### Who is affected?
+Developers using utility methods of ImageLocalService may find that the method
+they're using have been moved to ImageTool.
+
+#### How should I update my code?
+If you were using a method of ImageLocalService that's no longer there, use the
+corresponding method of ImageTool instead.
+
+#### Why was this change made?
+Utility methods should stay in utility classes rather than service classes to
+avoid unnecessary AOP overhead.
+
+---------------------------------------


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-473 Add breaking changes document for 6.2 (to appear under dev.liferay.com/develop/reference), add breaking change entry for image utility methods moving from imagelocalservice to imagetool

@jhinkey