### PR TITLE
Altered placement of tutorial links in intro to tutorials

### DIFF
--- a/develop/tutorials/articles/01-introduction/00-intro.markdown
+++ b/develop/tutorials/articles/01-introduction/00-intro.markdown
@@ -29,7 +29,7 @@ If you don't like Eclipse (which Liferay IDE is based on) and prefer to use
 NetBeans, IntelliJ IDEA, or something else, you certainly can. Liferay code can
 be written in any way Java code is written. 
 
-Here are some links to tutorials on development tools:
+Here are some links to tutorials on Liferay development tools:
 
 [Beginning Liferay Development](/develop/learning-paths/-/knowledge_base/6-2/beginning-liferay-development) 
 
@@ -52,7 +52,7 @@ Faces (JSF).
 As you write apps, you'll want to leverage powerful frameworks that work
 seamlessly with Liferay and help you complete your app faster. Liferay contains
 several frameworks that give you all the tools you need to perform various
-common tasks that you don't want to have to write yourself, such as handling
+common tasks that you don't want to write yourself, such as handling
 permissions and letting users enter comments, categories, and tags. 
 
 <!-- Here
@@ -95,73 +95,3 @@ Here are some good tutorials to start with:
 Now that you know what Liferay Tutorials offers, it's time to discover new
 things as you develop sites in Liferay. 
 
-
-
-
-
-
-
-
-
-
-
-
-<div id="wrapper">
-<table id="table" cellspacing="10">
-<tr>
-<th>
-<strong>Development Tools</strong>
-</th>
-
-<th>
-<strong>Developing Apps</strong>
-</th>
-
-<th>
-<strong>Styling and Customizing</strong>
-</th>
-</tr>
-
-<tr>
-<td>
-<a href="/develop/learning-paths/-/knowledge_base/6-2/beginning-liferay-development" >Beginning Liferay Development</a>
-</td>
-<td>
-<a href="/develop/learning-paths/-/knowledge_base/6-2/writing-your-first-liferay-application" >Writing Your First Application</a>
-</td>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates" >Themes and Layout Templates</a>
-</td>
-</tr>
-
-<tr>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/plugins-sdk" >Developing with the Plugins SDK</a>
-</td>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/developing-jsp-portlets-using-liferay-mvc" >Developing Portlets Using Liferay MVC</a>
-</td>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal" >Customizing Liferay Portal</a>
-</td>
-</tr>
-
-<tr>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/liferay-ide" >Developing with Liferay IDE</a>
-</td>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/liferay-faces-jsf-portlets" >Liferay Faces</a>
-</td>
-</tr>
-
-<tr>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/maven" >Developing with Maven</a>
-</td>
-<td>
-<a href="/develop/tutorials/-/knowledge_base/6-2/opensocial-gadgets" >OpenSocial Gadgets</a>
-</td>
-</tr>
-</table>
-</div>

--- a/develop/tutorials/articles/01-introduction/00-intro.markdown
+++ b/develop/tutorials/articles/01-introduction/00-intro.markdown
@@ -29,6 +29,16 @@ If you don't like Eclipse (which Liferay IDE is based on) and prefer to use
 NetBeans, IntelliJ IDEA, or something else, you certainly can. Liferay code can
 be written in any way Java code is written. 
 
+Here are some links to tutorials on development tools:
+
+[Beginning Liferay Development](/develop/learning-paths/-/knowledge_base/6-2/beginning-liferay-development) 
+
+[Developing with the Plugins SDK](/develop/tutorials/-/knowledge_base/6-2/plugins-sdk)
+
+[Developing with Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/liferay-ide)
+
+[Developing with Maven](/develop/tutorials/-/knowledge_base/6-2/maven)
+
 #### Developing Liferay Applications [](id=developing-liferay-applications)
 
 As a developer wanting to run your own applications on top of Liferay Portal,
@@ -60,19 +70,44 @@ tag libraries and snazzy UI components that
 [Liferay UI Taglibs](/develop/tutorials/-/knowledge_base/6-2/liferay-ui-taglibs)
 provide.
 
+Start learning to develop apps for Liferay:
+
+[Writing Your First Application](/develop/learning-paths/-/knowledge_base/6-2/writing-your-first-liferay-application)
+
+[Developing Portlets Using Liferay MVC](/develop/tutorials/-/knowledge_base/6-2/developing-jsp-portlets-using-liferay-mvc)
+
+[Liferay Faces](/develop/tutorials/-/knowledge_base/6-2/liferay-faces-jsf-portlets)
+
+[OpenSocial Gadgets](/develop/tutorials/-/knowledge_base/6-2/opensocial-gadgets)
+
+
 #### Styling and Customizing Liferay [](id=styling-and-customizing-liferay)
 
 What if you want to skin Liferay or customize it? Creating themes and
 customizations is easy in Liferay. 
 
+Here are some good tutorials to start with:
+
+[Themes and Layout Templates](/develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
+
+[Customizing Liferay Portal](/develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal)
+
 Now that you know what Liferay Tutorials offers, it's time to discover new
 things as you develop sites in Liferay. 
 
-To get you started, here are links to topics in the three areas
-discussed on this page.
+
+
+
+
+
+
+
+
+
+
 
 <div id="wrapper">
-<table id="table">
+<table id="table" cellspacing="10">
 <tr>
 <th>
 <strong>Development Tools</strong>


### PR DESCRIPTION
Removed table of links and included links in relevant sections of 00-intro.markdown file of develop/tutorials/articles/01-introduction. No ticket entered. @jhinkey