### PR TITLE
Replace broken links discovered in the OSGi and Modularity tutorial

### DIFF
--- a/develop/tutorials/articles/01-introduction-to-liferay-development/02-OSGi-and-modularity.markdown
+++ b/develop/tutorials/articles/01-introduction-to-liferay-development/02-OSGi-and-modularity.markdown
@@ -459,8 +459,8 @@ for you to learn more.
 
 [BLADE CLI](/develop/tutorials/-/knowledge_base/7-0/blade-cli)
 
-[Creating A Liferay Workspace](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace)
+[Liferay IDE](/develop/tutorials/-/knowledge_base/7-0/liferay-ide)
 
-[Migrating A Liferay 6 Application](/develop/tutorials/-/knowledge_base/7-0/migrating-a-liferay-6-application)
+[Planning a Plugin Upgrade to Liferay 7](/develop/tutorials/-/knowledge_base/7-0/migrating-existing-code-to-liferay-7)
 
 

--- a/develop/tutorials/articles/100-tooling/03-blade-cli/02-creating-a-liferay-workspace-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/02-creating-a-liferay-workspace-with-blade-cli.markdown
@@ -19,7 +19,7 @@ command:
 
 This command builds a workspace and automatically adds and configures your
 current Plugins SDK environment for use inside the workspace. See the
-[Using a Plugins SDK From Your Workspace](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace#using-a-plugins-sdk-from-your-workspace)
+[Using a Plugins SDK From Your Workspace](/develop/tutorials/-/knowledge_base/7-0/liferay-workspace#using-a-plugins-sdk-from-your-workspace)
 section for more information on how to use a Plugins SDK from within a
 workspace.
 

--- a/develop/tutorials/articles/100-tooling/03-blade-cli/11-managing-module-projects-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/11-managing-module-projects-with-blade-cli.markdown
@@ -25,7 +25,7 @@ This parameter automatically redeploys the module when changes are detected.
 **Note:** The `blade deploy` command requires a gradle wrapper to successfully
 execute. To ensure the availability of the Gradle wrapper, be sure to work in a
 Liferay Workspace. For more information on Liferay Workspaces, see the
-[Creating a Liferay Workspace](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace)
+[Creating a Liferay Workspace with Blade CLI](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace-with-blade-cli)
 tutorial.
 
 $$$
@@ -41,7 +41,7 @@ also be useful during development. Make sure you're in a Liferay Workspace and
 have a bundle installed and configured in the workspace before testing the Blade
 CLI commands on your own. To learn more about installing a Liferay server in a
 Liferay Workspace, see the
-[Running a Liferay Instance From Your Workspace](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace#running-a-liferay-instance-from-your-workspace)
+[Creating a Liferay Workspace with Liferay IDE](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace-with-liferay-ide)
 section. The following Blade CLI commands are covered in this sub-section:
 
 - `server`

--- a/develop/tutorials/articles/120-business-logic-and-data-access/02-service-builder-persistence/02-running-service-builder-and-understanding-the-generated-code.markdown
+++ b/develop/tutorials/articles/120-business-logic-and-data-access/02-service-builder-persistence/02-running-service-builder-and-understanding-the-generated-code.markdown
@@ -56,7 +56,7 @@ information about the generated files appears below.
 Open a terminal window and navigate to your module project's root folder, which
 should be located in your Liferay Workspace's `modules` directory. To learn more
 about creating your module project in a Liferay Workspace, visit the
-[Creating a Liferay Workspace](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace)
+[Creating a Liferay Workspace with Blade CLI](/develop/tutorials/-/knowledge_base/7-0/creating-a-liferay-workspace-with-blade-cli)
 tutorial. Liferay Workspaces use Gradle as their build tool, so this will be the
 assumed build language used in this tutorial. Liferay is tool agnostic, however,
 and you can use other tools, as well.

--- a/develop/tutorials/articles/340-data-upgrades-and-verifiers/creating-an-upgrade-process-for-your-application.markdown
+++ b/develop/tutorials/articles/340-data-upgrades-and-verifiers/creating-an-upgrade-process-for-your-application.markdown
@@ -171,7 +171,7 @@ There you have it. Now you know how to create an upgrade process for your app!
 
 ## Related Topics [](id=related-topics)
 
-[Migrating a Liferay 6 Application](/develop/tutorials/-/knowledge_base/7-0/migrating-a-liferay-6-application)
+[Planning a Plugin Upgrade to Liferay 7](/develop/tutorials/-/knowledge_base/7-0/migrating-existing-code-to-liferay-7)
 
 [Application Configuration](/develop/tutorials/-/knowledge_base/7-0/application-configuration)
 


### PR DESCRIPTION
Hey Rich,

As I revisited this tutorial I discovered it's related article links were broken. When I did a global search, I found they were used in a few other tutorials as well.

Thanks