### PR TITLE
Change "license" to "activation key"

### DIFF
--- a/develop/learning-paths/mvc/articles/02-beginning-liferay-development/01-developing-apps-with-liferay-developer-studio.markdown
+++ b/develop/learning-paths/mvc/articles/02-beginning-liferay-development/01-developing-apps-with-liferay-developer-studio.markdown
@@ -18,7 +18,7 @@ of getting your Liferay Portal runtime installed. The fastest way to do this is
 with the defaults: leave *Configure Liferay Portal EE bundled with the Studio
 installation* checked and click *Next*. 
 
-5.  Browse to select your license key provided by Liferay and click *Next*. 
+5.  Browse to select your activation key provided by Liferay and click *Next*. 
 
 6.  Though Liferay Portal ships with an embedded database, as a developer,
 you'll want to use a database you can query with your own tools. For this
@@ -41,8 +41,8 @@ repository. Click *Finish*.
 After this, the wizard completes, and you have a fully configured development
 environment, ready to begin work! 
 
-If you don't have a Liferay enterprise edition license or if you want to use an
-existing installation of Eclipse, continue with the next tutorial on developing
-apps with Liferay IDE. You can otherwise start
+If you don't have a Liferay enterprise edition activation key or if you want to
+use an existing installation of Eclipse, continue with the next tutorial on
+developing apps with Liferay IDE. You can otherwise start
 [Writing Your First Liferay Application](/develop/learning-paths/mvc/-/knowledge_base/6-2/writing-your-first-liferay-application).
 

--- a/discover/deployment/articles/05-configuring-for-high-availability/01-liferay-clustering.markdown
+++ b/discover/deployment/articles/05-configuring-for-high-availability/01-liferay-clustering.markdown
@@ -475,10 +475,10 @@ We have one more store to go over: the Documentum store.
 
 ![EE Only Feature](../../images/ee-feature-web.png)
 
-If you have a Liferay Portal EE license, you have access to the Documentum hook
-which adds support for Documentum to Liferay's Documents and Media library.
-The Documentum hook is included in the Documentum Connector EE app which you can
-download and install from Liferay Marketplace. 
+If you have a Liferay Portal EE activation key, you have access to the
+Documentum hook which adds support for Documentum to Liferay's Documents and
+Media library. The Documentum hook is included in the Documentum Connector EE
+app which you can download and install from Liferay Marketplace. 
 
 This hook doesn't add an option to make the Liferay repository into a Documentum
 repository, as the other store implementations do. Instead, it gives you the


### PR DESCRIPTION
Surprisingly, I only had to change this terminology in two Markdown files. I grep searched in `develop/reference`, `develop/learning-paths`, `develop/tutorials`, `discover/deployment`, and `discover/portal`. Most license references dealt with Marketplace licensing or the LGPL license.

https://issues.liferay.com/browse/LRDOCS-1530