### PR TITLE
New token for product's full name

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -302,6 +302,7 @@
 			<filterchain>
 				<filterreader classname="org.apache.tools.ant.filters.ReplaceTokens">
 					<param type="token" name="${product.token}" value="${product.name}"/>
+					<param type="token" name="${product.token.full}" value="${product.name}"/>
 				</filterreader>
 			</filterchain>
 		</copy>
@@ -336,6 +337,7 @@
 			<filterchain>
 				<filterreader classname="org.apache.tools.ant.filters.ReplaceTokens">
 					<param type="token" name="${product.token}" value="${product.name.enterprise}"/>
+					<param type="token" name="${product.token.full}" value="${product.name.enterprise.full}"/>
 				</filterreader>
 			</filterchain>
 		</copy>

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/00-from-liferay-6-to-liferay-7-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/00-from-liferay-6-to-liferay-7-intro.markdown
@@ -1,4 +1,4 @@
-# From Liferay 6 to @product@ 7 [](id=from-liferay-6-to-liferay-7)
+# From Liferay 6 to @product-full@ 7 [](id=from-liferay-6-to-liferay-7)
 
 Becoming familiar with a platform as large and fully featured as Liferay is 
 a big task. You learn the ins and outs of what it can do, the tips and best 
@@ -13,7 +13,7 @@ And then there's a major upgrade and everything changes.
 
 This can be disheartening, as what was once familiar now seems alien, and what 
 once made you proficient now works differently. But we have good news for you. 
-@product@ 7 contains lots of improvements for developers; and this tutorial 
+@product-full@ 7 contains lots of improvements for developers; and this tutorial 
 series--or Learning Path--shows you how to make the best of them. You'll also 
 learn that yes, while a lot of things have changed, they've changed for the 
 better, and yet Liferay still works in ways that you'll find are familiar. In 
@@ -21,18 +21,18 @@ other words, since you already know previous versions of Liferay, you're
 several steps ahead of everybody else. 
 
 This Learning Path shows Liferay developers all the architectural improvements 
-that @product@ 7 offers. It describes the benefits of @product@ 7 for developers 
+that @product-full@ 7 offers. It describes the benefits of @product-full@ 7 for developers 
 compared to previous versions, the changes that modularity brings, how to 
 develop modules and how they differ from plugins, and includes comprehensive 
 tutorials on how to upgrade existing projects.
 
 You'll be able to apply your existing knowledge of portlet and theme development
-and portal customization to @product@ 7 too. To help you upgrade your existing 
+and portal customization to @product-full@ 7 too. To help you upgrade your existing 
 plugins, you'll see all the options, learn the pros and cons of each, and 
-examine common steps for adapting your plugins to @product@ 7. Finally, you'll 
+examine common steps for adapting your plugins to @product-full@ 7. Finally, you'll 
 learn how and when to modularize plugins.
 
-In the end, we believe you'll both want to adopt @product@ 7, and you'll see 
+In the end, we believe you'll both want to adopt @product-full@ 7, and you'll see 
 how you can thrive using it.
 
 The first thing to examine is what’s changed the most since Liferay 6 and then 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/02-benefits-of-liferay-7-for-liferay-6-developers/00-benefits-of-liferay-7-for-liferay-6-developers-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/02-benefits-of-liferay-7-for-liferay-6-developers/00-benefits-of-liferay-7-for-liferay-6-developers-intro.markdown
@@ -1,6 +1,6 @@
 # Benefits of @product-full@ 7 for Liferay 6 Developers [](id=benefits-of-liferay-7-for-liferay-6-developers)
 
-More than in any other @product@ release, @product-full@ 7 centers on you, the
+More than in any other Liferay release, @product-full@ 7 centers on you, the
 developer. Liferay's platform has been rebuilt, making it easier to build on and
 maintain, and providing more new developer features than any previous Liferay
 release.

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/02-benefits-of-liferay-7-for-liferay-6-developers/00-benefits-of-liferay-7-for-liferay-6-developers-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/02-benefits-of-liferay-7-for-liferay-6-developers/00-benefits-of-liferay-7-for-liferay-6-developers-intro.markdown
@@ -1,6 +1,6 @@
-# Benefits of @product@ 7 for Liferay 6 Developers [](id=benefits-of-liferay-7-for-liferay-6-developers)
+# Benefits of @product-full@ 7 for Liferay 6 Developers [](id=benefits-of-liferay-7-for-liferay-6-developers)
 
-More than in any other Liferay Portal release, @product@ 7 centers on you, the
+More than in any other @product@ release, @product-full@ 7 centers on you, the
 developer. Liferay's platform has been rebuilt, making it easier to build on and
 maintain, and providing more new developer features than any previous Liferay
 release.
@@ -26,13 +26,13 @@ Let's consider how they make development easier for you.
 Liferay has always been simple and lean, compared to the proprietary
 alternatives; this version widens the gap even more.
 
-@product@ 7 is simpler than its predecessors, thanks to a streamlined and modular
+@product-full@ 7 is simpler than its predecessors, thanks to a streamlined and modular
 architecture. In addition, many Liferay specific ways of creating extensions and
 applications have evolved to follow official or de-facto standards. As a result,
 developers can now more easily reuse their existing knowledge and use what they
 learn developing for Liferay outside of it.
 
-@product@ 7 is also leaner. Its modularized core allows developers and system
+@product-full@ 7 is also leaner. Its modularized core allows developers and system
 administrators to remove parts they don't need or don't want; this facilitates
 deployment, reduces startup times and memory footprints, and results in more
 efficiencies and performance improvements.
@@ -40,12 +40,12 @@ efficiencies and performance improvements.
 ## Modular Development Paradigm [](id=modular-development-paradigm)
 
 If you have been using Liferay, you've already experienced some of the benefits
-of modular development, thanks to plugins. @product@ 7 takes these benefits to a
+of modular development, thanks to plugins. @product-full@ 7 takes these benefits to a
 whole new level.
 
 In addition to building plugins as you have previously, you can take advantage
 of a complete module development and runtime system based on OSGi standards.
-@product@ 7 facilitates creating applications of all types by composing and
+@product-full@ 7 facilitates creating applications of all types by composing and
 reusing modules.
 
 And don't worry, modules are easy to understand. A module is distributed as a
