### PR TITLE
Dist number headers

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -281,7 +281,7 @@
 		<concat destfile="${metadata.file}">base.source.url=https://github.com/${repo.owner}/${repo.name}/blob/${repo.branch}/${purpose.dir}/${base.filepath}</concat>
 	</target>
 
-	<target name="dist-ce" depends="dist-ce-temp, prepare-dist" description="Zips up the folder's CE articles and images for importing.">
+	<target name="dist-ce" depends="dist-ce-temp, prepare-dist, number-headers" description="Zips up the folder's CE articles and images for importing.">
 		<zip destfile="${dist.dir}/${product.abbrev}-${product.community}-${product.version}-${purpose.dir}-${doc.dir}.zip">
 			<fileset dir="${temp.dir}" includes="articles/" />
 			<fileset dir="${temp.dir}" includes="images/" />
@@ -315,7 +315,7 @@
 	
 	</target>
 
-	<target name="dist-dxp" depends="dist-dxp-temp, prepare-dist" description="Zips up the folder's CE and DXP articles and images for importing.">
+	<target name="dist-dxp" depends="dist-dxp-temp, prepare-dist, number-headers-dxp" description="Zips up the folder's CE and DXP articles and images for importing.">
 		<zip destfile="${dist.dir}/${product.abbrev}-${product.enterprise}-${product.version}-${purpose.dir}-${doc.dir}.zip">
 			<fileset dir="${temp.dir}" includes="articles/" />
 			<fileset dir="${temp.dir}" includes="images/" />

--- a/develop/tutorials/articles/100-tooling/03-blade-cli/02-creating-a-liferay-workspace-with-blade-cli.markdown
+++ b/develop/tutorials/articles/100-tooling/03-blade-cli/02-creating-a-liferay-workspace-with-blade-cli.markdown
@@ -52,7 +52,7 @@ As discussed in the
 [Liferay Workspace](/develop/tutorials/-/knowledge_base/7-0/liferay-workspace)
 tutorial, Liferay Workspaces can generate and hold a Liferay Server. This lets you
 build/test your plugins against a running Liferay instance. Once you've properly
-generataed and installed a Liferay server in your workspace, you can begin using
+generated and installed a Liferay server in your workspace, you can begin using
 it with the Blade CLI. To start your Liferay instance, run
 
     blade server start -b


### PR DESCRIPTION
Hey Rich;

This change forces the `dist` targets to generate header IDs for our trackable Markdown files.

I just wanted to be clear, there has never been a time when articles with no header IDs were deployed to LDN/Customer Portal. The `dist` targets always ran the `number-headers` task on the articles, it was just done in a temporary folder where the CE and DXP articles were combined. Since the task was executed outside our *liferay-docs* repo, the changes were never reflected in our trackable files.

With that said, the extra precaution of making sure the header IDs are permanently set is probably good.

Thanks!