### PR TITLE
updated versions in build.gradle

### DIFF
--- a/code/sample-content-portlet-lr-workspace/modules/com.liferay.docs.samplecontent/build.gradle
+++ b/code/sample-content-portlet-lr-workspace/modules/com.liferay.docs.samplecontent/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compile 'com.liferay.portal:com.liferay.portal.kernel:1.0.1-SNAPSHOT'
+	compile 'com.liferay.portal:com.liferay.portal.kernel:2.0.0'
 	compile 'javax.portlet:portlet-api:2.0'
 	compile 'javax.servlet:servlet-api:2.5'
 	compile 'org.osgi:org.osgi.core:6.0.0'


### PR DESCRIPTION
We're using this for training, and the portal.kernel dependency needed a version update to build.