### PR TITLE
Fixing image links in Screens tutorials.

### DIFF
--- a/develop/tutorials/articles/122-ios-apps-with-liferay-screens/08-adding-screenlet-actions.markdown
+++ b/develop/tutorials/articles/122-ios-apps-with-liferay-screens/08-adding-screenlet-actions.markdown
@@ -43,7 +43,7 @@ Use the following steps to add an action to your your Screenlet:
    the action. For example, Add Boookmark Screenlet's XIB file needs a new 
    button for getting the URL's title: 
 
-    ![Figure 1: The sample Add Bookmark Screenlet's XIB file contains a new button next to the *Title* field for retrieving the URL's title.](../../../images/screens-ios-xcode-add-bookmark-advanced.png)
+    ![Figure 1: The sample Add Bookmark Screenlet's XIB file contains a new button next to the *Title* field for retrieving the URL's title.](../../images/screens-ios-xcode-add-bookmark-advanced.png)
 
 3. Wire the UI components in your XIB file to your View class. In your View 
    class, you must also set each component's `restorationIdentifier` to its 

--- a/develop/tutorials/articles/122-ios-apps-with-liferay-screens/11-progress-presenters.markdown
+++ b/develop/tutorials/articles/122-ios-apps-with-liferay-screens/11-progress-presenters.markdown
@@ -112,7 +112,7 @@ button:
    example, the XIB file in Add Bookmark Screenlet contains an iOS 
    `UIActivityIndicatorView` over the get title button: 
 
-    ![Figure 1: The updated Add Bookmark Screenlet's XIB file contains a new activity indicator over the get title button.](../../../images/screens-ios-xcode-add-bookmark-advanced-progress.png)
+    ![Figure 1: The updated Add Bookmark Screenlet's XIB file contains a new activity indicator over the get title button.](../../images/screens-ios-xcode-add-bookmark-advanced-progress.png)
 
 2. In your View class, create an outlet for the XIB's new activity indicator. 
    For example, Add Bookmark Screenlet's View class (`AddBookmarkView_default`) 

--- a/develop/tutorials/articles/122-ios-apps-with-liferay-screens/14-custom-cells-list-screenlets-ios.markdown
+++ b/develop/tutorials/articles/122-ios-apps-with-liferay-screens/14-custom-cells-list-screenlets-ios.markdown
@@ -43,7 +43,7 @@ For example, the following screenshot shows the XIB file
 `BookmarkCell_default-custom.xib` for Bookmark List Screenlet's custom cell. 
 This cell must show a bookmark's name and URL, so it contains two labels. 
 
-![Figure 1: The XIB file for Bookmark List Screenlet’s custom cell.](../../../images/screens-ios-xcode-custom-cell.png)
+![Figure 1: The XIB file for Bookmark List Screenlet’s custom cell.](../../images/screens-ios-xcode-custom-cell.png)
 
 This XIB's custom class, `BookmarkCell_default_custom`, contains an outlet for 
 each label. The `bookmark` variable also contains a `didSet` observer that sets 

--- a/develop/tutorials/articles/122-ios-apps-with-liferay-screens/15-sorting-list-screenlet.markdown
+++ b/develop/tutorials/articles/122-ios-apps-with-liferay-screens/15-sorting-list-screenlet.markdown
@@ -30,7 +30,7 @@ Screenlet property. For example, to set the sample Bookmark List Screenlet to
 sort its list of bookmarks by URL, you must set *Obc Class Name* to 
 *com.liferay.bookmarks.util.comparator.EntryURLComparator* in Interface Builder: 
 
-![Figure 1: To use a comparator, set the *Obc Class Name* property in Interface Builder to the comparator's fully qualified class name.](../../../images/screens-ios-obc-ib.png)
+![Figure 1: To use a comparator, set the *Obc Class Name* property in Interface Builder to the comparator's fully qualified class name.](../../images/screens-ios-obc-ib.png)
 
 That’s it! Note that although all list Screenlets inherit the `obcClassName` 
 property from 

--- a/develop/tutorials/articles/122-ios-apps-with-liferay-screens/16-complex-lists.markdown
+++ b/develop/tutorials/articles/122-ios-apps-with-liferay-screens/16-complex-lists.markdown
@@ -25,7 +25,7 @@ these steps is a bit different:
     Bookmark List Screenlet's Collection Theme. It's a simple square that 
     displays the bookmark's URL and the URL's first letter. 
 
-    ![Figure 1: The XIB file for the cell in Bookmark List Screenlet's custom View.](../../../images/screens-ios-collectionview-cell.png)
+    ![Figure 1: The XIB file for the cell in Bookmark List Screenlet's custom View.](../../images/screens-ios-collectionview-cell.png)
 
 2.  Create your XIB file's class by extending `UICollectionViewCell`. Create as 
     many outlets and actions as you need for your UI components and write the 


### PR DESCRIPTION
Image links in several Screens tutorials for the recent port from master to 6.2.x were broken. Now they're fixed.