### PR TITLE
Fix link syntax for 6.2 developer tutorial and user articles

### DIFF
--- a/develop/tutorials/articles/02-mvc/09-making-urls-friendly/02-removing-the-primary-key-from-portlet-urls.markdown
+++ b/develop/tutorials/articles/02-mvc/09-making-urls-friendly/02-removing-the-primary-key-from-portlet-urls.markdown
@@ -763,5 +763,5 @@ to create even friendlier URLs.
 
 ## Next Steps [](id=next-steps)
 
-[Creating Remote Services](develop/learning-paths/-/knowledge_base/6-2/creating-web-services-for-your-application)
+[Creating Remote Services](/develop/learning-paths/-/knowledge_base/6-2/creating-web-services-for-your-application)
 

--- a/develop/tutorials/articles/101-plugins-sdk/01-setting-up-the-plugins-sdk.markdown
+++ b/develop/tutorials/articles/101-plugins-sdk/01-setting-up-the-plugins-sdk.markdown
@@ -147,5 +147,5 @@ You're set to start using your Liferay Plugins SDK!
 
 **Related Topics**
 
-[Developing Plugins with Liferay IDE](develop/tutorials/-/knowledge_base/6-2/liferay-ide)
-[Developing Plugins with Maven](develop/tutorials/-/knowledge_base/6-2/maven)
+[Developing Plugins with Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/liferay-ide)
+[Developing Plugins with Maven](/develop/tutorials/-/knowledge_base/6-2/maven)

--- a/develop/tutorials/articles/103-maven/01-setting-up-maven.markdown
+++ b/develop/tutorials/articles/103-maven/01-setting-up-maven.markdown
@@ -181,7 +181,7 @@ create!
 
 ## Related Topics [](id=related-topics)
 
-[Developing with the Plugins SDK](develop/tutorials/-/knowledge_base/6-2/plugins-sdk)
+[Developing with the Plugins SDK](/develop/tutorials/-/knowledge_base/6-2/plugins-sdk)
 
-[Developing Plugins with Liferay IDE](develop/tutorials/-/knowledge_base/6-2/liferay-ide)
+[Developing Plugins with Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/liferay-ide)
 

--- a/develop/tutorials/articles/103-maven/04-maven-parent-plugin-projects.markdown
+++ b/develop/tutorials/articles/103-maven/04-maven-parent-plugin-projects.markdown
@@ -215,6 +215,6 @@ You've configured your parent plugin project.
 
 **Related Topics:**
 
-[Developing Plugins with Liferay IDE](develop/tutorials/-/knowledge_base/6-2/liferay-ide)
-[Developing with Maven](develop/tutorials/-/knowledge_base/6-2/maven)
+[Developing Plugins with Liferay IDE](/develop/tutorials/-/knowledge_base/6-2/liferay-ide)
+[Developing with Maven](/develop/tutorials/-/knowledge_base/6-2/maven)
 

--- a/develop/tutorials/articles/105-mvc-portlets/02-configurable-portlet-preferences.markdown
+++ b/develop/tutorials/articles/105-mvc-portlets/02-configurable-portlet-preferences.markdown
@@ -287,5 +287,5 @@ use Liferay's portlet preferences in the portlets you develop.
 
 ## Related Topics [](id=related-topics)
 
-[User Interfaces with AlloyUI](develop/tutorials/-/knowledge_base/6-2/alloyui)
-[User Interfaces with the Liferay UI Taglib](develop/tutorials/-/knowledge_base/6-2/liferay-ui-taglibs)
+[User Interfaces with AlloyUI](/develop/tutorials/-/knowledge_base/6-2/alloyui)
+[User Interfaces with the Liferay UI Taglib](/develop/tutorials/-/knowledge_base/6-2/liferay-ui-taglibs)

--- a/develop/tutorials/articles/105-mvc-portlets/03-using-portlet-namespacing.markdown
+++ b/develop/tutorials/articles/105-mvc-portlets/03-using-portlet-namespacing.markdown
@@ -39,5 +39,5 @@ Liferay portlets.
 
 ## Related Topics [](id=related-topics)
 
