### PR TITLE
Embedding portlets in a theme via FTL has changed

### DIFF
--- a/develop/tutorials/articles/28-themes-and-layout-templates/embedding-portlets-in-themes-and-layout-templates.markdown
+++ b/develop/tutorials/articles/28-themes-and-layout-templates/embedding-portlets-in-themes-and-layout-templates.markdown
@@ -21,13 +21,19 @@ declare an embedded portlet. For example, the `portal_normal.ftl` template file
 is a popular place to declare embedded portlets. Insert the following
 declaration wherever you want to embed the portlet:
 
-    ${theme.runtime("CLASS_NAME", ACTION)}
+    <@liferay-portlet["runtime"]
+        portletProviderAction=ACTION
+        portletProviderClassName="CLASS_NAME"
+    />
 
-This declaration expects two parameters: the class name of the entity type the
-portlet should handle and the type of action. Here's an example of an embedded
+This declaration expects two parameters: the type of action and the class name
+of the entity type the portlet should handle. Here's an example of an embedded
 portlet declaration: 
 
-    $theme.runtime("com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry", $portletProviderAction.VIEW)
+    <@liferay-portlet["runtime"]
+        portletProviderAction=portletProviderAction.VIEW
+        portletProviderClassName="com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry"
+    />
 
 This declares that the theme is requesting to view language entries. There are
 four different kinds of actions supported by the Portlet Providers framework:


### PR DESCRIPTION
cc/ @mwilliams2014

Based on [this breaking change](https://github.com/liferay/liferay-portal/blob/master/readme/7.0/BREAKING_CHANGES.markdown#taglibs-are-no-longer-accessible-via-the-theme-variable-in-freemarker), embedding portlets in FreeMarker has changed. Julio confirmed this change.