### PR TITLE
Fix build bug caused by absent "images" dir

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -306,6 +306,7 @@
 				</filterreader>
 			</filterchain>
 		</copy>
+		<mkdir dir="${temp.dir}/images"/>
 		<!-- Cannot use filtering for images (due to corruption), so must copy separately -->
 		<copy todir="${temp.dir}">
 			<fileset dir="${project.dir}/${purpose.dir}/${base.filepath}">

--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -271,6 +271,7 @@
 				</filterreader>
 			</filterchain>
 		</copy>
+		<mkdir dir="${temp.dir}/images"/>
 		<copy todir="${temp.dir}">
 			<fileset dir="${project.dir}/${purpose.dir}/${base.filepath}">
 				<include name="images/**/*.png"/>


### PR DESCRIPTION
Hey Rich; we were running into this error because the `discover/reference` directory had no images in its `images` folder. Because of this, the folder was not being created for our `/temp` dir, where our check-images target checks for the directory. I made a minor addition so that the `/images` dir is always created. 

Let me know if you run into any additional issues. Thanks!

https://issues.liferay.com/browse/LRDOCS-2575