### PR TITLE
Portal configuration reference for 7.0

### DIFF
--- a/discover/reference/articles/articles.markdown
+++ b/discover/reference/articles/articles.markdown
@@ -1,1 +1,0 @@
-Article folders go here. 

--- a/discover/reference/articles/configuration-reference.markdown
+++ b/discover/reference/articles/configuration-reference.markdown
@@ -1,0 +1,33 @@
+# Configuration Reference [](id=configuration-reference)
+
+The Configuration Reference page gives you shortcuts to Liferay Portal
+configuration reference documentation. From here, you can easily check Liferay
+definitions and configuration defaults as you customize your portal.
+
+<p>&nbsp;</p>
+
+<p>
+<span style="font-size:18px;">
+<a href="http://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html">
+portal.properties<span class="opens-new-window-accessible">(Opens New Window)</span>
+</a>
+</span>
+</p>
+
+<p>
+Describes the configuration defaults for Liferay Portal. 
+</p>
+
+<p>&nbsp;</p>
+
+<p>
+<span style="font-size:18px;">
+<a href="http://docs.liferay.com/portal/7.0/propertiesdoc/system.properties.html">
+system.properties<span class="opens-new-window-accessible">(Opens New Window)</span>
+</a>
+</span>
+</p>
+
+<p>
+Describes the system configuration defaults for Liferay Portal. 
+</p>


### PR DESCRIPTION
Hi Rich,

We hadn't created the Discover/Reference/article. I copied it over to master and updated it to point to our 7.0 docs. I imported to LDN just now and it's showing.