### PR TITLE
Fix develop/reference dir so "ant dist" works

### DIFF
--- a/develop/reference/images/placeholder.txt
+++ b/develop/reference/images/placeholder.txt
@@ -1,0 +1,1 @@
+This file is a temporary placeholder for the directory.


### PR DESCRIPTION
The command `ant dist` currently fails in the `develop/reference` directory because it cannot find an `images` directory. I've added the directory so the command runs properly.