### PR TITLE
LRDOCS-2939 Fixed broken links

### DIFF
--- a/develop/tutorials/articles/125-opensocial-gadgets/01-sending-pubsub-messages-between-gadgets-and-portlets.markdown
+++ b/develop/tutorials/articles/125-opensocial-gadgets/01-sending-pubsub-messages-between-gadgets-and-portlets.markdown
@@ -1,8 +1,8 @@
 # Sending PubSub Messages Between Gadgets and Portlets [](id=sending-pubsub-messages-between-gadgets-and-portlet)
 
 <!-- You can test the gadget-to-gadget tutorial using the following gadgets:
-https://raw.github.com/dejuknow/opensocial-gadgets/6.2.x/GoogleMaps/GoogleMapsPublisher.xml
-https://raw.github.com/dejuknow/opensocial-gadgets/6.2.x/GoogleMaps/GoogleMapsViewer.xml
+https://raw.github.com/dejuknow/opensocial-gadgets/master/GoogleMaps/GoogleMapsPublisher.xml
+https://raw.github.com/dejuknow/opensocial-gadgets/master/GoogleMaps/GoogleMapsViewer.xml
 -->
 
 The Portal Directory hook required for the portlet-to-gadget tutorial is
@@ -70,7 +70,7 @@ $$$
 
 We will now dive into the source code and analyze how this interaction is
 accomplished. To view the full contents of the Google Map, visit the
-[GoogleMapsPublisher.xml](https://raw.githubusercontent.com/dejuknow/opensocial-gadgets/6.2.x/GoogleMaps/GoogleMapsPublisher.xml)
+[GoogleMapsPublisher.xml](https://raw.githubusercontent.com/dejuknow/opensocial-gadgets/master/GoogleMaps/GoogleMapsPublisher.xml)
 file.
 
 The following excerpt from the Google Map XML file enables the gadget to use
@@ -109,7 +109,7 @@ processed by the gadget to show the address location on its map.
 
 Next, we'll analyze the tutorial's *subscribing* gadget's source code specified
 in the
-[GoogleMapsViewer.xml](https://raw.githubusercontent.com/dejuknow/opensocial-gadgets/6.2.x/GoogleMaps/GoogleMapsViewer.xml)
+[GoogleMapsViewer.xml](https://raw.githubusercontent.com/dejuknow/opensocial-gadgets/master/GoogleMaps/GoogleMapsViewer.xml)
 file.
 
 The subscriber source code is similar to that of the publisher: it mandates the


### PR DESCRIPTION
As discussed on pull request [1630](https://github.com/sez11a/liferay-docs/pull/1630), updated opensocial gadget's xml links