### PR TITLE
LRDOCS-1808 Update incorrect explanation of the patching tool's index-info command

### DIFF
--- a/discover/portal/articles/17-advanced-portal-operation/05-patching-liferay.markdown
+++ b/discover/portal/articles/17-advanced-portal-operation/05-patching-liferay.markdown
@@ -112,7 +112,7 @@ command:
 
     ./patching-tool.sh index-info
 
-As there's no database connection at patching time, the patches needed to be
+As there's no database connection at patching time, the indexes need to be
 created at portal startup. In order to get the indexes automatically created,
 please add the following line to your `portal-ext.properties` file if your
 server has permissions to modify the indexes on the database:


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-1808 Update incorrect explanation of the patching tool's index-info command