### PR TITLE
Fix 6.2 doc links pointing to liferay-docs Github projects

### DIFF
--- a/devGuide/en/chapters/03-developing-portlet-applications.markdown
+++ b/devGuide/en/chapters/03-developing-portlet-applications.markdown
@@ -2295,7 +2295,7 @@ Importantly, you must name the files of all structures and templates, except
 page templates, after their source structures and templates. You can go back to
 any of the beginning steps in this section to make refinements to the sample
 plugin to try importing different structures and templates. The final
-`sample-templates-importer-portlet` project is available [here](https://github.com/liferay/liferay-docs/tree/master/devGuide/code/devGuide-sdk/portlets/sample-templates-importer-portlet). 
+`sample-templates-importer-portlet` project is available [here](https://github.com/liferay/liferay-docs/tree/6.2.x/devGuide/code/devGuide-sdk/portlets/sample-templates-importer-portlet). 
 
 As you've seen for yourself, importing templates and structures with your plugin
 isn't difficult at all. The Resource Importer app's Templates Importer feature

--- a/devGuide/en/chapters/05-generating-your-service-layer.markdown
+++ b/devGuide/en/chapters/05-generating-your-service-layer.markdown
@@ -195,7 +195,7 @@ attributes.
 
 If you'd like to examine the finished example project, it's a part of our *Dev
 Guide SDK* which you can browse at
-[https://github.com/liferay/liferay-docs/tree/master/devGuide/code/devGuide-sdk](https://github.com/liferay/liferay-docs/tree/master/devGuide/code/devGuide-sdk). 
+[https://github.com/liferay/liferay-docs/tree/6.2.x/devGuide/code/devGuide-sdk](https://github.com/liferay/liferay-docs/tree/master/devGuide/code/devGuide-sdk). 
 The project is in the SDK's
 [portlets/event-listing-portlet](https://github.com/liferay/liferay-docs/tree/master/devGuide/code/devGuide-sdk/portlets/event-listing-portlet)
 folder.

--- a/devGuide/en/chapters/13-designing-with-alloyui.markdown
+++ b/devGuide/en/chapters/13-designing-with-alloyui.markdown
@@ -623,7 +623,7 @@ Here is an example of a customized carousel using the configuration above:
 ![Figure 13.4: Image carousels can be customized. Here is an example of a customized carousel, using the scripting above.](../../images/alloyui-customized-carousel-in-portlet.png)
 
 You can access a finished version of the customized portlet at 
-[https://github.com/liferay/liferay-docs/tree/master/devGuide/code/12-working-with-alloyUI/customized-carousel-portlet](https://github.com/liferay/liferay-docs/tree/master/devGuide/code/12-working-with-alloyUI/customized-carousel-portlet)
+[https://github.com/liferay/liferay-docs/tree/6.2.x/devGuide/code/12-working-with-alloyUI/customized-carousel-portlet](https://github.com/liferay/liferay-docs/tree/6.2.x/devGuide/code/12-working-with-alloyUI/customized-carousel-portlet)
 
 Now that you've gotten your feet wet using some of AlloyUI's components, next
 you'll see how to work with the AlloyUI source so you can create your own

--- a/develop/tutorial-template.markdown
+++ b/develop/tutorial-template.markdown
@@ -7,7 +7,7 @@ and show him or her the end state of what you'll accomplish in this tutorial.
 
 You can use multiple paragraphs if you want, of course, but get to the point as
 soon as possible. Note that for the entirety of the tutorial, all the
-[Documentation Guidelines](https://github.com/liferay/liferay-docs/tree/master/guidelines) 
+[Documentation Guidelines](https://github.com/liferay/liferay-docs/tree/6.2.x/guidelines) 
 apply. 
 
 ## Major Task One

--- a/develop/tutorials/articles/107-service-builder/08-invoking-remote-services.markdown
+++ b/develop/tutorials/articles/107-service-builder/08-invoking-remote-services.markdown
@@ -14,7 +14,7 @@ remote service's permission checks. Consider the following common scenario:
 In the above scenario, it's a best practice to invoke the remote service instead
 of the local service. Doing so ensures that you don't need to duplicate
 permission checking code. This is the practice followed by the
-[Event Listing](https://github.com/liferay/liferay-docs/tree/master/develop/tutorials/tutorials-sdk-6.2-ga3/portlets/event-listing-portlet)
+[Event Listing](https://github.com/liferay/liferay-docs/tree/6.2.x/develop/tutorials/code/tutorials-sdk/portlets/event-listing-portlet)
 project.
 
 Of course, the main reason for creating remote services is to be able to invoke
@@ -23,7 +23,7 @@ both via a JSON API and via SOAP. By default, running Service Builder with
 `remote-service` set to `true` for your entities generates a JSON web services
 API for your project. You can access your project's JSON-based RESTful services
 via a convenient web interface. If you've deployed the
-[Event Listing](https://github.com/liferay/liferay-docs/tree/master/develop/tutorials/tutorials-sdk-6.2-ga3/portlets/event-listing-portlet)
+[Event Listing](https://github.com/liferay/liferay-docs/tree/6.2.x/develop/tutorials/code/tutorials-sdk/portlets/event-listing-portlet)
 project, visit the following URL to view its JSON web services:
 
     http://localhost:8080/event-listing-portlet/api/jsonws


### PR DESCRIPTION
Hey Rich,

This PR piggybacks off of liferay#223. This fixes all remaining links pointing to 6.2 projects in `liferay-docs`.