### PR TITLE
LRDOCS-3137 Update Tooling Guidelines for liferay-docs

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -166,11 +166,11 @@
         </copy>
 	</target>
 
-	<target name="check" depends="check-images-site, check-intros, number-headers, number-images-site, check-headers" description="Checks for necessary requirements before CE distribution.">
+	<target name="check" depends="check-images, check-intros, number-headers, number-images, check-headers" description="Checks for necessary requirements before CE distribution.">
 
 	</target>
 
-	<target name="check-dxp" depends="check-images-site-dxp, check-intros-dxp, number-headers-dxp, number-images-site-dxp, check-headers-dxp" description="Checks for necessary requirements before DXP distribution.">
+	<target name="check-dxp" depends="check-images-dxp, check-intros-dxp, number-headers-dxp, number-images-dxp, check-headers-dxp" description="Checks for necessary requirements before DXP distribution.">
 
 	</target>
 
@@ -184,17 +184,17 @@
 		</checkarticleimgssite>
 	</target>
 
-	<target name="check-images-site" description="Verifies all images referenced in a project's Markdown articles found in ${doc.dir}/articles.">
+	<target name="check-images" description="Verifies all images referenced in a project's Markdown articles found in ${doc.dir}/articles.">
 		<checkimgssite docdir="${doc.dir}" producttype="ce">
 		</checkimgssite>
 	</target>
 
-	<target name="check-images-site-dist" description="Verifies all images referenced in a project's Markdown articles.">
+	<target name="check-images-dist" description="Verifies all images referenced in a project's Markdown articles.">
 		<checkimgssite docdir="${doc.dir}/${temp.dir}" producttype="dist">
 		</checkimgssite>
 	</target>
 
-	<target name="check-images-site-dxp" description="Verifies all images referenced in a project's Markdown articles found in ${doc.dir}/articles.">
+	<target name="check-images-dxp" description="Verifies all images referenced in a project's Markdown articles found in ${doc.dir}/articles.">
 		<checkimgssite docdir="${doc.dir}" producttype="dxp">
 		</checkimgssite>
 	</target>
@@ -416,17 +416,17 @@
 		</java>
 	</target>
 
-	<target name="number-images-site" description="numbers the images in a markdown chapter file">
+	<target name="number-images" description="numbers the images in a markdown chapter file">
 		<numberimgssite docdir="${doc.dir}" producttype="ce">
 		</numberimgssite>
 	</target>
 
-	<target name="number-images-site-dist" description="Numbers the images of Markdown articles found in ${doc.dir}/articles and ${doc.dir}/articles-dxp.">
+	<target name="number-images-dist" description="Numbers the images of Markdown articles found in ${doc.dir}/articles and ${doc.dir}/articles-dxp.">
 		<numberimgssite docdir="${doc.dir}/${temp.dir}" producttype="dist">
 		</numberimgssite>
 	</target>
 
-	<target name="number-images-site-dxp" description="Numbers the images of Markdown articles found in ${doc.dir}/articles and ${doc.dir}/articles-dxp.">
+	<target name="number-images-dxp" description="Numbers the images of Markdown articles found in ${doc.dir}/articles and ${doc.dir}/articles-dxp.">
 		<numberimgssite docdir="${doc.dir}" producttype="dxp">
 		</numberimgssite>
 	</target>
@@ -449,7 +449,7 @@
 		</copy>
 	</target>
 
-	<target name="prepare-dist" depends="check-images-site-dist, check-intros-dist, clean-dist, number-headers-dist, number-images-site-dist, check-headers-dist, create-metadata-file" description="Prepares the document for distribution.">
+	<target name="prepare-dist" depends="check-images-dist, check-intros-dist, clean-dist, number-headers-dist, number-images-dist, check-headers-dist, create-metadata-file" description="Prepares the document for distribution.">
 		<echo message="... creating ${dist.dir} directory"/>
 		<mkdir dir="${dist.dir}"/>
 	</target>

--- a/guidelines/liferay-documentation-tools.markdown
+++ b/guidelines/liferay-documentation-tools.markdown
@@ -29,8 +29,8 @@ our documentation for the web, for ebooks, and for print.
 ## Markdown Environment
 
 For liferay.com, we use Pegdown with our own, customized parser, which is
-included in this project. You can use this with our `convert.sh` script in the
-`bin` folder to preview your articles. 
+included in this project. You can use this with our `convert.[sh|bat]` script in
+the `bin` folder to preview your articles. 
 
 ### Editing Markdown Files
 
