### PR TITLE
Add back missing agent opts + UTF8 encoding recommendation to the LCS documentation

### DIFF
--- a/discover/deployment/articles-dxp/07-liferay-connected-services/01-lcs-preconfiguration.markdown
+++ b/discover/deployment/articles-dxp/07-liferay-connected-services/01-lcs-preconfiguration.markdown
@@ -186,4 +186,31 @@ you're running Windows, drop the `.sh` from each command that has it.
 
         -Dpatching.tool.home=/opt/liferay-dxp-digital-enterprise-7.0/patching-tool/
 
-Great! Now you're all set to activate your @product@ instance with LCS. 
+There are also a few other things to consider when using the agent. Due to class
+loading issues, the agent starts in a separate JVM. You can specify options for
+it by using the `patching.tool.agent.jvm.opts` property. 
+
+        -Dpatching.tool.agent.jvm.opts="-Xmx1024m -Xms512m -Dfile.encoding=UTF8"
+
+You may also experience issues on Windows if the user starting the app server
+doesn’t have administrator privileges.
+Here are some examples of the errors you may see:
+
+`java.nio.file.FileSystemException: ..\webapps\ROOT\WEB-INF\lib\util-java.jar: Not a file!`
+`java.io.FileNotFoundException: java.io.IOException: Access refused`
+
+To solve this, set the `java.io.tmpdir` system property as follows in the
+`patching.tool.agent.jvm.opts` property:
+
+        -Dpatching.tool.agent.jvm.opts="-Xmx1024m -Xms512m -Dfile.encoding=UTF8 -Djava.io.tmpdir=%TMP%"
+
+The agent also has some flags you can set to control how it behaves:
+
+    `debug`: Provides verbose output in the console.
+    `nohalt`: Starts the portal even if the agent encounters an issue.
+
+You can specify these as follows:
+
+        -Dpatching.tool.agent.properties=debug,nohalt
+
+Great! Now you're all set to activate your @product@ instance with LCS.


### PR DESCRIPTION
Hi Rich,

I've just see that  https://customer.liferay.com/documentation/7.0/deploy/-/official_documentation/deployment/lcs-preconfiguration misses some agent option so I've readded it from https://customer.liferay.com/documentation/6.1/admin/-/official_documentation/portal/patching-liferay

I've also added another system property `-Dfile.encoding=UTF8` in the agent opts as a customer faced an issue that was solved by this.

Please let me know if you have any questions.

Best,
Zoli