### PR TITLE
Staging tutorials - added more detail

### DIFF
--- a/develop/tutorials/articles/export-import-and-staging/initiating-new-processes-with-exportimportconfiguration-objects.markdown
+++ b/develop/tutorials/articles/export-import-and-staging/initiating-new-processes-with-exportimportconfiguration-objects.markdown
@@ -4,7 +4,7 @@ The Staging and Export/Import features of Liferay are the building blocks for
 creating, managing, and publishing a site. These features can be accessed in
 your Portal's *Publishing Tools* menu. You can also, however, start these
 processes programatically. This lets you provide new interfaces or mimic the
-functionality of these features in your own application?
+functionality of these features in your own application.
 
 For example, suppose you want your custom OSGi application to have an export
 feature, which users could use to export content from their application as a LAR

--- a/develop/tutorials/articles/export-import-and-staging/initiating-new-processes-with-exportimportconfiguration-objects.markdown
+++ b/develop/tutorials/articles/export-import-and-staging/initiating-new-processes-with-exportimportconfiguration-objects.markdown
@@ -6,9 +6,21 @@ your Portal's *Publishing Tools* menu. You can also, however, start these
 processes programatically. This lets you provide new interfaces or mimic the
 functionality of these features in your own application?
 
+For example, suppose you want your custom OSGi application to have an export
+feature, which users could use to export content from their application as a LAR
+file. To offer this feature, you'd need to call services offered by the
+`ExportImportService` interface. All of the methods in this interface require an
+`ExportImportConfiguration` object, which is a controller object that contains
+many parameters and settings that are required during the exportation process of
+content from Liferay. The `ExportImportConfiguration` is essential to the export
+functionality of your custom application. Liferay provides a way to generate
+these configuration objects, so you can easily pass them in your service
+methods.
+
 In this tutorial, you'll learn about the `ExportImportConfiguration` framework
-and how you can take advantage of provided services and factories to fulfill
-your export/import and staging needs.
+and how you can take advantage of provided services and factories to create
+these controller obects. Once they're created, you can easily fulfill your
+export/import and staging needs.
 
 You can initiate a new export/import or staging process by creating an
 `ExportImportConfiguration` object. This object serves as the controller object,
@@ -16,7 +28,7 @@ which sets up the export/import or staging process. The
 `ExportImportConfiguration` object contains a large set of parameters and
 settings that are processed during export/import and staging. Liferay provides
 an extensive amount of services that can be called to initiate various
-export/import or staging processes, and many of these services utilize the
+export/import or staging processes, and many of these services use the
 `ExportImportConfiguration` object.
 
 It's also important to know that a `ExportImportConfiguration` is a Portal
@@ -87,6 +99,17 @@ your custom export/import or staging process.
     holds all the required parameters and settings necessary to export your
     layouts from Portal. Although this example code resides in Liferay Portal,
     you could easily use this framework from your own plugin or module.
+
+    +$$$
+
+    **Note:** If you're not calling the export/import or staging service methods
+    from an OSGi module, you should not use the interface. The Liferay
+    OSGi container automatically handles interface referencing, which is why
+    using the interface is permitted for modules. If you're calling
+    export/import or staging service methods outside of a module, you should use
+    their service Util classes (e.g., `ExportImportLocalServiceUtil`).
+
+    $$$
 
 It's that easy! To start your own export/import or staging process, you must
 create an `ExportImportConfiguration` object using a combination of the three

--- a/develop/tutorials/articles/export-import-and-staging/using-the-export-import-lifecycle-listener-framework.markdown
+++ b/develop/tutorials/articles/export-import-and-staging/using-the-export-import-lifecycle-listener-framework.markdown
@@ -47,7 +47,7 @@ Follow the steps below:
     Export/Import Lifecycle Listener framework:
     [`BaseExportImportLifecycleListener`](https://github.com/liferay/liferay-portal/blob/master/portal-service/src/com/liferay/portlet/exportimport/lifecycle/BaseExportImportLifecycleListener.java)
     or
-   [`BaseProcessExportImportLifecycleListener`](https://github.com/liferay/liferay-portal/blob/master/portal-service/src/com/liferay/portlet/exportimport/lifecycle/BaseProcessExportImportLifecycleListener.java).
+    [`BaseProcessExportImportLifecycleListener`](https://github.com/liferay/liferay-portal/blob/master/portal-service/src/com/liferay/portlet/exportimport/lifecycle/BaseProcessExportImportLifecycleListener.java).
     To choose, you'll need to consider what parts of a lifecycle you want to
     listen for.
 

--- a/develop/tutorials/articles/export-import-and-staging/using-the-export-import-lifecycle-listener-framework.markdown
+++ b/develop/tutorials/articles/export-import-and-staging/using-the-export-import-lifecycle-listener-framework.markdown
@@ -13,6 +13,19 @@ short list of events you can listen for:
 - A portlet export has failed
 - An entity export has succeeded
 
+The concept of listening for export/import and staging events sounds cool, but
+you may be curious as to why listening for certain events is useful. Liferay
+Portal uses this framework by default in several cases. For instance, Liferay
+clears the cache when a web content import process finishes. To accomplish this,
+the lifecycle listener framework listens for an event that specifies that a web
+content import process has completed. Once that event occurs, there is code that
+reacts on that event by automatically clearing the cache. You could implement
+this sort of functionality yourself for any Portal event. You can listen for a
+specific event, and then complete an action based on when that event occurs. For
+a list of events you can listen for during Export/Import and Staging processes,
+see
+[ExportImportLifecycleConstants](https://docs.liferay.com/portal/7.0-a1/javadocs/com/liferay/portlet/exportimport/lifecycle/ExportImportLifecycleConstants.html).
+
 In this tutorial, you'll learn how to use the `ExportImportLifecycleListener`
 framework to listen for processes/events during the staging and export/import
 lifecycles.


### PR DESCRIPTION
Hey Rich; I've added brief examples to each tutorial intro, explaining a use case that should make it easier for readers to imagine using the feature in their own module. I also added a brief note that @matethurzo informed me about, which describes when to use interfaces and Util classes for this framework. 

I didn't add anything to the directory intro Markdown file, because I intended this folder to hold many other staging-related tutorials. Therefore, I kept it brief, only explaining Staging and Export/Import in generic terms. Let me know if you have any further suggestions. Thanks!