@@ -52,13 +52,11 @@ install. The Markdown plugin is available in jEdit's plugin manager, and the
 mode file can be downloaded from
 [https://github.com/peterlynch/jEdit-modes|Github](https://github.com/peterlynch/jEdit-modes) or [http://hasseg.org/blog/post/302/markdown-and-pod-syntax-highlighting-modes-for-jedit](http://hasseg.org/blog/post/302/markdown-and-pod-syntax-highlighting-modes-for-jedit).  
 
-
 To install the mode file, copy it into your `.jedit/modes` folder, and edit the
 `catalog` file which is in the same folder. Add this line to the file, between
 the <MODES> tags: 
 
-	<MODE NAME="markdown" FILE="markdown.xml" FILE_NAME_GLOB="*.{markdown,md}" />
-
+    <MODE NAME="markdown" FILE="markdown.xml" FILE_NAME_GLOB="*.{markdown,md}" />
 
 Save the file and restart jEdit. While editing, you now have syntax highlighting
 and can preview Markdown files in HTML using the plugin.
@@ -75,26 +73,24 @@ Now you've got a great environment for editing Markdown files.
 ## Markdown Image Numbers Tool 
 
 We have a tool that you can call with Ant that numbers the images in a Markdown
-chapter file. While you're writing or editing a Markdown chapter file, you can
-just number all the images in that chapter with a lowercase x. For example, if
-you were editing chapter 2 of Using Liferay Portal, your image tags could take
-the following form:
+chapter file. While you're writing or editing a Markdown file, you can
+just number all the images in that chapter with a lowercase x. For example, your
+image tags could take the following form:
 
-	![Figure 2.x: <image-description>](../../images/<image-name>)
+    ![Figure x: <image-description>](../../images/<image-name>)
 
-When you are finished working on a chapter file, you can call the
-`number-images` Ant task from the directory of the document you are working on
-and supply the chapter as an argument:
+When you are finished working on a file, you can call the `number-images` Ant
+task from the parent directory (e.g., `/develop/tutorials`) of the document you
+are working on:
 
-	ant number-images -Dchapter=<chapter-name>
+    ant number-images
 
-For example, to number the images of chapter 2 of Using Liferay Portal, you
-would use the following command from liferay-docs/userGuide:
+If you're working in a DXP article located in `/articles-dxp`, run the
+corresponding DXP Ant task:
 
-	ant number-images -Dchapter=02-liferay-marketplace
+    ant number-images-dxp
 
-Our numbering tool will also renumber the images of incorrectly numbered
-chapters.
+The DXP task numbers images for articles in `/articles` and `/articles-dxp`.
 
 ## Assigning Header IDs 
 
@@ -103,41 +99,32 @@ unique URL. These IDs not only prevent documents from using the same URLs but
 they also help to preserve web content URLs despite changes to header text in
 revisions of the document.
 
-1.  Edit your document's `liferay-docs/<document>/doc.properties` to specify the
-    product abbreviation, product version, and an abbreviation for your
-    document. These property values help namespace the header IDs.
+Once you've finished creating headers for your article, number your headers
+using the Ant task:
 
-    Example - `devGuide/doc.properties`: 
+    ant number-headers
 
+If you're working in a DXP article located in `/articles-dxp`, run the
+corresponding DXP Ant task:
 
-        product.abbrev=lp
-        product.name=Liferay Portal
-        product.version=6.2
-        doc.name=Dev Guide
-
-2.  Number the section headers of your document.
-
-        ant number-headers
+    ant number-headers-dxp
 
 It will fail if header IDs conflict.
 
 Example - Output from header ID conflict
 
+    number-headers:
+        [java] Numbering headers for files in ../tutorials/articles ...
+        [java] Dup id:liferay-ide file:..\tutorials\articles\100-tooling\02-liferay-ide\01-installing-liferay-ide.markdown line:1 (already used by file:..\tutorials\articles\100-tooling\02-liferay-ide\00-liferay-ide-intro.markdown)
+        [java] Exception in thread "main" java.lang.Exception: FAILURE - Duplicate header IDs exist
+        [java]     at com.liferay.documentation.util.NumberHeadersSiteMain.main(Unknown Source)
 
-	...  number-headers:
-	[numberheaders] Numbering headers for files in ..\devGuide\en\chapters ...
-	[numberheaders] Dup id:summary-liferay-portal-6-2-dev-guide-06-en file:06-hooks.markdown line:305 (already used by file:06-hooks.markdown)
-	...
+    BUILD FAILED
 
 To resolve a conflict, you *must* be sure to preserve the header ID that existed
 first, if that header is a part of the *live* version of the document on
-Liferay.com. Then, remove the newer header ID from the other header and run ...
-
-
-	ant number-headers
-
-
-... again to produce a new unique ID for that header.
+dev.liferay.com. Then, remove the newer header ID from the other header and run
+the Ant task again to produce a new unique ID for that header.
 
 ## Markdown Tips
 
@@ -154,15 +141,17 @@ below.
 
 ### Figures 
 
-Previously, Open/LibreOffice added the words: *Illustration #* to captions when
-they were entered. This was nice, but is unfortunately something we'll need to
-abandon. To do figures, you should do it this way: 
+To do figures, you should do it this way: 
 
+    ![Figure 1: Logging into Liferay Portal is easy.](../../images/logging-into-liferay-portal.png)
 
-	![Figure 1.1: Logging into Liferay Portal](../../images/01-logging-into-liferay-portal.png)
+If you're working in a DXP Markdown article, your image should be saved in the
+`/images-dxp` folder and the figure path should reflect that folder:
 
-This causes Pandoc to create the following, easily styled markup: 
+    ![Figure 1: This diagram breaks down the evaluation process for the weather rule.](../../images-dxp/weather-rule-diagram.png)
 
+Using this syntax for figure images causes Pandoc to create the following,
+easily styled markup:
 
 	<div class="figure">
 	<img src="../../images/01-logging-into-liferay-portal.png" alt="Figure 1.1: Logging into Liferay Portal" />
@@ -174,19 +163,19 @@ We've duplicated this behavior in the Pegdown parser that we've implemented.
 ### Inline Images / Icon Images
 
 An icon's image helps the reader identify the icon in the UI. To use an existing
-icon snapshot, check a document's `images/` folder for files ending in *-icon.png*.
-Follow these steps
-to include an icon image inline in your article's Markdown text:
+icon snapshot, check a document's `images/` folder for files ending in
+*-icon.png*. Follow these steps to include an icon image inline in your
+article's Markdown text:
 
-1. Take a snapshot of the icon, if one doesn't already exist in the document's
-`images/` folder. Please save the snapshot to the `images/` folder and end its name with
-`-icon.png`. 
-2. Crop the image to remove unrelated content from around the icon.
-3. Resize the image's height to no greater than 20 pixels. **Important:** Make sure to keep the
-aspect ratio. 
+1.  Take a snapshot of the icon, if one doesn't already exist in the document's
+    `images/` folder. Please save the snapshot to the `images/` folder and end
+    its name with `-icon.png`.
+2.  Crop the image to remove unrelated content from around the icon.
+3.  Resize the image's height to no greater than 20 pixels. **Important:** Make
+    sure to keep the aspect ratio. 
 4. In the Markdown text, include the icon image in parentheses.
 
-Inline icon image example Markdown:
+Inline icon image example in Markdown:
 
     Click the *Add Blog Entry* icon (![Add Blog Entry](../../images/add-icon.png))
     to bring up the blog entry editor.
@@ -207,10 +196,10 @@ We can do the same in Markdown using the HTML code for this character, which is
 
 ### Tables
 
-Because Pegdown does not support the [Pandoc extension table
-syntax](http://johnmacfarlane.net/pandoc/README.html#tables), we use a table
-syntax similar to
-[MultiMarkdown](http://fletcher.github.com/peg-multimarkdown/mmd-manual.pdf),
+Because Pegdown does not support the
+[Pandoc extension table syntax](http://johnmacfarlane.net/pandoc/README.html#tables),
+we use a table syntax similar to
+[MultiMarkdown](http://fletcher.github.com/peg-multimarkdown/mmd-manual.pdf)
 that supports the following features:
 
 * Cell content alignment (left, right, or center)
@@ -270,14 +259,14 @@ Table Options
 
 ---
 
- ![important](./images/tip.png) **Important:** - Pandoc does not 
-support MultiMarkdown table syntax. If you use Pandoc to build a document for
-test purposes, you'll notice that the table does not get converted as you would
-expect. If you are using Pandoc to convert a document for a final product
-(e.g. ePub), you'll need to temporarily change the table syntax to follow the
-Pandoc extension.
+![important](./images/tip.png) **Important:** - Pandoc does not support
+MultiMarkdown table syntax. If you use Pandoc to build a document for test
+purposes, you'll notice that the table does not get converted as you would
+expect. If you are using Pandoc to convert a document for a final product (e.g.
+ePub), you'll need to temporarily change the table syntax to follow the Pandoc
+extension.
 
- ![The example table converted using Pandoc](images/mmdTablePandocHTML.png)
+![The example table converted using Pandoc](images/mmdTablePandocHTML.png)
 
 ---
 
@@ -446,7 +435,7 @@ formats using Pandoc. The Liferay Docs README describes the repository contents,
 directory structure, and conversion process. We concatenate the individual
 chapter files of a document and insert a markdown title block which pandoc
 parses as bibliographic information. See
-[http://johnmacfarlane.net/pandoc/README.html|http://johnmacfarlane.net/pandoc/README.html](http://johnmacfarlane.net/pandoc/README.html|http://johnmacfarlane.net/pandoc/README.html)
+[http://johnmacfarlane.net/pandoc/README.html](http://johnmacfarlane.net/pandoc/README.html)
 for details. The default title block in build.properties is empty:
 
 	%
@@ -480,12 +469,12 @@ documentation on Liferay.com. Previously, the URLs for our web content were
 determined by the heading text of our documents (e.g. the text from "#
 Introduction to Liferay Portal" markdown was used to generate the URL final
 string in the web content's URL
-[http://www.liferay.com/documentation/liferay-portal/6.1/user-guide/-/ai/introduction-to-liferay](http://www.liferay.com/documentation/liferay-portal/6.1/user-guide/-/ai/introduction-to-liferay).
+[http://www.liferay.com/documentation/liferay-portal/6.1/user-guide/-/ai/introduction-to-liferay](http://www.liferay.com/documentation/liferay-portal/6.1/user-guide/-/ai/introduction-to-liferay)).
 If the titles of the web content were changed, either by re-import of the
 markdown or manual edits via the GUI, the URLs changed too--breaking any links
 to the web content.
 
-In response to this issue, Liferay portal and the AssetImporter have been
+In response to this issue, Liferay Portal and the AssetImporter have been
 improved so that web content can be referenced by static IDs. Regardless of
 whether the titles of a web content change, its ID remains the same, preserving
 the URL of that web content.
@@ -499,38 +488,22 @@ Example 1 - ID to an existing web content:
 
 Example 2 - ID for a new section header:
 
-    ### Using the Dockbar [](id=lp-6-1-ugen01-using-the-dockbar-0)
+    ## Adding and Updating Assets [](id=adding-and-updating-assets)
 
 Each header, regardless of level, is to have a corresponding ID. This gives us
 the flexibility to create web content for even the lowliest of subsections if we
 so choose. But no need to worry, those IDs get stripped out of the web content
 on import to Liferay.com.
 
-
-The naming convention for new headers is as follows:
-
-*product.abbrev-product.version-(doc.abbrev)(lang)(chapterNum)-(headerText)-increment*
-
-
-Example, `id=lp-6-1-ugen01-using-the-dockbar-0` can be broken down into:
-
-* **product.abbrev:** lp	(for Liferay Portal)
-* **product.version:** 6-1	(for version 6.1)
-* **doc.abbrev:** ug	(for User Guide)
-* **lang:** en	(for English)
-* **chapterNum:** 01	(derived from the file's prefix - e.g.,
-  `01-introduction-to-liferay-ui.markdown`)
-* **headerText:** using-the-dockbar	(derived from "### Using the Dockbar")
-* **increment:** 0	(indicating this is the first such header having the
-  attributes mentioned above. This increment becomes necessary to distinguish
-between web content with header text, like "Summary", found within the same
-chapter.)
+The naming convention for new headers very closely follows the existing header
+title. Uppercase letters are converted to lowercase and spaces are converted to
+dashes.
 
 ### How should I specify an ID for a new header? 
 
-Execute ant target `number-headers` from your document directory. Note, unless
-you specify otherwise, your default language (e.g., `en`) is used in the
-document ID.
+Execute ant target `number-headers` or `number-headers-dxp` from your document
+directory (e.g., `/develop/tutorials`). You can also run `ant check` or `ant
+check-dxp` to generate header IDs and to various other checks and tasks.
 
 ### What should I do with the ID for an existing header I've modified? 
 
@@ -540,9 +513,9 @@ document.
 
 ### If I re-order sections or chapters, what do I do with their header IDs? 
 
-**IMPORTANT:** Do not change the ID of an existing header.
-You can however, move the header (along with its ID) around within a chapter
-document or into a different chapter document.
+**IMPORTANT:** Do not change the ID of an existing header. You can however, move
+the header (along with its ID) around within an article or into a different
+article.
 
 ### If I want to update existing web content and find that its source is missing header IDs, what do I do? 
 
@@ -561,29 +534,19 @@ between headers. It will fail if any issues are encountered.
 
 Example - Header ID conflict output
 
-	...
 	number-headers:
-	[numberheaders] Numbering headers for files in ..\devGuide\en\chapters ...
-	[numberheaders] Dup id:lp-6-1-dgen10-summary-0 file:11-marketplace.markdown line:305 (already used by file:10-plugin-security.markdown)
-	...
+        [java] Numbering headers for files in ../tutorials/articles ...
+        [java] Dup id:liferay-ide file:..\tutorials\articles\100-tooling\02-liferay-ide\01-installing-liferay-ide.markdown line:1 (already used by file:..\tutorials\articles\100-tooling\02-liferay-ide\00-liferay-ide-intro.markdown)
+        [java] Exception in thread "main" java.lang.Exception: FAILURE - Duplicate header IDs exist
+        [java]     at com.liferay.documentation.util.NumberHeadersSiteMain.main(Unknown Source)
+
+    BUILD FAILED
 
 To resolve the above conflict, the author *must* be sure to preserve the header
 ID that existed first, if that header is a part of the *live* version of the
 document on Liferay.com. Then, the author should remove the newer header ID from
 the other header and run `ant number-headers` to produce a new unique ID for
 that header.
-
-**Important**, each document directory (e.g., `liferay-docs/userGuide/`) has a
-file `doc.properties` that specifies the product abbreviation, product version,
-and documentation abbreviation to assure that IDs are name-spaced properly.
-
-
-Example - devGuide/doc.properties:
-
-
-    product.abbrev=lp
-    product.version=6.1
-    doc.abbrev=dg
 
 ### Will the header IDs show in the web content? 
 
@@ -593,7 +556,7 @@ used in your markdown source.
 ### Are there safe-guards to prevent upload of documents that have missing or conflicting IDs? 
 
 Yes, the dependency targets (e.g. `number-headers`) executed by our distribution
-targets, `dist` and `dist-win`, fail and report errors if the documents are
+targets, `dist-ce` and `dist-dxp`, fail and report errors if the documents are
 missing IDs or have conflicting IDs.
 
 ## Contact Information 

--- a/guidelines/liferay-documentation-tools.markdown
+++ b/guidelines/liferay-documentation-tools.markdown
@@ -1,7 +1,7 @@
 # Liferay Documentation Tools
 
 Liferay's documentation is currently implemented in Markdown. We chose Markdown
-for several reasons: 
+for several reasons:
 
 1. It's readable. Even if you don't know Markdown, you can read it without
    having to filter out the syntax.  
@@ -9,42 +9,42 @@ for several reasons:
 2. It gets out of a writer's way. You don't have to worry about mousing to
    various icons to change text into a heading or create bulleted lists. Just
    start typing. The syntax is so intuitive, you probably have used it all your
-   life anyway. 
+   life anyway.
 
 3. It's easily convertable to other formats. Using Markdown lets us publish to
-   the web, mobile, and print from the same source files. 
+   the web, mobile, and print from the same source files.
 
 4. It's great for collaborating. Using Github, we can easily see what various
    people have contributed, through the same diffs we'd use in programming. We
    can merge those changes pretty easily, too, because the format is simple enough
    that the changes in the diffs happen to be the actual changes made to the text,
-   rather than a bunch of formatting tags. 
+   rather than a bunch of formatting tags.
 
 In summary, Markdown is, by definition, a text based format that's designed to
 be as readable as possible. It lets you write in a very natural format which can
 then be converted to other formats for publication. We have switched to using
 Markdown for the Liferay 6.1 documentation. It's allowing us to single-source
-our documentation for the web, for ebooks, and for print. 
+our documentation for the web, for ebooks, and for print.
 
 ## Markdown Environment
 
 For liferay.com, we use Pegdown with our own, customized parser, which is
 included in this project. You can use this with our `convert.[sh|bat]` script in
-the `bin` folder to preview your articles. 
+the `bin` folder to preview your articles.
 
 ### Editing Markdown Files
 
 Most programmers have a close relationship with their text editor of choice.
 This is not an attempt to break that relationship in any way: Markdown is plain
 text, and you should use whatever tool makes you most effective. One of the
-reasons we chose it is to allow writers to use whatever tools they want. 
+reasons we chose it is to allow writers to use whatever tools they want.
 
 For those who are looking for some guidance on a good tool to use, you can use
 jEdit. It's a great cross-platform text editor which is highly extensible.
 Though it's written in Java, it can be configured to start in the background
 when your machine starts, which makes it pop up as fast as any native editor.
 This makes it ideal regardless of which platform (Linux, Windows, or Mac) you
-use. 
+use.
 
 For Markdown, jEdit has a Markdown plugin that can render a Markdown document
 into HTML, and there's also a syntax highlighting mode file that you can
@@ -54,7 +54,7 @@ mode file can be downloaded from
 
 To install the mode file, copy it into your `.jedit/modes` folder, and edit the
 `catalog` file which is in the same folder. Add this line to the file, between
-the <MODES> tags: 
+the <MODES> tags:
 
     <MODE NAME="markdown" FILE="markdown.xml" FILE_NAME_GLOB="*.{markdown,md}" />
 
@@ -66,9 +66,9 @@ you'll also need to set the width to be narrower than the 120 character default
 provided by the Markdown mode file. To do this, go to *Utilities* -> *Global
 Options* -> *Editing*. Under *Change Settings for Mode*, select *Markdown*, and
 then change the *Wrap Margin* to 80. Of course, make sure also that *Word Wrap*
-is set to *Soft*. 
+is set to *Soft*.
 
-Now you've got a great environment for editing Markdown files. 
+Now you've got a great environment for editing Markdown files.
 
 ## Ant Target Quick Reference
 
@@ -121,7 +121,7 @@ documenting. -Cody -->
 
 - `dist-ce`: Packages all necessary CE resources into a ZIP file deployable to
   LDN.
-  
+
 - `dist-dxp`: Packages all necessary DXP resources into a ZIP file deployable to
   Liferay's Customer Portal.
 
@@ -132,12 +132,37 @@ documenting. -Cody -->
   information.
 
 - `number-images`: Numbers all Markdown articles' images in the folder. Image
-  numbers (e.g., *![Figure x:*) are replaced with the correct image numbering if
+  numbers (e.g., *![Figure x:* ) are replaced with the correct image numbering if
   they are incorrect. See the
   [Markdown Image Numbers Tool](#markdown-image-numbers-tool) section for more
   information.
 
-## Markdown Image Numbers Tool 
+## Tokens
+
+Our documentation is deployed to two separate sites to display CE and DXP
+documentation. Instead of having a completely separate folder structure for both
+docs, we have all articles that are targeted for both CE and DXP residing in the
+`/articles` folder and DXP-only documentation residing in the `/articles-dxp`
+folder. Because so many single articles are deployed to two separate sites,
+we've created tokens that use one type of string when publishing to one site and
+another different string for the second site. The available tokens are listed
+below:
+
+**CE Docs**
+
+- `@product` = Liferay Portal
+- `@product-ver` = Liferay Portal CE 7.0
+- `@app-ref@` = https://docs.liferay.com/ce/apps
+- `@platform-ref@` = https://docs.liferay.com/ce/portal
+
+**DXP Docs**
+
+- `@product` = Liferay DXP
+- `@product-ver` = Liferay Digital Enterprise 7.0
+- `@app-ref@` = https://docs.liferay.com/dxp/apps
+- `@platform-ref@` = https://docs.liferay.com/dxp/digital-enterprise
+
+## Markdown Image Numbers Tool
 
 We have a tool that you can call with Ant that numbers the images in a Markdown
 chapter file. While you're writing or editing a Markdown file, you can
@@ -159,7 +184,7 @@ corresponding DXP Ant task:
 
 The DXP task numbers images for articles in `/articles` and `/articles-dxp`.
 
-## Assigning Header IDs 
+## Assigning Header IDs
 
 Header IDs help to assure that each uploaded document's web contents have a
 unique URL. These IDs not only prevent documents from using the same URLs but
@@ -196,7 +221,7 @@ the Ant task again to produce a new unique ID for that header.
 ## Markdown Tips
 
 Below are some tips for some constructs that are unique to Liferay
-documentation. 
+documentation.
 
 ### Spaces vs. Tabs
 
@@ -204,11 +229,11 @@ Our standard is the opposite of Liferay's code: we use spaces instead of tabs.
 Why? Because lists and code blocks in Markdown are much easier to control using
 spaces instead of tabs. Please see the documentation for Markdown for further
 information on this, or we provide a good example of it when we talk about lists
-below. 
+below.
 
-### Figures 
+### Figures
 
-To do figures, you should do it this way: 
+To do figures, you should do it this way:
 
     ![Figure 1: Logging into Liferay Portal is easy.](../../images/logging-into-liferay-portal.png)
 
@@ -224,8 +249,8 @@ easily styled markup:
 	<img src="../../images/01-logging-into-liferay-portal.png" alt="Figure 1.1: Logging into Liferay Portal" />
 	<p class="caption">Figure 1.1: Logging into Liferay Portal</p>
 	</div>
-	
-We've duplicated this behavior in the Pegdown parser that we've implemented. 
+
+We've duplicated this behavior in the Pegdown parser that we've implemented.
 
 ### Inline Images / Icon Images
 
@@ -239,7 +264,7 @@ article's Markdown text:
     its name with `-icon.png`.
 2.  Crop the image to remove unrelated content from around the icon.
 3.  Resize the image's height to no greater than 20 pixels. **Important:** Make
-    sure to keep the aspect ratio. 
+    sure to keep the aspect ratio.
 4. In the Markdown text, include the icon image in parentheses.
 
 Inline icon image example in Markdown:
@@ -251,11 +276,11 @@ Result shown in a Knowledge Base article:
 
 ![Inline icon image](images/render-icon-image-inline.png)
 
-### Right Arrows 
+### Right Arrows
 
 We are in the habit of using right arrows to denote a series of things a user
 can click on, such as Go To -> Control Panel -> Web Content. Open/LibreOffice
-would automatically replace the dash and greater-than sign with a right arrow. 
+would automatically replace the dash and greater-than sign with a right arrow.
 
 We can do the same in Markdown using the HTML code for this character, which is
 `&rarr;`. I created a SuperAbbrev in jEdit which transforms `rightarrow` into
@@ -347,11 +372,11 @@ want to draw special attention to it or if the text contains ancillary
 information that doesn't quite belong in the main text. For example, notes,
 tips, and warnings are often placed in sidebars. To create a sidebar, set off
 your sidebar text with a begin sidebar token (`+$$$`) and an end sidebar token
-(`$$$`), like so: 
+(`$$$`), like so:
 
     +$$$
 
-    Your sidebar text goes here. 
+    Your sidebar text goes here.
 
     $$$
 
@@ -402,7 +427,7 @@ is disrupted and the step that follows restarts at `1`.
         **Note:** A sidebar note. Text is placed in sidebars if it deserves
         special attention or if it contains ancillary information that doesn't
         quite belong in the main text. For example, notes, tips, and warnings
-        are often placed in sidebars. 
+        are often placed in sidebars.
 
         $$$
 
@@ -473,7 +498,7 @@ This paragraph is not indented 4 spaces from the step number.
 
 ![liferay-cube image](./images/liferay-cube.png)
 
-3. Third step. 
+3. Third step.
 
 +$$$
 **Note:** This sidebar note disrupts continuous numbering because it is not
@@ -493,9 +518,9 @@ Well, there you have it--the do's and don'ts of ordered lists.
 **Important:** Before you send a pull request, view your Markdown file converted
 to HTML, using your editor's Pegdown converter or by viewing your document
 blob on Github. That way you can be sure any ordered lists you have, preserve
-their consinutous numbering. 
+their consinutous numbering.
 
-### Markdown Metadata 
+### Markdown Metadata
 
 Our build process supports conversion from Markdown to html, odt, and epub
 formats using Pandoc. The Liferay Docs README describes the repository contents,
@@ -529,7 +554,7 @@ This FAQ is provided to help answer questions and provide information on how and
 why we use IDs for the headers in the Markdown files of our official product
 documentation.
 
-### What are the header IDs and why are they important? 
+### What are the header IDs and why are they important?
 
 Header IDs were created for the purpose of preserving the URLs of our official
 documentation on Liferay.com. Previously, the URLs for our web content were
@@ -566,25 +591,25 @@ The naming convention for new headers very closely follows the existing header
 title. Uppercase letters are converted to lowercase and spaces are converted to
 dashes.
 
-### How should I specify an ID for a new header? 
+### How should I specify an ID for a new header?
 
 Execute ant target `number-headers` or `number-headers-dxp` from your document
 directory (e.g., `/develop/tutorials`). You can also run `ant check` or `ant
 check-dxp` to generate header IDs and to various other checks and tasks.
 
-### What should I do with the ID for an existing header I've modified? 
+### What should I do with the ID for an existing header I've modified?
 
 **IMPORTANT:** Do not change the ID of an existing header.  If the header does
 not have an existing header, then run the `number-headers` target on the
 document.
 
-### If I re-order sections or chapters, what do I do with their header IDs? 
+### If I re-order sections or chapters, what do I do with their header IDs?
 
 **IMPORTANT:** Do not change the ID of an existing header. You can however, move
 the header (along with its ID) around within an article or into a different
 article.
 
-### If I want to update existing web content and find that its source is missing header IDs, what do I do? 
+### If I want to update existing web content and find that its source is missing header IDs, what do I do?
 
 First, inform the document owner (e.g. Rich for the User Guide and Jim for the
 Dev Guide).
@@ -594,7 +619,7 @@ header in the respective markdown source. After updating the IDs in the
 markdown, be sure to run ant target `number-headers` to detect any issues with
 the headers.
 
-### How can I be sure that my header IDs will not be in conflict with other header IDs (e.g., IDs in other documents)? 
+### How can I be sure that my header IDs will not be in conflict with other header IDs (e.g., IDs in other documents)?
 
 Ant target `number-headers` detects and reports any issues and/or conflicts
 between headers. It will fail if any issues are encountered.
@@ -615,17 +640,17 @@ document on Liferay.com. Then, the author should remove the newer header ID from
 the other header and run `ant number-headers` to produce a new unique ID for
 that header.
 
-### Will the header IDs show in the web content? 
+### Will the header IDs show in the web content?
 
 No, they will not show unless possibly there is a syntax error in the header ID
 used in your markdown source.
 
-### Are there safe-guards to prevent upload of documents that have missing or conflicting IDs? 
+### Are there safe-guards to prevent upload of documents that have missing or conflicting IDs?
 
 Yes, the dependency targets (e.g. `number-headers`) executed by our distribution
 targets, `dist-ce` and `dist-dxp`, fail and report errors if the documents are
 missing IDs or have conflicting IDs.
 
-## Contact Information 
+## Contact Information
 
 Rich Sezov (sez11a), Jim Hinkey (jhinkey)

--- a/guidelines/liferay-documentation-tools.markdown
+++ b/guidelines/liferay-documentation-tools.markdown
@@ -70,6 +70,73 @@ is set to *Soft*.
 
 Now you've got a great environment for editing Markdown files. 
 
+## Ant Target Quick Reference
+
+Each Ant target described in this section is for Liferay's CE docs only (unless
+otherwise noted). Most targets have a DXP version that runs on all CE and DXP
+docs. Append `-dxp` to the targets listed below when checking/editing DXP-only
+documentation.
+
+Each target should be executed from a document directory in the `liferay-docs`
+repo. For example, `/develop/tutorials`, `/discover/portal`, etc.
+
+<!-- compare-with-older-branch/dist-diffs process is broken. Need to fix before
+documenting. -Cody -->
+
+- `article-to-html`: Converts a Markdown article to HTML. This target requires a
+  `-Darticle` argument, which should point to your Markdown article (e.g.,
+  `ant article-to-html -Darticle=articles/100-tooling/05-maven/01-installing-liferay-maven-artifacts.markdown`).
+  The generated HTML is located in the document directory's `/build` folder.
+
+- `check-headers`: Checks all Markdown headers to ensure they properly begin
+  with `#` characters.
+
+- `check`: Runs several targets at once to make sure Markdown articles follow
+  LDN standards to ensure a successful build and publishing process. This target
+  should be executed before every pull request. This target includes the
+  `check-headers`, `check-images`, `check-intros`, `number-headers`, and
+  `number-images` tasks.
+
+- `check-article-images`: Checks a specific Markdown article's image paths.
+  If an image path (e.g., `../../images/test-pic.png`) does not point to an
+  existing image in the `/images` folder, an error is thrown. This target
+  requires a `-Darticle` argument, which should point to your Markdown article
+  (e.g., `ant check-article-images -Darticle=articles/100-tooling/05-maven/01-installing-liferay-maven-artifacts.markdown`).
+
+- `check-images`: Checks all Markdown articles' image paths in the folder. If an
+  image path (e.g., `../../images/test-pic.png`) does not point to an existing
+  image in the `/images` folder, an error is thrown.
+
+- `check-intros`: Checks all directories for an intro file (e.g.,
+  `00-intro.markdown`). If a folder does not have an intro article, an error is
+  thrown.
+
+- `clean-images`: (no DXP target) Deletes images from the `images` and
+  `images-dxp` folders that are not used in their corresponding Markdown
+  articles.
+
+- `check-links`: (no DXP target) Checks LDN links (CE articles only) to ensure
+  they're pointing at an existing LDN article. A list of invalid links are
+  listed if any are found.
+
+- `dist-ce`: Packages all necessary CE resources into a ZIP file deployable to
+  LDN.
+  
+- `dist-dxp`: Packages all necessary DXP resources into a ZIP file deployable to
+  Liferay's Customer Portal.
+
+- `number-headers`: Numbers all Markdown article headers with a unique header
+  ID. If there are any duplicate IDs, an error is thrown. See the
+  [Assigning Header IDs](#assigning-header-ids) and
+  [Markdown Header ID FAQ](#markdown-header-id-faq) sections for more
+  information.
+
+- `number-images`: Numbers all Markdown articles' images in the folder. Image
+  numbers (e.g., *![Figure x:*) are replaced with the correct image numbering if
+  they are incorrect. See the
+  [Markdown Image Numbers Tool](#markdown-image-numbers-tool) section for more
+  information.
+
 ## Markdown Image Numbers Tool 
 
 We have a tool that you can call with Ant that numbers the images in a Markdown

--- a/guidelines/liferay-documentation-tools.markdown
+++ b/guidelines/liferay-documentation-tools.markdown
@@ -132,7 +132,7 @@ documenting. -Cody -->
   information.
 
 - `number-images`: Numbers all Markdown articles' images in the folder. Image
-  numbers (e.g., *\![Figure x:* ) are replaced with the correct image numbering if
+  numbers (e.g., *\!\[Figure x:* ) are replaced with the correct image numbering if
   they are incorrect. See the
   [Markdown Image Numbers Tool](#markdown-image-numbers-tool) section for more
   information.

--- a/guidelines/liferay-documentation-tools.markdown
+++ b/guidelines/liferay-documentation-tools.markdown
@@ -132,7 +132,7 @@ documenting. -Cody -->
   information.
 
 - `number-images`: Numbers all Markdown articles' images in the folder. Image
-  numbers (e.g., *![Figure x:* ) are replaced with the correct image numbering if
+  numbers (e.g., *\![Figure x:* ) are replaced with the correct image numbering if
   they are incorrect. See the
   [Markdown Image Numbers Tool](#markdown-image-numbers-tool) section for more
   information.


### PR DESCRIPTION
There are a few things I did in this PR:
- Updated all guidelines in the `liferay-documentation-tools.markdown` file for accuracy. Many topics in this article were outdated.
- Documented build targets in quick reference section
- Documented tokens
- Renamed a couple targets (`check-images` and `number-images`) to follow naming conventions for the Ant targets. They previously had the word *site* in them (e.g. `check-images-site`), which was a leftover from when we were first migrating over to LDN.



https://issues.liferay.com/browse/LRDOCS-3137