### PR TITLE
Workflow Link

### DIFF
--- a/discover/portal/articles/06-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
+++ b/discover/portal/articles/06-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
@@ -8,7 +8,7 @@ scripts takes it to the next level.
 Examine the default single approver workflow definition file included with Kaleo
 for an overview of how the feature works. You can find the default single
 approver workflow definition file in Liferay's source code here:
-[hhttps://github.com/liferay/com-liferay-portal-workflow/tree/7.0.x/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml](https://github.com/liferay/com-liferay-portal-workflow/tree/7.0.x/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml).
+[https://github.com/liferay/com-liferay-portal-workflow/blob/com.liferay.portal.workflow.kaleo.runtime.impl-2.0.3/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml](https://github.com/liferay/com-liferay-portal-workflow/blob/com.liferay.portal.workflow.kaleo.runtime.impl-2.0.3/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml).
 The final step in the workflow runs a script that makes content available for
 use. As you can see in the snippet below, it uses JavaScript to access the Java
 class associated with the workflow to set the status of the content to

--- a/discover/portal/articles/06-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
+++ b/discover/portal/articles/06-setting-up-liferay/04-scripting/03-leveraging-the-script-engine-in-workflow.markdown
@@ -5,13 +5,9 @@ approving content in an enterprise environment. Even if you don't leverage
 custom scripts, it's a powerful and robust workflow solution. Adding custom
 scripts takes it to the next level.
 
-Examine the default single approver workflow definition file included with Kaleo
-for an overview of how the feature works. You can find the default single
-approver workflow definition file in Liferay's source code here:
-[https://github.com/liferay/com-liferay-portal-workflow/blob/com.liferay.portal.workflow.kaleo.runtime.impl-2.0.3/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml](https://github.com/liferay/com-liferay-portal-workflow/blob/com.liferay.portal.workflow.kaleo.runtime.impl-2.0.3/portal-workflow-kaleo-runtime-impl/src/main/resources/META-INF/definitions/single-approver-definition.xml).
-The final step in the workflow runs a script that makes content available for
-use. As you can see in the snippet below, it uses JavaScript to access the Java
-class associated with the workflow to set the status of the content to
+The final step in a workflow should run a script that makes content available
+for use. As you can see in the snippet below, JavaScript can be used to access
+the Java class associated with the workflow to set the status of the content to
 *approved*.
 
     <script>


### PR DESCRIPTION
Hey Rich;

I know the fixed link goes against our new restrictions on source code linking, but since this is not linkable from doc.liferay.com (XML file), it will have to be fully explained in the article. I can alert the original author of this doc (Russ?) about this, but I know we're all busy, so I don't know when this will get resolved.

I figured two wrongs don't make a right, and if we're incorrectly pointing to the source code, we should at least have that link be correct. Let me know if you think tearing out the entire link is better than keeping it in there, and I can make that change too.

Addresses PR liferay#199.

Thanks!