### PR TITLE
LRDOCS-3121 New tokens for Reference Doc URLs

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -302,6 +302,8 @@
 			<filterchain>
 				<filterreader classname="org.apache.tools.ant.filters.ReplaceTokens">
 					<param type="token" name="${product.token}" value="${product.name}"/>
+					<param type="token" name="${product.token.app.reference}" value="${product.app.reference}"/>
+					<param type="token" name="${product.token.platform.reference}" value="${product.platform.reference}"/>
 					<param type="token" name="${product.token.version}" value="${product.name.version}"/>
 				</filterreader>
 			</filterchain>
@@ -337,6 +339,8 @@
 			<filterchain>
 				<filterreader classname="org.apache.tools.ant.filters.ReplaceTokens">
 					<param type="token" name="${product.token}" value="${product.name.enterprise}"/>
+					<param type="token" name="${product.token.app.reference}" value="${product.app.enterprise.reference}"/>
+					<param type="token" name="${product.token.platform.reference}" value="${product.platform.enterprise.reference}"/>
 					<param type="token" name="${product.token.version}" value="${product.name.enterprise.version}"/>
 				</filterreader>
 			</filterchain>

--- a/release-site.properties
+++ b/release-site.properties
@@ -14,7 +14,7 @@
     product.platform.enterprise.reference=https://docs.liferay.com/dxp/digital-enterprise
     product.platform.reference=https://docs.liferay.com/ce/portal
     product.token=product
-    product.token.app.reference=app-reference
-    product.token.platform.reference=platform-reference
+    product.token.app.reference=app-ref
+    product.token.platform.reference=platform-ref
     product.token.version=product-ver
     product.version=7.0

--- a/release-site.properties
+++ b/release-site.properties
@@ -3,12 +3,18 @@
 ##
 
     product.abbrev=lp
+    product.app.enterprise.reference=https://docs.liferay.com/dxp/apps
+    product.app.reference=https://docs.liferay.com/ce/apps
     product.community=ce
     product.enterprise=dxp
     product.name=Liferay Portal
     product.name.enterprise=Liferay DXP
     product.name.enterprise.version=Liferay Digital Enterprise 7.0
     product.name.version=Liferay Portal CE 7.0
+    product.platform.enterprise.reference=https://docs.liferay.com/dxp/digital-enterprise
+    product.platform.reference=https://docs.liferay.com/ce/portal
     product.token=product
+    product.token.app.reference=app-reference
+    product.token.platform.reference=platform-reference
     product.token.version=product-ver
     product.version=7.0


### PR DESCRIPTION
/cc @jhinkey 

https://issues.liferay.com/browse/LRDOCS-3121 

This is in preparation for the new [docs.liferay.com](https://docs.liferay.com) URLs for app and platform Javadoc.

The tokens are more thoroughly explained in the ticket, but here's a summary:

**CE**
`@app-ref@` = https://docs.liferay.com/ce/apps
`@platform-ref@`= https://docs.liferay.com/ce/portal

**DXP**
`@app-ref@` = https://docs.liferay.com/dxp/apps
`@platform-ref@`= https://docs.liferay.com/dxp/digital-enterprise