@@ -68,11 +68,11 @@ Service Builder. This mechanism, however, is still a bit limited (Java EE's
 class loader doesn't allow for much more) and doesn't give you the freedom to
 specify any or all classes from one module to use from within another module.
 
-@product@ 7 enables greater reusability, both in code and runtime memory, several
+@product-full@ 7 enables greater reusability, both in code and runtime memory, several
 folds. For any desired reusable functionality you just create a module
 (remember, it's just a JAR file with some metadata) with the classes you want
 and deploy it. Other modules need only declare that they use the classes in that
-module (by specifying their packages) and @product@ 7 automatically wires them
+module (by specifying their packages) and @product-full@ 7 automatically wires them
 together. All invocations are regular Java calls! Try it out; it's beautiful. :)
 
 This mechanism eliminates the dreaded "JAR/classpath hell" issue. No longer do
@@ -87,7 +87,7 @@ Whenever we ask Liferay developers what is their favorite characteristic of
 Liferay, "Great extensibility" is one of the top three most popular responses.
 You can customize almost every detail and add your own functionality on top.
 
-Is @product@ 7 more extensible? You bet! Many more extension points have been
+Is @product-full@ 7 more extensible? You bet! Many more extension points have been
 added. But not only that, all new extension points and many existing ones which
 have been upgraded, use a new extension mechanism based on OSGi's service model.
 Here are some of the mechanism's benefits:
@@ -111,7 +111,7 @@ Implementing extensibility has never been easier.
 
 ## Optimized for Your Tooling of Choice [](id=optimized-for-your-tooling-of-choice)
 
-@product@ 7 empowers you to use the tools you like.
+@product-full@ 7 empowers you to use the tools you like.
 
 If you don't have strong preferences and are open to our suggestions, we offer
 Liferay Workspace. It provides an opinionated directory structure and build
@@ -126,7 +126,7 @@ collection of new archetypes.
 -->
 
 And if you want to continue using the Plugins SDK, we've got you covered. The
-Plugins SDK is available to facilitate your transition to @product@ 7. In fact, a
+Plugins SDK is available to facilitate your transition to @product-full@ 7. In fact, a
 Plugins SDK structure can reside in a Liferay Workspace alongside new
 developments that use the new build environment; you can switch between
 traditional projects and new projects at your own pace.
@@ -138,11 +138,11 @@ commands to start/stop the server and deploy and administer modules.
 
 ## Powerful Configurability [](id=powerful-configurability)
 
-Creating configurable code is a breeze with @product@ 7. And applications that use
+Creating configurable code is a breeze with @product-full@ 7. And applications that use
 Liferay's new Configuration API allow administrators to change the configuration
 on the fly, through an auto-generated user interface called System Settings.
 
-Now you understand how @product@ 7 enriches your experience as a developer and
+Now you understand how @product-full@ 7 enriches your experience as a developer and
 makes developing apps and customizations fun.
 
 Next, we'll take a look at OSGi and modularity to discuss key concepts and

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/03-osgi-and-modularity-for-liferay-6-developers/00-osgi-and-modularity-for-liferay-6-developers-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/03-osgi-and-modularity-for-liferay-6-developers/00-osgi-and-modularity-for-liferay-6-developers-intro.markdown
@@ -21,7 +21,7 @@ to provide a great developer experience.
 It wasn't long before Liferay discovered that OSGi and its supporting
 tools/technologies fit the bill!
 
-In this tutorial, you'll learn how @product@ 7 uses OSGi to meet these objectives.
+In this tutorial, you'll learn how @product-full@ 7 uses OSGi to meet these objectives.
 And equally important, you'll find out how easy and fun modular development can
 be.
 
@@ -29,12 +29,12 @@ Here are the topics you'll dig into:
 
 1. **Modules as an Improvement over Traditional Plugins**: Development and
    customization of applications for Liferay has been done traditionally in
-   plugins (Portlet, Hook, Ext and Web). In @product@ 7, plugins are replaced with
+   plugins (Portlet, Hook, Ext and Web). In @product-full@ 7, plugins are replaced with
    (and can be automatically converted to) modules. You'll see the similarities
    and differences of plugins and modules, and you'll learn the benefits of
    using modules.
 
-2. **Leveraging Dependencies**: In @product@ 7, developers can both declare
+2. **Leveraging Dependencies**: In @product-full@ 7, developers can both declare
    dependencies among modules and can combine modules to create applications.
    Since leveraging dependencies provides huge benefits, it's important to spend
    a lot of time showing how to do it. 
@@ -43,10 +43,10 @@ Here are the topics you'll dig into:
    called OSGi Services (also known as microservices). Together with the
    Declarative Services standard, it provides a clean way to inject dependencies
    (similar to Spring Dependency Injection) in a dynamic environment. It also
-   offers an elegant extensibility model that @product@ 7 leverages extensively.
+   offers an elegant extensibility model that @product-full@ 7 leverages extensively.
 
 <!-- Uncomment when these sections are added. Jim
-4. **Dynamic Deployment**: Module deployment is managed by @product@ 7 (not the
+4. **Dynamic Deployment**: Module deployment is managed by @product-full@ 7 (not the
 application server). This section demonstrates how to use dynamic deployment to
 allow for more dynamicity and speed.
 -->
@@ -58,11 +58,11 @@ Let's start with learning how modules are better than traditional plugins.
 
 ## Modules as an Improvement over Traditional Plugins [](id=modules-as-an-improvement-over-traditional-plugins)
 
-In @product@ 7, you can develop applications using OSGi modules or using
+In @product-full@ 7, you can develop applications using OSGi modules or using
 traditional Liferay plugins (WAR-style portlets, hooks, EXT, and web
 applications). Liferay's Plugin Compatibility Layer (explained later) makes it
 possible to deploy traditional plugins to the OSGi runtime framework. To benefit
-from all @product@ 7 and OSGi offer, however, you should use OSGi modules.
+from all @product-full@ 7 and OSGi offer, however, you should use OSGi modules.
 
 Here are some important benefits of using modules:
 
@@ -99,7 +99,7 @@ separate from the code, they're specified in context in the code.
 
 These are just a few ways modules outshine traditional plugins. Note, however,
 that developers experienced with Liferay plugins have the best of both worlds.
-@product@ 7 supports traditional plugins *and* modules. Existing Liferay
+@product-full@ 7 supports traditional plugins *and* modules. Existing Liferay
 developers can find comfort in the simplicity of modules and their similarities
 with plugins.
 
@@ -238,11 +238,11 @@ This part of the tutorial explains:
 
 - **How to develop modular apps using dependencies**
 
-Let's start by learning how dependencies operate in @product@ 7.
+Let's start by learning how dependencies operate in @product-full@ 7.
 
 ### How Dependencies Work [](id=how-dependencies-work)
 
-Since all of @product@ 7 leverages dependencies, it also demonstrates how to use
+Since all of @product-full@ 7 leverages dependencies, it also demonstrates how to use
 them. As mentioned previously, all of what was in Liferay 6 and its apps has
 been refactored into OSGi modules. The `portal-service` API (the main API in
 Liferay 6) has been replaced by the `portal-kernel` module (@product@'s kernel
@@ -294,17 +294,17 @@ modules to create apps.
 
 ### Dependencies Facilitate Modular Development [](id=dependencies-facilitate-modular-development)
 
-@product@ 7's support of dependencies and semantic versioning facilitates modular
+@product-full@ 7's support of dependencies and semantic versioning facilitates modular
 development. The dependency frameworks enable you to use modules and link them
 together. You can use these modules throughout your organization and distribute
-them to others. @product@ 7's integration with dependency management frees you to
+them to others. @product-full@ 7's integration with dependency management frees you to
 modularize existing apps and develop apps that combine modules. It's a powerful
 and fun way to develop apps on @product@.
 
 Here are some general steps to consider when modularizing an existing app:
 
 1. **Start by putting the entire app in a single module**: This is a minimal
-first step that acquaints you with @product@ 7's module framework. You'll gain
+first step that acquaints you with @product-full@ 7's module framework. You'll gain
 confidence as you build, deploy, and test your app in an environment of your
 choice, such as a Liferay Workspace, Gradle, or Maven project.
 
@@ -374,7 +374,7 @@ OSGi Services and dependency injection using OSGi Declarative Services.
 
 ## OSGi Services and Dependency Injection with Declarative Services [](id=osgi-services-and-dependency-injection-with-declarative-services)
 
-In @product@ 7, the OSGi framework registers objects as *services*. Each service
+In @product-full@ 7, the OSGi framework registers objects as *services*. Each service
 offers functionality and can leverage functionality other services provide. The
 OSGi Services model supports a collaborative environment for objects.
 
@@ -441,7 +441,7 @@ As an improvement over dependency injection with Spring, OSGi Declarative
 Services supports dynamic dependency injection. Developers can create and
 publish service components for other classes to use. Developers can update the
 components and even publish alternative component implementations for a service.
-This kind of dynamism is a powerful part of @product@ 7.
+This kind of dynamism is a powerful part of @product-full@ 7.
 
 ## Example: Building an OSGi Module [](id=example-building-an-osgi-module)
 
@@ -564,7 +564,7 @@ Congratulations! You've successfully built and deployed an OSGi module to
 
 [OSGi enRoute](http://enroute.osgi.org/)
 
-@product@ 7 leverages the following services extensively. They're specified in
+@product-full@ 7 leverages the following services extensively. They're specified in
 [*The OSGi Alliance OSGi Compendium: Release 6*](https://www.osgi.org/developer/specifications/).
 
 - *Declarative Services Specification* 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/06-planning-a-plugin-upgrade-to-liferay-7/00-planning-a-plugin-upgrade-to-liferay-7-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/06-planning-a-plugin-upgrade-to-liferay-7/00-planning-a-plugin-upgrade-to-liferay-7-intro.markdown
@@ -1,7 +1,7 @@
-# Planning a Plugin Upgrade to @product@ 7 [](id=migrating-existing-code-to-liferay-7)
+# Planning a Plugin Upgrade to @product-full@ 7 [](id=migrating-existing-code-to-liferay-7)
 
 You've probably heard the term *modularity* discussed frequently in relation to
-@product@ 7.0. With @product@ 7.0 being a modular platform, Liferay applications are
+@product-full@ 7.0. With @product-full@ 7.0 being a modular platform, Liferay applications are
 now composed of one or more
 [modules](https://dev.liferay.com/participate/liferaypedia/-/wiki/Main/Module).
 
@@ -23,7 +23,7 @@ reason, it remains backwards compatible with traditional plugin applications.
 This means two things: you can write both module and plugins, and you can easily
 upgrade your 6.2 plugins to new 7.0 APIs without converting them to modules
 first. In fact before you begin converting your traditional application into
-modules, we recommend that you first migrate it to a @product@ 7.0 compatible
+modules, we recommend that you first migrate it to a @product-full@ 7.0 compatible
 WAR-style application. It is much easier to convert the application to modules
 after adapting to the new API and resolving [breaking changes](https://dev.liferay.com/develop/reference/-/knowledge_base/7-0/breaking-changes).
 Jumping from a 6.2 application to 7.0 modules can complicate debugging
@@ -32,7 +32,7 @@ to the migration process.
 
 The standard migration process consists of two general steps: 
 
-**Step 1:  Adapting your 6.2 traditional plugins to @product@ 7's API** <!--(/develop/tutorials/-/knowledge_base/7-0/adapting-to-liferay-7s-api)-->
+**Step 1:  Adapting your 6.2 traditional plugins to @product-full@ 7's API** <!--(/develop/tutorials/-/knowledge_base/7-0/adapting-to-liferay-7s-api)-->
 
 **Step 2:  Converting your traditional plugins to OSGi modules** <!--(/develop/tutorials/-/knowledge_base/7-0/modularizing-an-existing-portlet)-->
 
@@ -87,12 +87,12 @@ troubleshoot and obscure problems. Module versions, however, can be stated
 explicitly in the dependency, eliminating these types of issues.
 
 Now that you have some ammunition to make an informed decision on whether to
-stop after adapting your application's plugins to @product@ 7, or to continue on
+stop after adapting your application's plugins to @product-full@ 7, or to continue on
 with modularizing them. The next tutorial takes you through the first step:
-adapting plugins to @product@ 7's API.
+adapting plugins to @product-full@ 7's API.
 
 **Related Topics**
 
-<!--[Adapting to @product@ 7's API](/develop/tutorials/-/knowledge_base/7-0/adapting-to-liferay-7s-api)-->
+<!--[Adapting to @product-full@ 7's API](/develop/tutorials/-/knowledge_base/7-0/adapting-to-liferay-7s-api)-->
 
 [Modularizing an Existing Portlet](/develop/tutorials/-/knowledge_base/7-0/modularizing-an-existing-portlet)

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/00-upgrading-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/00-upgrading-plugins-intro.markdown
@@ -1,7 +1,7 @@
-# Upgrading Plugins to @product@ 7 [](id=upgrading-plugins-to-liferay-7)
+# Upgrading Plugins to @product-full@ 7 [](id=upgrading-plugins-to-liferay-7)
 
 The plugin upgrade tutorials guide you through a process of making the minimal
-changes necessary for existing plugins to work in @product@ 7. This group of
+changes necessary for existing plugins to work in @product-full@ 7. This group of
 tutorials starts by covering the most common cases, and there are more tutorials 
 to come that cover more specific cases, including those based on feedback. 
 Upgrade tutorials for all plugin types are on their way, including guidance for 
@@ -18,7 +18,7 @@ The tutorials will cover upgrading all existing plugin types and templates:
 - FreeMarker and Velocity Templates
 
 The first upgrade process step is to adapt your existing plugin's code to
-@product@ 7's APIs. The great news is that Liferay's Code Upgrade Tool makes this
+@product-full@ 7's APIs. The great news is that Liferay's Code Upgrade Tool makes this
 easier than ever. It identifies Liferay API changes affecting your code, 
 explains the API changes, and offers resolution steps. And the tool offers 
 auto-correction where it can. 
@@ -26,9 +26,9 @@ auto-correction where it can.
 <!-- TODO Give an overview of the rest of the upgrade process. Jim -->
 
 You might be tempted to optimize your existing plugins right away to benefit 
-from the new things @product@ 7 offers, but you shouldn't. It's much better to 
+from the new things @product-full@ 7 offers, but you shouldn't. It's much better to 
 upgrade your plugins according to these tutorials. In this way, you'll get your 
 plugins running in Liferay as fast as possible, and at the same time you'll have 
 prepared the plugins for the optimizations you can implement later. 
 
-You'll start with adapting existing plugin code to @product@ 7's API.
+You'll start with adapting existing plugin code to @product-full@ 7's API.

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/01-adapting-to-liferay-7s-api.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/01-adapting-to-liferay-7s-api.markdown
@@ -1,7 +1,7 @@
-# Adapting to @product@ 7's API with the Code Upgrade Tool [](id=adapting-to-liferay-7s-api-with-the-code-upgrade-tool)
+# Adapting to @product-full@ 7's API with the Code Upgrade Tool [](id=adapting-to-liferay-7s-api-with-the-code-upgrade-tool)
 
 The first upgrade process step is to adapt your existing plugin's code to
-@product@ 7's API. @product@ 7 is a major release that contains significant API
+@product-full@ 7's API. @product-full@ 7 is a major release that contains significant API
 changes. As part of the modularization process, many packages have been renamed
 to adopt a new standard. But each API change has been carefully documented to
 explain what changed, how to adapt to the change, and why the change was made.
@@ -12,10 +12,10 @@ how to adapt the code to the new APIs.
 
 The Liferay Code Upgrade Tool (initially called the Migration Tool) is in
 Liferay IDE and Liferay Developer Studio. You should use the tool to adapt code
-to @product@ 7; you can switch back to your favorite tool afterwards.
+to @product-full@ 7; you can switch back to your favorite tool afterwards.
 
-This tutorial shows you how to adapt existing plugin code to @product@ 7's API. As
-a prerequisite, you set up your existing traditional plugin in a @product@ 7
+This tutorial shows you how to adapt existing plugin code to @product-full@ 7's API. As
+a prerequisite, you set up your existing traditional plugin in a @product-full@ 7
 Plugins SDK, in Liferay IDE or Liferay Developer Studio. Then you find your
 plugin's dependencies and configure them. Finally, you use the Code Upgrade Tool
 to address upgrade issues. It's all straightforward.
@@ -29,7 +29,7 @@ chain.
 
 $$$
 
-Let's start by setting up your plugin in a @product@ 7 Plugins SDK using Liferay IDE
+Let's start by setting up your plugin in a @product-full@ 7 Plugins SDK using Liferay IDE
 or Liferay Developer Studio.
 
 ## Setup [](id=setup)
@@ -44,11 +44,11 @@ version 3.0 or newer. Otherwise, download it from the product site:
 
 * [Liferay Developer Studio](https://web.liferay.com/group/customer/dxp/downloads/developer-tools)
 
-Next, you need a @product@ 7 Plugins SDK for your traditional plugin. The new SDK
+Next, you need a @product-full@ 7 Plugins SDK for your traditional plugin. The new SDK
 is available on the [downloads page](https://www.liferay.com/downloads).
 
-Then, either move your plugin into the @product@ 7 Plugins SDK or unzip the 
-@product@ 7 Plugins SDK on top of your existing Plugins SDK. This upgrades it 
+Then, either move your plugin into the @product-full@ 7 Plugins SDK or unzip the 
+@product-full@ 7 Plugins SDK on top of your existing Plugins SDK. This upgrades it 
 to the latest version. 
 
 In your `build.[username].properties` file, make sure to set the
@@ -66,14 +66,14 @@ project as follows:
     configuring your project.
 
 Your existing plugin project, along with its Plugins SDK, appears in the IDE.
-You're ready to adapt the plugin to @product@ 7!
+You're ready to adapt the plugin to @product-full@ 7!
 
 ## Resolving Module Dependencies [](id=resolving-module-dependencies)
 
 Now that you've imported your plugin project to Liferay IDE or Developer Studio,
 you probably see compile errors for some of the Liferay classes it uses.
 They're listed as undefined classes or unresolved symbols because they've been
-moved, renamed, or removed. As a part of modularization in @product@ 7, many of
+moved, renamed, or removed. As a part of modularization in @product-full@ 7, many of
 these classes reside in new modules.
 
 You need to resolve all of these Liferay classes for your plugin. Some of the
@@ -118,9 +118,9 @@ starts with configuring your plugin project to declare the modules it needs.
 
 ### Identifying Module Dependencies [](id=identifying-module-dependencies)
 
-Before @product@ 7.0, all the platform APIs were in a single JAR file:
+Before @product-full@ 7.0, all the platform APIs were in a single JAR file:
 `portal-service.jar`. Many of these APIs are now in independent modules. 
-Modularization has resulted in many benefits, as described in the article [Benefits of @product@ 7 for Liferay 6 Developers](/develop/tutorials/-/knowledge_base/7-0/benefits-of-liferay-7-for-liferay-6-developers#modular-development-paradigm)
+Modularization has resulted in many benefits, as described in the article [Benefits of @product-full@ 7 for Liferay 6 Developers](/develop/tutorials/-/knowledge_base/7-0/benefits-of-liferay-7-for-liferay-6-developers#modular-development-paradigm)
 One such advantage is that these API modules can evolve separately from the
 platform kernel. They also simplify future upgrades. For example, instead of
 having to check all of Liferay's APIs, each module's [Semantic Versioning](http://semver.org/)
@@ -190,7 +190,7 @@ shortly.
 +$$$
 
 Note: Previous versions of the Plugins SDK made `portal-service.jar` available
-to projects; the @product@ 7 Plugins SDK similarly makes `portal-kernel.jar`
+to projects; the @product-full@ 7 Plugins SDK similarly makes `portal-kernel.jar`
 available. If you're using a Liferay bundle (i.e., @product@ pre-installed on an
 app server), the Liferay utility modules are already in your classpath.
 
@@ -340,7 +340,7 @@ Liferay's Code Upgrade Tool to adapt the rest of your plugin's code.
 ## Adapting to the API with the Code Upgrade Tool [](id=adapting-to-the-api-with-the-code-upgrade-tool)
 
 The Code Upgrade Tool identifies areas in your code that need to be adapted to
-Liferay's APIs changes. As @product@ 7 was being developed, some of the changes
+Liferay's APIs changes. As @product-full@ 7 was being developed, some of the changes
 were unavoidable and resulted in problems that affect plugin upgrades. They're
 commonly known as *breaking changes* and are captured in @product@'s [Breaking Changes](/develop/reference/-/knowledge_base/7-0/breaking-changes)
 document.
@@ -354,7 +354,7 @@ To start the Code Upgrade Tool, follow these steps:
 
 1. In the *Project Explorer*, right-select your plugin project.
 
-2. Select *Liferay &rarr; Find @product@ 7 breaking API changes*
+2. Select *Liferay &rarr; Find @product-full@ 7 breaking API changes*
 
 The following view appears.
 
@@ -404,20 +404,20 @@ clicking the search icon. The issue's description and comments provide relevant
 information.
 
 Resolving all of a plugin's reported upgrade problems makes for a great start
-in adapting your plugin to @product@ 7.
+in adapting your plugin to @product-full@ 7.
 
 ## Summary [](id=summary)
 
 Congratulations on completing the first step in upgrading your plugin to @product@
 7! Let's consider all that you've done.
 
-You set up your plugin in a @product@ 7 Plugins SDK, imported it into Liferay IDE
-or Liferay Developer Studio, and set up a @product@ 7 server in that IDE. Then,
+You set up your plugin in a @product-full@ 7 Plugins SDK, imported it into Liferay IDE
+or Liferay Developer Studio, and set up a @product-full@ 7 server in that IDE. Then,
 you fixed class imports and resolved dependencies on all the modules your plugin
 uses. Finally, you leveraged Liferay's Code Upgrade Tool to hunt down and adapt
 to breaking API changes. Way to go!
 
-It's onward and upward with upgrading your traditional plugins on @product@ 7!
+It's onward and upward with upgrading your traditional plugins on @product-full@ 7!
 
 ## Related Articles [](id=related-articles)
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/03-converting-struts-action-wrappers-to-mvc-commands.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/03-converting-struts-action-wrappers-to-mvc-commands.markdown
@@ -56,7 +56,7 @@ For most cases, the `MVCCommand` mapping is the same mapping defined in the
 legacy struts action.
 
 Using the beginning login example once again, the `struts-action-path` mapping, 
-`/login/login`, remains the same for the `MVCCommand` mapping in @product@ 7, but
+`/login/login`, remains the same for the `MVCCommand` mapping in @product-full@ 7, but
 some of the mappings may have changed. It’s best to check Liferay's source code
 to determine the correct mapping.
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/05-upgrading-themes.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/05-upgrading-themes.markdown
@@ -1,10 +1,10 @@
 # Upgrading Themes [](id=upgrading-themes)
 
 If you've developed themes in Liferay 6.2, as part of your upgrade you'll want
-to use them in @product@ 7. While you're at it, you should leverage theme
+to use them in @product-full@ 7. While you're at it, you should leverage theme
 improvements, including support for Sass, Bootstrap 3, and Lexicon (Liferay's UI
 design language). This tutorial demonstrates upgrading a Liferay 6.2 theme to
-@product@ 7. 
+@product-full@ 7. 
 
 Theme upgrades involve these steps:
 
@@ -25,7 +25,7 @@ contains its original source code.
 
 Before upgrading a theme, consider [migrating the theme](/develop/tutorials/-/knowledge_base/7-0/migrating-a-6-2-theme-to-liferay-7)
 to use the [Themes Generator](/develop/tutorials/-/knowledge_base/7-0/themes-generator).
-@product@ 7 doesn't require this migration, but the Themes Generator's `upgrade`
+@product-full@ 7 doesn't require this migration, but the Themes Generator's `upgrade`
 Gulp task automates many upgrade steps. Themes Generator themes can also
 leverage exclusive new features, such as
 [Themelets](/develop/tutorials/-/knowledge_base/7-0/themelets).
@@ -38,7 +38,7 @@ see *all* upgrade steps, in case you want to run them manually.
 
 ## Running the Upgrade Task for Themes Generator Themes [](id=running-the-upgrade-task-for-themes-generator-themes)
 
-A Liferay 6.2 theme can be upgraded to @product@ 7, regardless of its project
+A Liferay 6.2 theme can be upgraded to @product-full@ 7, regardless of its project
 environment (Themes Generator, Plugins SDK, Maven, etc.). But a theme that's
 been migrated to the Themes Generator can leverage the theme `upgrade` Gulp task.
 If you're developing your theme in an environment other than the Themes
@@ -75,7 +75,7 @@ Here are the steps for using the theme `upgrade` Gulp task:
     The task continues upgrading CSS files, prompting you to update CSS file
     names.
 
-2.  For @product@ 7, Sass files should use the `.scss` extension and file names for
+2.  For @product-full@ 7, Sass files should use the `.scss` extension and file names for
     Sass partials should start with an underscore (e.g., `_custom.scss`). The
     `upgrade` task prompts you for each CSS file to rename.
 
@@ -107,7 +107,7 @@ If you're developing your theme in an environment other than the Plugins SDK,
 skip this section. 
 
 A theme's Liferay version must be updated to `7.0.0+` for the theme to run on
-@product@ 7. 
+@product-full@ 7. 
 
 If you're using the Plugins SDK, open the `liferay-plugin-package.properties`
 file and change the `liferay-versions` property value to `7.0.0+`: 
@@ -134,12 +134,12 @@ compatibility version:
 3.  If your theme uses the Themes Generator and has a `package.json` file,
     update the file's Liferay version references to `7.0`.
 
-Your theme's Liferay version references are updated for @product@ 7. Next, you'll
+Your theme's Liferay version references are updated for @product-full@ 7. Next, you'll
 update the CSS.
 
 ## Updating CSS Code [](id=updating-css-code)
 
-@product@ 7's UI improvements required these CSS-related changes:
+@product-full@ 7's UI improvements required these CSS-related changes:
 
 - Adding new CSS files
 - Removing unneeded CSS files
@@ -154,7 +154,7 @@ improvements. Start with updating CSS file names for Sass.
 ### Updating CSS File Names for Sass [](id=updating-css-file-names-for-sass)
 
 Although Sass was available in Liferay 6.2, only Sass partial files followed the
-Sass naming convention (using file suffix `.scss`). In @product@ 7 themes, all
+Sass naming convention (using file suffix `.scss`). In @product-full@ 7 themes, all
 Sass files must end in `scss`. 
 
 +$$$
@@ -183,7 +183,7 @@ Next, the CSS rules must be updated to use Bootstrap 3 syntax.
 
 ### Updating CSS Rules [](id=updating-css-rules)
 
-@product@ 7 uses Bootstrap 3's CSS rule syntax. The new syntax lets developers
+@product-full@ 7 uses Bootstrap 3's CSS rule syntax. The new syntax lets developers
 leverage Bootstrap 3 features and improvements.
 
 If your theme does not use the Themes Generator, you can refer to the
@@ -304,7 +304,7 @@ After updating your theme's CSS rules, you should update its CSS responsiveness.
 
 ### Updating the Responsiveness [](id=updating-the-responsiveness)
 
-In @product@ 7, Bootstrap 3 explicit media queries replace Bootstrap 2
+In @product-full@ 7, Bootstrap 3 explicit media queries replace Bootstrap 2
 `respond-to` mixins for CSS responsiveness. Follow these steps to update CSS
 responsiveness:
 
@@ -367,13 +367,13 @@ theme's design incorporates Font Awesome icons in its social media links.
 The icons are easy to use in themes too.
 
 In Liferay 6.2, the CSS file `aui.css`  defined the Font Awesome icon paths. In
-@product@ 7, the Sass file `_aui_variables.scss` defines them.
+@product-full@ 7, the Sass file `_aui_variables.scss` defines them.
 
 +$$$
 
-**Note:** In @product@ 7, the `aui.css` file holds the `lexicon-base` style
+**Note:** In @product-full@ 7, the `aui.css` file holds the `lexicon-base` style
 import. The [Theme Reference Guide](/develop/reference/-/knowledge_base/7-0/theme-reference-guide)
-describes all the @product@ 7 theme files.
+describes all the @product-full@ 7 theme files.
 
 $$$
 
@@ -390,7 +390,7 @@ Next, you'll update the theme templates.
 
 ## Updating Theme Templates [](id=updating-theme-templates)
 
-@product@ 7 theme templates are essentially the same as Liferay 6.2 theme
+@product-full@ 7 theme templates are essentially the same as Liferay 6.2 theme
 templates. Here are the main changes:
 
 -   Velocity templates are now deprecated in favor of FreeMarker templates
@@ -413,7 +413,7 @@ The menus that replace the Dockbar supports a more flexible and responsive
 design for creating better user experiences. 
 
 You should start by addressing the Velocity templates. Since Velocity
-templates have been deprecated and aren't compatible with @product@ 7, **you
+templates have been deprecated and aren't compatible with @product-full@ 7, **you
 must convert your Velocity theme templates to FreeMarker**.
 
 If you're using the Themes Generator, the `gulp upgrade` command reports the
@@ -435,7 +435,7 @@ For example, here is the command's output for the Lunar Resort theme:
 
 For all the theme's templates, it suggests replacement code for deprecated code. 
 
-Next, you'll learn how to update various theme templates to @product@ 7. If you
+Next, you'll learn how to update various theme templates to @product-full@ 7. If you
 didn't modify any theme templates, you can skip these sections.
 
 ### Updating Portal Normal FTL [](id=updating-portal-normal-ftl)
@@ -502,7 +502,7 @@ updated to use the new syntax.
     -  *The User Personal Bar*: Display notifications and the user's avatar and
         name. 
 
-    ![Figure 3: The Dockbar was removed in @product@ 7 and must be replaced with the new Control Menu.](../../../images/upgrading-themes-dockbar.png)
+    ![Figure 3: The Dockbar was removed in @product-full@ 7 and must be replaced with the new Control Menu.](../../../images/upgrading-themes-dockbar.png)
 
     The new design enhances the user experience by providing clear and
     purposeful menus. 
@@ -635,7 +635,7 @@ file:
 
     The plugin no longer needs this property as the resources importer is now an
     [OSGI module](https://github.com/liferay/liferay-portal/tree/master/modules/apps/web-experience/export-import/export-import-resources-importer)
-    built-in and deployed with @product@ 7.
+    built-in and deployed with @product-full@ 7.
 
 2.  Since the group model class's fully-qualified class name has changed, replace the
     `resources-importer-target-class-name` property's value with the
@@ -648,7 +648,7 @@ update your theme's web content.
 
 ### Updating Web Content [](id=updating-web-content)
 
-All @product@ 7 web content articles must be written in XML and have a structure
+All @product-full@ 7 web content articles must be written in XML and have a structure
 and template. Article creation requires a structure and article content
 rendering requires a template. Follow these steps to update your web content:
 
@@ -768,7 +768,7 @@ rendering requires a template. Follow these steps to update your web content:
             </dynamic-element>
         </root>
 
-7.  @product@ 7's migration from Bootstrap 2 to Bootstrap 3 requires that you
+7.  @product-full@ 7's migration from Bootstrap 2 to Bootstrap 3 requires that you
     replace all `div` element `class` attribute values of Bootstrap 2 format 
     `span[number]` with values that use the Bootstrap 3 format:
 
@@ -810,7 +810,7 @@ the ZIP file's `/resources-importer/journal/articles/Basic Web Content/` folder.
 
 +$$$
 
-**Note:** Although Liferay 6.2 used AlloyUI 2.0.x, @product@ 7 uses AlloyUI 3.0.x.
+**Note:** Although Liferay 6.2 used AlloyUI 2.0.x, @product-full@ 7 uses AlloyUI 3.0.x.
 As a result, you may need to update your code that uses AlloyUI. Refer to
 AlloyUI's [examples](http://alloyui.com/examples/) and [API docs](http://alloyui.com/api/)
 for details. 
@@ -821,7 +821,7 @@ Next, you must update your resources importer's sitemap file.
 
 ### Updating the Sitemap [](id=updating-the-sitemap)
 
-In Liferay 6.2, portlet IDs were incremental numbers. In @product@ 7, they're
+In Liferay 6.2, portlet IDs were incremental numbers. In @product-full@ 7, they're
 explicit class names. The new IDs are intuitive and unique. But you must update
 your `sitemap.json` file with the new portlet IDs.
 
@@ -848,7 +848,7 @@ patterns.
 
 ## Applying Lexicon UI Design Patterns [](id=applying-lexicon-ui-design-patterns)
 
-@product@ 7 uses a design language called [Lexicon](http://liferay.github.io/lexicon/).
+@product-full@ 7 uses a design language called [Lexicon](http://liferay.github.io/lexicon/).
 It provides styling guidelines and best practices for application UIs. Lexicon's
 HTML and JavaScript components enable developers to build fully-realized UIs
 quickly and effectively. This section demonstrates how to apply Lexicon to a
@@ -950,7 +950,7 @@ The Lexicon updates applied to the form are as follows:
 
 You can apply similar Lexicon design patterns to your theme's HTML files.
 
-You've updated your theme to @product@ 7! You can deploy it from your theme
+You've updated your theme to @product-full@ 7! You can deploy it from your theme
 project.
 
 Themes Generator-based project:
@@ -968,6 +968,6 @@ upgraded themes.
 
 [Themes Generator](/develop/tutorials/-/knowledge_base/7-0/themes-generator)
 
-[Migrating a theme to @product@ 7](/develop/tutorials/-/knowledge_base/7-0/migrating-a-6-2-theme-to-liferay-7)
+[Migrating a theme to @product-full@ 7](/develop/tutorials/-/knowledge_base/7-0/migrating-a-6-2-theme-to-liferay-7)
 
-[Upgrading to @product@ 7] (/discover/deployment/-/knowledge_base/7-0/upgrading-to-liferay-7)
+[Upgrading to @product-full@ 7] (/discover/deployment/-/knowledge_base/7-0/upgrading-to-liferay-7)

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/06-upgrading-layouts-and-themes.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/06-upgrading-layouts-and-themes.markdown
@@ -1,16 +1,16 @@
 # Upgrading Layout Templates [](id=upgrading-layout-templates)
 
-Layout templates for @product@ 7 differ slightly from layout templates for
+Layout templates for @product-full@ 7 differ slightly from layout templates for
 Liferay 6. The layout template's rows and columns are affected by Bootstrap's
 new grid system syntax.
 
 This tutorial demonstrates the following:
 
-- How to upgrade your layout template to @product@ 7
+- How to upgrade your layout template to @product-full@ 7
 
 <!-- Comment out Code Upgrade Tool instructions until the tool is worth using with layout templates. Jim
 
-There are a couple ways you can upgrade your layout template to @product@ 7. If
+There are a couple ways you can upgrade your layout template to @product-full@ 7. If
 your project is in Liferay IDE or Liferay Developer Studio, you can use the Code 
 Upgrade Tool to start the upgrade process. The second option is to manually 
 upgrade the template files in the editor of your choice.
@@ -24,16 +24,16 @@ section.
 
 Since Liferay IDE and Liferay Developer Studio version 3.0, the Code Upgrade
 Tool has been available to use. The Code Upgrade Tool runs through your code,
-points out the @product@ 7 breaking changes, and suggest how to update it. Follow
-these steps to upgrade your layout template to @product@ 7.
+points out the @product-full@ 7 breaking changes, and suggest how to update it. Follow
+these steps to upgrade your layout template to @product-full@ 7.
 
 1.  Right-click on your layout template project in the *Package Explorer*, and 
-    select *Liferay* &rarr; *Find @product@ 7 breaking API changes*.
+    select *Liferay* &rarr; *Find @product-full@ 7 breaking API changes*.
     
     Figure 1: The Code Upgrade Tool finds the breaking changes in your code and suggests how to fix them. ../../../images/upgrading-layouts-find-api-breaking-changes.png
     
     The breaking changes and suggested fixes are listed in the 
-    *@product@ 7 Migration Problems* tab of the workspace. At the moment, only a 
+    *@product-full@ 7 Migration Problems* tab of the workspace. At the moment, only a 
     `Code Problems` folder is shown. You'll have to select a file first, in 
     order to see the related breaking changes.
     
@@ -42,7 +42,7 @@ these steps to upgrade your layout template to @product@ 7.
     
     Now you can see the problems listed, with suggested fixes listed below.
     
-    Figure 2: Breaking changes are listed in the *@product@ 7 Migration Problems* tab. ../../../images/upgrading-layouts-list-of-breaking-changes.png
+    Figure 2: Breaking changes are listed in the *@product-full@ 7 Migration Problems* tab. ../../../images/upgrading-layouts-list-of-breaking-changes.png
     
     In this case, there is only one problem listed.
     
@@ -52,7 +52,7 @@ these steps to upgrade your layout template to @product@ 7.
     Currently the `liferay-versions` property is set to 6.2. The Code Upgrade
     Tool can fix this.
     
-3.  Right-click on the problem in the *@product@ 7 Migration Problems* tab and
+3.  Right-click on the problem in the *@product-full@ 7 Migration Problems* tab and
     select *Correct automatically*.
     
     Figure 3: The Code Upgrade Tool can automatically update some breaking changes for you. ../../../images/upgrading-layouts-correct-automatically.png
@@ -61,7 +61,7 @@ these steps to upgrade your layout template to @product@ 7.
     some more adjustments to make.
     
 The next section covers the rest of the changes you'll need to make to your
-layout template for @product@ 7.
+layout template for @product-full@ 7.
 
 ## Upgrading Your Layout Template Files [](id=upgrading-your-layout-template-files)
 
@@ -72,7 +72,7 @@ template. If you followed the steps in the last section, you can skip to step 2.
 Upgrading a layout template involves updating its Liferay version and updating
 the class syntax for its rows and columns.
 
-Follow these steps to upgrade your layout template for @product@ 7:
+Follow these steps to upgrade your layout template for @product-full@ 7:
 
 1.  Open your `liferay-plugin-package.properties` file and update the 
     `liferay-versions` property to `7.0.0+`:
@@ -103,7 +103,7 @@ Follow these steps to upgrade your layout template for @product@ 7:
         <div class="portlet-column portlet-column-last col-md-4" id="column-3">
  
 As an example, here's Liferay 6 layout template [1_2_1_columns.tpl](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-web/docroot/layouttpl/custom/1_2_1_columns.tpl)
-upgraded to @product@ 7:
+upgraded to @product-full@ 7:
 
     <div class="columns-1-2-1" id="main-content" role="main">
             <div class="portlet-layout row">
@@ -137,14 +137,14 @@ upgraded to @product@ 7:
             </div>
     </div>
 
-Your layout template is ready to use in @product@ 7!
+Your layout template is ready to use in @product-full@ 7!
 
 **Related Topics**
 
-[Planning a Plugin Upgrade to @product@ 7](/develop/tutorials/-/knowledge_base/7-0/migrating-existing-code-to-liferay-7)
+[Planning a Plugin Upgrade to @product-full@ 7](/develop/tutorials/-/knowledge_base/7-0/migrating-existing-code-to-liferay-7)
 
-[Benefits of @product@ 7 for Liferay 6 Developers](/develop/tutorials/-/knowledge_base/7-0/benefits-of-liferay-7-for-liferay-6-developers)
+[Benefits of @product-full@ 7 for Liferay 6 Developers](/develop/tutorials/-/knowledge_base/7-0/benefits-of-liferay-7-for-liferay-6-developers)
 
 <!-- Uncomment this link when the referenced tutorial is published. Jim
-[Adapting to @product@ 7's API with the Code Upgrade Tool](/develop/tutorials/-/knowledge_base/7-0/adapting-to-liferay-7s-api-with-the-code-upgrade-tool)
+[Adapting to @product-full@ 7's API with the Code Upgrade Tool](/develop/tutorials/-/knowledge_base/7-0/adapting-to-liferay-7s-api-with-the-code-upgrade-tool)
 -->

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/08-optimizing-existing-plugins-for-liferay-7/00-modularizing-an-existing-portlet-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/08-optimizing-existing-plugins-for-liferay-7/00-modularizing-an-existing-portlet-intro.markdown
@@ -250,7 +250,7 @@ learn how to create these modules next.
 ## Converting Your Application's Service Builder API and Implementation [](id=converting-your-applications-service-builder-api-and-implementation)
 
 In this section, you'll learn about converting a Liferay 6 Service Builder
-application to a @product@ 7 style application. In the previous section, you
+application to a @product-full@ 7 style application. In the previous section, you
 learned how to generate your implementation and API modules. If you haven't yet
 run the `servicebuilder` blade command outlined in step 2 of the previous
 section, run it now. The API module holds your application's Service Builder
@@ -353,7 +353,7 @@ dependencies to these:
     }
 
 Excellent! You've successfully generated your application's services using
-Service Builder. They now reside in modules, and can be deployed to @product@ 7.0.
+Service Builder. They now reside in modules, and can be deployed to @product-full@ 7.0.
 If you'd like to learn more information about creating implementation and API
 modules from scratch, visit the
 [Creating an Implementation Module](/develop/tutorials/-/knowledge_base/7-0/creating-liferay-components#creating-an-implementation-module)
@@ -365,7 +365,7 @@ respectively.
 
 ## Building Your Module JARs for Deployment [](id=building-your-module-jars-for-deployment)
 
-Now it's time to build your modules and deploy them to your @product@ 7.0
+Now it's time to build your modules and deploy them to your @product-full@ 7.0
 instance. To build your project, run `gradle build` from your project's root
 directory.
 
@@ -417,7 +417,7 @@ shell as shown below.
 ![Figure 1: Once you've connected to your Liferay instance in your Gogo shell prompt, run *lb* to list your new converted modules.](../../../images/deploy-converted-modules.png)
 
 This tutorial explained how to convert your traditional application into the modular
-format of a @product@ 7 style applicaton. You first created a web client
+format of a @product-full@ 7 style applicaton. You first created a web client
 (`*-web`) module that holds your application's portlet classes and UI. Then you
 learned how to create a service implementation module and a service API module.
 Your learned how to run Service Builder to generate code for your application's

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/08-optimizing-existing-plugins-for-liferay-7/12-migrating-a-theme-from-the-plugins-sdk-to-the-themes-generator.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/08-optimizing-existing-plugins-for-liferay-7/12-migrating-a-theme-from-the-plugins-sdk-to-the-themes-generator.markdown
@@ -1,6 +1,6 @@
 # Migrating a Theme from the Plugins SDK to the Themes Generator [](id=migrating-a-6-2-theme-to-liferay-7)
 
-After you've upgraded your existing theme to @product@ 7, the Themes Generator
+After you've upgraded your existing theme to @product-full@ 7, the Themes Generator
 offers enhanced development features and tools for optimizing your theme and
 streamlining theme management. To introduce one of its most powerful features,
 we'll pose some questions. 
@@ -25,7 +25,7 @@ project. The Themes Generator is a Node.js-based tool that gives you access to
 an array of  [theme Gulp tasks](/develop/reference/-/knowledge_base/7-0/theme-gulp-tasks),
 that facilitate developing and managing themes. 
 
-The *upgrade* Gulp task upgrades Liferay 6 themes to @product@ 7. For details,
+The *upgrade* Gulp task upgrades Liferay 6 themes to @product-full@ 7. For details,
 refer to the [Upgrading Themes](/develop/tutorials/-/knowledge_base/7-0/themelets/upgrading-themes)
 tutorial. 
 

--- a/release-site.properties
+++ b/release-site.properties
@@ -7,7 +7,7 @@
     product.enterprise=dxp
     product.name=Liferay Portal
     product.name.enterprise=Liferay DXP
-	product.name.enterprise.full=Liferay DXP Digital Enterprise
+    product.name.enterprise.full=Liferay DXP Digital Enterprise
     product.token=product
-	product.token.full=product-full
+    product.token.full=product-full
     product.version=7.0

--- a/release-site.properties
+++ b/release-site.properties
@@ -7,5 +7,7 @@
     product.enterprise=dxp
     product.name=Liferay Portal
     product.name.enterprise=Liferay DXP
+	product.name.enterprise.full=Liferay DXP Digital Enterprise
     product.token=product
+	product.token.full=product-full
     product.version=7.0


### PR DESCRIPTION
Hey Rich,

I've noticed a lot of noise on Jira revolving around the product name we use. I've seen comments mentioning that *Liferay DXP* shouldn't be used with a version number, and should be replaced with *Liferay DXP Digital Enterprise*.

This is an easy fix with our token generator. I've created a new token named `@product-full@`, which will generate **Liferay DXP Digital Enterprise** for DXP articles and **Liferay Portal** for CE articles. We can use this new token when specifying the version of Liferay.

I've added this token throughout the *From Liferay 6 to 7* articles.

Let me know what you think.