### PR TITLE
Guidelines for Breaking Changes shouldn't be published on LDN

### DIFF
--- a/develop/reference/articles/04-breaking-changes/00-breaking-changes-intro.markdown
+++ b/develop/reference/articles/04-breaking-changes/00-breaking-changes-intro.markdown
@@ -20,55 +20,6 @@ feature or API will be dropped in an upcoming version.
 replaces an old API, in spite of the old API being kept in Liferay Portal for
 backwards compatibility.
 
-## Breaking Changes Contribution Guidelines [](id=breaking-changes-contribution-guidelines)
-
-Each change must have a brief descriptive title and contain the following
-information:
-
-* **[Title]** Provide a brief descriptive title. Use past tense and follow
-the capitalization rules from
-<http://en.wikibooks.org/wiki/Basic_Book_Design/Capitalizing_Words_in_Titles>.
-* **Date:** Specify the date you submitted the change. Format the date as
-*YYYY-MMM* (e.g., 2014-Mar) or *YYYY-MMM-DD* (e.g., 2014-Feb-25).
-* **JIRA Ticket:** Reference the related JIRA ticket (e.g., LPS-123456)
-(Optional).
-* **What changed?** Identify the affected component and the type of change that
-was made.
-* **Who is affected?** Are end-users affected? Are developers affected? If the
-only affected people are those using a certain feature or API, say so.
-* **How should I update my code?** Explain any client code changes required.
-* **Why was this change made?** Explain the reason for the change. If
-applicable, justify why the breaking change was made instead of following a
-deprecation process.
-
-Here's the template to use for each breaking change (note how it ends with a
-horizontal rule):
-
-```
-### Title [](id=title)
-- **Date:**
-- **JIRA Ticket:**
-
-#### What changed? [](id=what-changed)
-
-#### Who is affected? [](id=who-is-affected)
-
-#### How should I update my code? [](id=how-should-i-update-my-code)
-
-#### Why was this change made? [](id=why-was-this-change-made)
-
----------------------------------------
-```
-
-**80 Columns Rule:** Text should not exceed 80 columns. Keeping text within 80
-columns makes it easier to see the changes made between different versions of
-the document. Titles, links, and tables are exempt from this rule. Code samples
-must follow the column rules specified in Liferay's
-[Development Style](http://www.liferay.com/community/wiki/-/wiki/Main/Liferay+development+style).
-
-The remaining content of this document consists of the breaking changes listed
-in ascending chronological order.
-
 ## Breaking Changes List [](id=breaking-changes-list)
 
 ### Utility Methods Have Been Moved from ImageLocalServiceUtil [](id=utility-methods-have-been-moved-from-imagelocalserviceutil)


### PR DESCRIPTION
Hey Rich,

I've received some complaints about the Contribution Guidelines being published in in our 6.2 Breaking Changes article. I agree, so I've removed the contribution guidelines. Since the 7.0 Breaking Changes on LDN doesn't include these guidelines, it's best to keep all versions of this doc consistent. Thanks!