### PR TITLE
Support any image/video referenced from the images dir

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -274,8 +274,7 @@
 		<mkdir dir="${temp.dir}/images"/>
 		<copy todir="${temp.dir}">
 			<fileset dir="${project.dir}/${purpose.dir}/${base.filepath}">
-				<include name="images/**/*.png"/>
-				<include name="images/**/*.jpg"/>
+				<include name="images/**"/>
 			</fileset>
 		</copy>
 	
@@ -310,10 +309,8 @@
 		<!-- Cannot use filtering for images (due to corruption), so must copy separately -->
 		<copy todir="${temp.dir}">
 			<fileset dir="${project.dir}/${purpose.dir}/${base.filepath}">
-				<include name="images/**/*.png"/>
-				<include name="images-dxp/**/*.png"/>
-				<include name="images/**/*.jpg"/>
-				<include name="images-dxp/**/*.jpg"/>
+				<include name="images/**"/>
+				<include name="images-dxp/**"/>
 			</fileset>
 		</copy>
 


### PR DESCRIPTION
I removed the logic that only recognized files for `.jpg` and `.png` extensions. We're now able to reference `.gif` files or any other media files residing in the `images[-dxp]` folder.

https://issues.liferay.com/browse/LRDOCS-2590