### PR TITLE
LRDOCS-1389 Add references to Java's documentation about the <portlet:defineObjects /> tag

### DIFF
--- a/develop/tutorials/articles/06-mvc-portlets/02-configurable-portlet-preferences.markdown
+++ b/develop/tutorials/articles/06-mvc-portlets/02-configurable-portlet-preferences.markdown
@@ -158,13 +158,15 @@ the name of your portlet preference.
 
 +$$$
 
-**Note:** Make sure to declare
-directives for any taglibs your configuration JSP requires, or declare the
-directives in one of the JSPs that the configuration JSP includes. 
+**Note:** Make sure to declare directives for any taglibs your configuration JSP
+requires, or declare the directives in one of the JSPs that the configuration
+JSP includes. 
 
 You may also need to declare the `<portlet:defineObjects />` tag to access
 implicit variables. This tag provides useful portlet variables such as
-*renderRequest*, *portletConfig*, and *portletPreferences*. 
+*renderRequest*, *portletConfig*, and *portletPreferences*. For more information
+about the `<portlet:defineObjects />` tag, see
+[Java's portlet specification documentation](https://portlet-container.java.net/docs/jsr286.html#Tag_Library).
 
 $$$
 

--- a/develop/tutorials/articles/user-interfaces-with-alloyui/working-with-the-dom-in-alloyui.markdown
+++ b/develop/tutorials/articles/user-interfaces-with-alloyui/working-with-the-dom-in-alloyui.markdown
@@ -234,10 +234,13 @@ Some HTML nodes can generate events. You can handle these events to process
 their information and to provide content based on interaction with the user.
 In this section, you'll learn how to subscribe to node events and handle them. 
 
-First, you must declare the `portlet` and `aui` taglibs to access their tags.
-You must also specify the `<portlet:defineObjects />` tag to access portlet
-objects in your JSP. Add the following declarations in the beginning of your
-JSP:
+First, you must declare the `portlet` and `aui` tag libraries to access their
+tags. From the `portlet` tag library, you should include the
+`<portlet:defineObjects />` tag so that you can access portlet objects like
+`renderRequest`, `actionRequest`, and `portletPreferences` in your JSP. For more
+information about the `<portlet:defineObjects />` tag, see
+[Java's portlet specification documentation](https://portlet-container.java.net/docs/jsr286.html#Tag_Library).
+Add the following declarations to the beginning of your JSP:
 
     <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
     <%@ taglib prefix="aui" uri="http://liferay.com/tld/aui" %>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-1389 Add references to Java's documentation about the <portlet:defineObjects /> tag