-[Search and Indexing](develop/tutorials/-/knowledge_base/6-2/search-and-indexing)
-[User Interfaces with AlloyUI](develop/tutorials/-/knowledge_base/6-2/alloyui)
+[Search and Indexing](/develop/tutorials/-/knowledge_base/6-2/search-and-indexing)
+[User Interfaces with AlloyUI](/develop/tutorials/-/knowledge_base/6-2/alloyui)

--- a/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/97-migrating-from-liferay-faces-31-to-liferay-faces-32-42.markdown
+++ b/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/97-migrating-from-liferay-faces-31-to-liferay-faces-32-42.markdown
@@ -132,6 +132,6 @@ addition to other changes required to migrate to Liferay Faces 3.2/4.2.
 
 ## Related Topics [](id=related-topics)
 
-[Creating and Deploying JSF Portlets](develop/tutorials/-/knowledge_base/6-2/creating-and-deploying-jsf-portlets)
+[Creating and Deploying JSF Portlets](/develop/tutorials/-/knowledge_base/6-2/creating-and-deploying-jsf-portlets)
 
-[Understanding Liferay Faces Alloy](develop/tutorials/-/knowledge_base/6-2/understanding-liferay-faces-alloy)
+[Understanding Liferay Faces Alloy](/develop/tutorials/-/knowledge_base/6-2/understanding-liferay-faces-alloy)

--- a/develop/tutorials/articles/107-service-builder/02-defining-an-object-relational-map-with-service-builder.markdown
+++ b/develop/tutorials/articles/107-service-builder/02-defining-an-object-relational-map-with-service-builder.markdown
@@ -32,7 +32,7 @@ described in this section is only intended to demonstrate how to use Service
 Builder. The Calendar portlet provides many more features than the simple
 example application described here. For information about the Calendar portlet,
 please refer to the
-[Managing Events and Calendar Resources with Liferay's Calendar Portlet](discover/portal/-/knowledge_base/6-2/managing-events-and-calendar-resources-with-liferays-c) section.
+[Managing Events and Calendar Resources with Liferay's Calendar Portlet](/discover/portal/-/knowledge_base/6-2/managing-events-and-calendar-resources-with-liferays-c) section.
 
 $$$
 

--- a/develop/tutorials/articles/107-service-builder/11-registering-json-web-services.markdown
+++ b/develop/tutorials/articles/107-service-builder/11-registering-json-web-services.markdown
@@ -77,7 +77,7 @@ plugin to Liferay.
 To get some feedback from the portal on registering your plugin's services,
 configure the portal to log the plugin's informational messages (i.e., its `INFO
 ...` messages). See the section on Liferay's logging system in
-[Using Liferay Portal](discover/deployment/-/knowledge_base/6-2/liferays-logging-system) for details.
+[Using Liferay Portal](/discover/deployment/-/knowledge_base/6-2/liferays-logging-system) for details.
 
 To test Liferay's JSON web service registration process, add a simple method to
 your plugin's services. Edit your `*ServiceImpl` class and add the following

--- a/develop/tutorials/articles/107-service-builder/16-invoking-services-using-skinny-json-provider.markdown
+++ b/develop/tutorials/articles/107-service-builder/16-invoking-services-using-skinny-json-provider.markdown
@@ -47,7 +47,7 @@ making them ideal to use in browsers and mobile applications.
 The Skinny JSON Provider app is available through the Liferay Marketplace.
 You'll find it categorized as a Utility app. To learn how to install it, you can
 read the section
-[Downloading and Installing Apps](discover/portal/-/knowledge_base/6-2/downloading-and-installing-apps).
+[Downloading and Installing Apps](/discover/portal/-/knowledge_base/6-2/downloading-and-installing-apps).
 
 The app adds two new web service APIs that you can configure like other Liferay
 web services. Here is the context and the class name that you must specify to

--- a/develop/tutorials/articles/114-workflow/installing-kaleo-forms-ee.markdown
+++ b/develop/tutorials/articles/114-workflow/installing-kaleo-forms-ee.markdown
@@ -104,7 +104,7 @@ and outline view.
 $$$
 
 Once you have Kaleo Designer for Java installed, get into the flow (pun
-intended) by [creating your own workflow](develop/tutorials/-/knowledge_base/6-2/workflow/creating-a-workflow-project-with-kaleo) using the Kaleo Workflow Designer for
+intended) by [creating your own workflow](/develop/tutorials/-/knowledge_base/6-2/workflow/creating-a-workflow-project-with-kaleo) using the Kaleo Workflow Designer for
 Java. 
 
 <!-- ## Related Topics -->

--- a/develop/tutorials/articles/114-workflow/publishing-and-using-workflows.markdown
+++ b/develop/tutorials/articles/114-workflow/publishing-and-using-workflows.markdown
@@ -70,7 +70,7 @@ heading, select *Workflow*. Then, in the *Definitions* tab, click on the
 A workflow definition can be associated with publication of an asset or DDL
 record. Let's associate our ticket process workflow definition with a DDL record
 that lets a developer indicate whether she'll fix a ticket's issue. You can find
-detailed instructions for creating a DDL by visiting the section [Defining data types](discover/portal/-/knowledge_base/6-2/building-a-list-platform-in-liferay-and-defining-data-)
+detailed instructions for creating a DDL by visiting the section [Defining data types](/discover/portal/-/knowledge_base/6-2/building-a-list-platform-in-liferay-and-defining-data-)
 in *Discover* &rarr; *Portal*. We'll demonstrate how easy it is.
 
 ## Using Dynamic Data Lists with Workflows [](id=using-dynamic-data-lists-with-workflows)

--- a/develop/tutorials/articles/114-workflow/using-workflow-scripts.markdown
+++ b/develop/tutorials/articles/114-workflow/using-workflow-scripts.markdown
@@ -238,6 +238,6 @@ We need to create a valid DDL record to invoke this workflow properly. If you've
 never set up a DDL record before, or don't even know what a DDL does, don't
 fret. We've got you covered in the tutorial on [Publishing and Using Workflows](/develop/tutorials/-/knowledge_base/6-2/workflow/publishing-and-using-workflows). 
 
-Next, you might want to look at the tutorial on [leveraging template editors for notifications](develop/tutorials/-/knowledge_base/6-2/workflow/notification-templates). 
+Next, you might want to look at the tutorial on [leveraging template editors for notifications](/develop/tutorials/-/knowledge_base/6-2/workflow/notification-templates). 
 
 <!-- ## Related Topics -->

--- a/develop/tutorials/articles/114-workflow/workflow-enabling-entities.markdown
+++ b/develop/tutorials/articles/114-workflow/workflow-enabling-entities.markdown
@@ -206,7 +206,7 @@ approved entities.
 				WorkflowConstants.STATUS_APPROVED);
 	}
 
-For an example of using service Builder to create a finder that takes workflow status into account, check out the appropriate section of the [Learning Path on workflow](develop/learning-paths/-/knowledge_base/6-2/displaying-approved-workflow-items).
+For an example of using service Builder to create a finder that takes workflow status into account, check out the appropriate section of the [Learning Path on workflow](/develop/learning-paths/-/knowledge_base/6-2/displaying-approved-workflow-items).
 
 If your app includes an *admin* portlet in Liferay's Site Administration
 console, consider displaying all entities, regardless of workflow status. Many
@@ -231,9 +231,9 @@ your own workflow definitions, and use scripting to make them more robust.
 
 ##  Related Topics [](id=related-topics)
 
-[Approving Content with Workflow](develop/learning-paths/-/knowledge_base/6-2/approving-content-with-workflow)
+[Approving Content with Workflow](/develop/learning-paths/-/knowledge_base/6-2/approving-content-with-workflow)
 
-[Asset Framework](develop/tutorials/-/knowledge_base/6-2/asset-framework)
+[Asset Framework](/develop/tutorials/-/knowledge_base/6-2/asset-framework)
 
-[Service Builder and Services](develop/tutorials/-/knowledge_base/6-2/service-builder)
+[Service Builder and Services](/develop/tutorials/-/knowledge_base/6-2/service-builder)
 

--- a/develop/tutorials/articles/116-user-interfaces-with-alloyui/01-migrating-to-alloyui-2.0-bootstrap.markdown
+++ b/develop/tutorials/articles/116-user-interfaces-with-alloyui/01-migrating-to-alloyui-2.0-bootstrap.markdown
@@ -389,5 +389,5 @@ monotonous conversion work for you.
 
 [Liferay Faces AlloyUI Components](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/liferay-faces-alloy-ui-components)
 
-[Themes and Layout Templates](develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
+[Themes and Layout Templates](/develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
 

--- a/develop/tutorials/articles/116-user-interfaces-with-alloyui/02-using-alloyui-carousel-in-a-portlet.markdown
+++ b/develop/tutorials/articles/116-user-interfaces-with-alloyui/02-using-alloyui-carousel-in-a-portlet.markdown
@@ -145,7 +145,7 @@ You've just successfully used the `aui-carousel` in your portlet!
 
 ## Related Topics [](id=related-topics)
 
-[User Interfaces with the Liferay UI taglib](develop/tutorials/-/knowledge_base/6-2/liferay-ui-taglibs)
+[User Interfaces with the Liferay UI taglib](/develop/tutorials/-/knowledge_base/6-2/liferay-ui-taglibs)
 
-[Using AlloyUI in Your Application](develop/learning-paths/-/knowledge_base/6-2/using-alloy-ui-in-your-application)
+[Using AlloyUI in Your Application](/develop/learning-paths/-/knowledge_base/6-2/using-alloy-ui-in-your-application)
 

--- a/develop/tutorials/articles/121-android-apps-with-liferay-screens/01-preparing-android-projects-for-liferay-screens.markdown
+++ b/develop/tutorials/articles/121-android-apps-with-liferay-screens/01-preparing-android-projects-for-liferay-screens.markdown
@@ -244,4 +244,4 @@ how to do this.
 
 [Using Views in Android Screenlets](/develop/tutorials/-/knowledge_base/6-2/using-views-in-android-screenlets)
 
-[Preparing iOS Projects for Liferay Screens](develop/tutorials/-/knowledge_base/6-2/preparing-ios-projects-for-liferay-screens)
+[Preparing iOS Projects for Liferay Screens](/develop/tutorials/-/knowledge_base/6-2/preparing-ios-projects-for-liferay-screens)

--- a/develop/tutorials/articles/122-ios-apps-with-liferay-screens/01-preparing-ios-projects-for-liferay-screens.markdown
+++ b/develop/tutorials/articles/122-ios-apps-with-liferay-screens/01-preparing-ios-projects-for-liferay-screens.markdown
@@ -224,4 +224,4 @@ Great! Your iOS project is ready for Liferay Screens.
 
 [Using Themes in iOS Screenlets](/develop/tutorials/-/knowledge_base/6-2/using-themes-in-ios-screenlets)
 
-[Preparing Android Projects for Liferay Screens](develop/tutorials/-/knowledge_base/6-2/preparing-android-projects-for-liferay-screens)
+[Preparing Android Projects for Liferay Screens](/develop/tutorials/-/knowledge_base/6-2/preparing-android-projects-for-liferay-screens)

--- a/develop/tutorials/articles/125-opensocial-gadgets/01-sending-pubsub-messages-between-gadgets-and-portlets.markdown
+++ b/develop/tutorials/articles/125-opensocial-gadgets/01-sending-pubsub-messages-between-gadgets-and-portlets.markdown
@@ -227,7 +227,7 @@ user's experience.
 
 ## Related Topics [](id=related-topics)
 
-[Using Liferay's Message Bus](develop/tutorials/-/knowledge_base/6-2/using-liferays-message-bus)
+[Using Liferay's Message Bus](/develop/tutorials/-/knowledge_base/6-2/using-liferays-message-bus)
 
 [Customizing Liferay Portal with Hooks](/develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal)
 

--- a/develop/tutorials/articles/125-opensocial-gadgets/02-using-the-gadget-editor.markdown
+++ b/develop/tutorials/articles/125-opensocial-gadgets/02-using-the-gadget-editor.markdown
@@ -61,9 +61,9 @@ editor.
 
 **Related Topics**
 
-[Using the Mobile SDK](develop/tutorials/-/knowledge_base/6-2/mobile)
+[Using the Mobile SDK](/develop/tutorials/-/knowledge_base/6-2/mobile)
 
-[Using the Device Recognition API](develop/tutorials/-/knowledge_base/6-2/using-the-device-recognition-api)
+[Using the Device Recognition API](/develop/tutorials/-/knowledge_base/6-2/using-the-device-recognition-api)
 
 [Customizing Liferay Portal with Hooks](/develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal)
 

--- a/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/01-creating-a-hook-project-in-the-plugins-sdk.markdown
+++ b/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/01-creating-a-hook-project-in-the-plugins-sdk.markdown
@@ -120,7 +120,7 @@ get out there and create your customizations!
 
 ## Related Topics [](id=related-topics)
 
-[Developing with the Plugins SDK](develop/tutorials/-/knowledge_base/6-2/plugins-sdk)
+[Developing with the Plugins SDK](/develop/tutorials/-/knowledge_base/6-2/plugins-sdk)
 
-[Localization](develop/tutorials/-/knowledge_base/6-2/localization)
+[Localization](/develop/tutorials/-/knowledge_base/6-2/localization)
 

--- a/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/05-customizing-sites-and-site-templates-using-application-adapters.markdown
+++ b/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/05-customizing-sites-and-site-templates-using-application-adapters.markdown
@@ -112,7 +112,7 @@ for yourself and learned best practices along the way.
 
 **Related Topics**
 
-[Themes and Layout Templates](develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
+[Themes and Layout Templates](/develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
 
-[Advanced Content with Structures and Layout Templates](discover/portal/-/knowledge_base/6-2/advanced-content-with-structures-and-templates)
+[Advanced Content with Structures and Layout Templates](/discover/portal/-/knowledge_base/6-2/advanced-content-with-structures-and-templates)
 

--- a/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/07-performing-a-custom-action-using-a-hook.markdown
+++ b/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/07-performing-a-custom-action-using-a-hook.markdown
@@ -138,7 +138,7 @@ hook in Liferay Portal.
 
 **Related Topics**
 
-[MVC Portlets](develop/tutorials/-/knowledge_base/6-2/developing-jsp-portlets-using-liferay-mvc)
+[MVC Portlets](/develop/tutorials/-/knowledge_base/6-2/developing-jsp-portlets-using-liferay-mvc)
 
-[Overriding and Adding Struts Actions](develop/tutorials/-/knowledge_base/6-2/overriding-and-adding-struts-actions)
+[Overriding and Adding Struts Actions](/develop/tutorials/-/knowledge_base/6-2/overriding-and-adding-struts-actions)
 

--- a/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/08-creating-model-listeners.markdown
+++ b/develop/tutorials/articles/128-customizing-liferay-portal-with-hooks/08-creating-model-listeners.markdown
@@ -1,7 +1,7 @@
 # Creating Model Listeners [](id=creating-model-listeners)
 
 Model Listeners are used to listen for events on models and do something
-in response. They're similar in concept to [custom action hooks](develop/tutorials/-/knowledge_base/6-2/performing-a-custom-action-using-a-hook),
+in response. They're similar in concept to [custom action hooks](/develop/tutorials/-/knowledge_base/6-2/performing-a-custom-action-using-a-hook),
 which perform actions in response to portal events (user login, for
 example). Model listeners implement the
 [`ModelListener`](https://docs.liferay.com/portal/6.2/javadocs-all/com/liferay/portal/model/ModelListener.html)
@@ -21,9 +21,9 @@ entity for illustrative purposes.
 
 ## Creating a Hook Plugin Project [](id=creating-a-hook-plugin-project)
 
-First, create a hook plugin project in a [Liferay Plugins SDK](develop/tutorials/-/knowledge_base/6-2/creating-a-hook-project-in-the-plugins-sdk)
+First, create a hook plugin project in a [Liferay Plugins SDK](/develop/tutorials/-/knowledge_base/6-2/creating-a-hook-project-in-the-plugins-sdk)
 or with 
-[Maven](develop/tutorials/-/knowledge_base/6-2/developing-liferay-hook-plugins-with-maven).
+[Maven](/develop/tutorials/-/knowledge_base/6-2/developing-liferay-hook-plugins-with-maven).
 
 Once you have a hook plugin, start developing your model listener.
 
@@ -140,13 +140,13 @@ $$$
 
 Listening for events on Liferay's entities is just one of the many interesting
 ways to customize Liferay's core functionality with hooks. Keep reading in 
-[this section](develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal) to
+[this section](/develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal) to
 learn about more of Liferay's extension points. 
 
 ## Related Topics [](id=related-topics)
 
-[Overriding a Portal Service Using a Hook](develop/tutorials/-/knowledge_base/6-2/overriding-a-portal-service-using-a-hook)
+[Overriding a Portal Service Using a Hook](/develop/tutorials/-/knowledge_base/6-2/overriding-a-portal-service-using-a-hook)
 
-[Performing a Custom Action Using a Hook](develop/tutorials/-/knowledge_base/6-2/performing-a-custom-action-using-a-hook)
+[Performing a Custom Action Using a Hook](/develop/tutorials/-/knowledge_base/6-2/performing-a-custom-action-using-a-hook)
 
-[Service Builder and Services](develop/tutorials/-/knowledge_base/6-2/service-builder)
+[Service Builder and Services](/develop/tutorials/-/knowledge_base/6-2/service-builder)

--- a/develop/tutorials/articles/129-audience-targeting/reporting-user-behavior-with-audience-targeting.markdown
+++ b/develop/tutorials/articles/129-audience-targeting/reporting-user-behavior-with-audience-targeting.markdown
@@ -78,7 +78,7 @@ page and study the folders with the `report-` prefix.
 
 **Related Topics**
 
-[User Management](discover/portal/-/knowledge_base/6-2/user-management)
+[User Management](/discover/portal/-/knowledge_base/6-2/user-management)
 
-[Customizing Liferay Portal with Hooks](develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal)
+[Customizing Liferay Portal with Hooks](/develop/tutorials/-/knowledge_base/6-2/customizing-liferay-portal)
 

--- a/develop/tutorials/articles/129-audience-targeting/tracking-user-actions-with-audience-targeting.markdown
+++ b/develop/tutorials/articles/129-audience-targeting/tracking-user-actions-with-audience-targeting.markdown
@@ -341,5 +341,5 @@ of a deployable sample newsletter tracking action, you can download its
 
 [Creating Model Listeners](https://dev.liferay.com/develop/tutorials/-/knowledge_base/6-2/creating-model-listeners)
 
-[Web Content Management](discover/portal/-/knowledge_base/6-2/web-content-management)
+[Web Content Management](/discover/portal/-/knowledge_base/6-2/web-content-management)
 

--- a/develop/tutorials/articles/130-importing-resources/02-creating-plugins-to-share-structures-templates-and-more.markdown
+++ b/develop/tutorials/articles/130-importing-resources/02-creating-plugins-to-share-structures-templates-and-more.markdown
@@ -299,7 +299,7 @@ makes it easy. Have fun distributing your structures and templates!
 
 **Related Topics**
 
-[Customizing Sites and Site Templates with Application Adapters](develop/tutorials/-/knowledge_base/6-2/customizing-sites-and-site-templates-with-application-adapters)
+[Customizing Sites and Site Templates with Application Adapters](/develop/tutorials/-/knowledge_base/6-2/customizing-sites-and-site-templates-with-application-adapters)
 
-[Advanced Content with Structures and Templates](discover/portal/-/knowledge_base/6-2/advanced-content-with-structures-and-templates)
+[Advanced Content with Structures and Templates](/discover/portal/-/knowledge_base/6-2/advanced-content-with-structures-and-templates)
 

--- a/develop/tutorials/articles/130-importing-resources/03-importing-resources-with-your-themes.markdown
+++ b/develop/tutorials/articles/130-importing-resources/03-importing-resources-with-your-themes.markdown
@@ -551,7 +551,7 @@ and which you can download from Liferay Marketplace.
 
 **Related Topics**
 
-[Themes and Layout Templates](develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
+[Themes and Layout Templates](/develop/tutorials/-/knowledge_base/6-2/themes-and-layout-templates)
 
-[Application Display Templates](develop/tutorials/-/knowledge_base/6-2/application-display-templates)
+[Application Display Templates](/develop/tutorials/-/knowledge_base/6-2/application-display-templates)
 

--- a/discover/portal/articles/04-configuring-liferay-applications/01-look-and-feel.markdown
+++ b/discover/portal/articles/04-configuring-liferay-applications/01-look-and-feel.markdown
@@ -31,7 +31,7 @@ portlet URLs will point to the page you selected. The current page is the
 default. Note that you can use the Asset Publisher's View in a Specific Portlet
 feature and web content articles' Display Page attribute to achieve a more
 elegant solution for displaying the full view of web content articles on
-specific pages. Please see the [Setting Up Display Pages](discover/portal/-/knowledge_base/6-1/setting-up-display-pages) article for details.
+specific pages. Please see the [Setting Up Display Pages](/discover/portal/-/knowledge_base/6-1/setting-up-display-pages) article for details.
 
 +$$$
 

--- a/discover/portal/articles/04-configuring-liferay-applications/02-export-import.markdown
+++ b/discover/portal/articles/04-configuring-liferay-applications/02-export-import.markdown
@@ -9,7 +9,7 @@ icon of your portlet and select *Export/Import*. Exporting portlet data produces
 a `.lar` file that you can save and import into another portlet application of
 the same type. To import portlet data, you must select a `.lar` file. Be careful
 not to confuse portlet-specific `.lar` files with site-specific `.lar` files.
-See the section on [Creating and Managing Pages](discover/portal/-/knowledge_base/6-2/leveraging-liferays-multi-site-capabilities#creating-and-managing-pages) 
+See the section on [Creating and Managing Pages](/discover/portal/-/knowledge_base/6-2/leveraging-liferays-multi-site-capabilities#creating-and-managing-pages) 
 for a discussion of exporting and importing site page data. 
 
 +$$$

--- a/discover/portal/articles/08-personalization-and-customization/03-using-application-display-templates.markdown
+++ b/discover/portal/articles/08-personalization-and-customization/03-using-application-display-templates.markdown
@@ -102,7 +102,7 @@ access the XML source of your template. You can find these URLs by clicking the
 ADT from the menu and expanding the *Details* section. With the WebDAV URL, site
 administrators are capable of adding, browsing, editing, and deleting ADTs on a
 remote server. If you'd like to learn more about what the WebDAV URL can do,
-visit the *Document Management* chapter's [WebDAV access](discover/portal/-/knowledge_base/6-2/automatic-previews-and-metadata#webdav-access)
+visit the *Document Management* chapter's [WebDAV access](/discover/portal/-/knowledge_base/6-2/automatic-previews-and-metadata#webdav-access)
 section.
 
 +$$$

--- a/discover/portal/articles/14-liferay-utility-applications/00-liferay-utility-applications-intro.markdown
+++ b/discover/portal/articles/14-liferay-utility-applications/00-liferay-utility-applications-intro.markdown
@@ -3,7 +3,7 @@
 In this chapter we'll look at some Liferay utility applications that might be
 useful for you. The Software Catalog has been replaced by Liferay Marketplace
 but can still be installed as a plugin. Refer to the chapter on 
-[Liferay Marketplace](discover/portal/-/knowledge_base/6-2/leveraging-the-liferay-marketplace) 
+[Liferay Marketplace](/discover/portal/-/knowledge_base/6-2/leveraging-the-liferay-marketplace) 
 for information on downloading and managing Liferay plugins. The Reports,
 JasperReports, and Knowledge Base applications are only available to EE
 customers. In this chapter we'll discuss following applications:

--- a/discover/portal/articles/14-liferay-utility-applications/01-capturing-web-sites-with-bookmarks-portlet.markdown
+++ b/discover/portal/articles/14-liferay-utility-applications/01-capturing-web-sites-with-bookmarks-portlet.markdown
@@ -50,7 +50,7 @@ into the list of general bookmarks that aren't associated with a folder. These
 are listed in the bookmarks section, below the folders, in the portlet.
 
 Below the Permissions there are additional options for Categorization and
-Related Assets, just like in other Liferay applications. Please see the [Displaying Content Dynamically](discover/portal/-/knowledge_base/6-2/displaying-content-dynamically)
+Related Assets, just like in other Liferay applications. Please see the [Displaying Content Dynamically](/discover/portal/-/knowledge_base/6-2/displaying-content-dynamically)
 chapter for further information about this.
 
 Once you have added a new bookmark, it appears in the portlet. From here, you

--- a/discover/portal/articles/16-user-management/01-the-users-section-of-the-control-panel.markdown
+++ b/discover/portal/articles/16-user-management/01-the-users-section-of-the-control-panel.markdown
@@ -8,10 +8,10 @@ and roles.
 ![Figure 16.1: The Users section of the Control Panel allows portal administrators to manage users, organizations, user groups, and roles. It also allows administrators to monitor users' live portal sessions if monitoring has been enabled for the portal.](../../images/users-section-control-panel.png)
 
 Managing
-[sites](discover/portal/-/knowledge_base/6-2/building-a-site-with-liferay-web-content),
-[teams](discover/portal/-/knowledge_base/6-2/creating-teams-for-advanced-site-membership-management),
-[site templates](discover/portal/-/knowledge_base/6-2/using-site-templates), and
-[page templates](discover/portal/-/knowledge_base/6-2/using-page-templates) is
+[sites](/discover/portal/-/knowledge_base/6-2/building-a-site-with-liferay-web-content),
+[teams](/discover/portal/-/knowledge_base/6-2/creating-teams-for-advanced-site-membership-management),
+[site templates](/discover/portal/-/knowledge_base/6-2/using-site-templates), and
+[page templates](/discover/portal/-/knowledge_base/6-2/using-page-templates) is
 covered in detail elsewhere. Remember that it's possible and sometimes simpler
 to use sites, site memberships, and teams to organize users and manage
 permissions than it is to use organizations, user groups, and custom roles.
@@ -40,7 +40,7 @@ form appears that allows you to fill out a lot more information about the user.
 You don't have to fill anything else out right now. Just note that when the user
 account was created, a password was automatically generated. If Liferay was
 correctly installed and a mail server was set up (see
-[here](discover/portal/-/knowledge_base/6-2/server-administration#mail), an
+[here](/discover/portal/-/knowledge_base/6-2/server-administration#mail), an
 email message with the user's new password was sent to the user's email address.
 This, of course, requires that Liferay can properly communicate with your SMTP
 mail server.
@@ -167,8 +167,8 @@ add existing users to an organization.
 
 Many simple portal designs don't use organizations at all; they only use sites
 (see the sections on 
-[Web content Management](discover/portal/-/knowledge_base/6-2/web-content-management) and
-[Advanced Web Content Management](discover/portal/-/knowledge_base/6-2/advanced-web-content-management) for more information on sites). Remember that the main purpose of 
+[Web content Management](/discover/portal/-/knowledge_base/6-2/web-content-management) and
+[Advanced Web Content Management](/discover/portal/-/knowledge_base/6-2/advanced-web-content-management) for more information on sites). Remember that the main purpose of 
 organizations is to allow for distributed user management. They allow portal
 administrators to delegate some of their user management responsibilities to
 organization administrators. If you don't anticipate needing to delegate user

--- a/discover/portal/articles/17-using-the-control-panel/05-server-administration.markdown
+++ b/discover/portal/articles/17-using-the-control-panel/05-server-administration.markdown
@@ -170,7 +170,7 @@ portal.
 Instead of using your Liferay server's `portal-ext.properties` file to configure
 a mail server, you can configure a mail server from the Mail tab of the Server
 Configuration section of the Control Panel. If your portal is to receive mail
-(see, for example, our coverage of the [Message Boards portlet](discover/portal/-/knowledge_base/6-2/discuss-ask-and-answer-using-the-message-boards)
+(see, for example, our coverage of the [Message Boards portlet](/discover/portal/-/knowledge_base/6-2/discuss-ask-and-answer-using-the-message-boards)
 ), you can connect a POP mail server. If your portal is to send mail, which is
 useful for sending notifications to users, you can connect to an SMTP server.
 We highly recommend setting up mail servers for your portal.


### PR DESCRIPTION
This fixes a bunch of links.

Requires uploading these changes to the 6.2 Developer tutorials and 6.2 User docs.

cc/ @amosfong