### PR TITLE
LRDOCS-3497 Add in new Service Builder Maven command

### DIFF
--- a/develop/tutorials/articles/120-service-builder/02-service-builder-persistence/02-running-service-builder-and-understanding-the-generated-code.markdown
+++ b/develop/tutorials/articles/120-service-builder/02-service-builder-persistence/02-running-service-builder-and-understanding-the-generated-code.markdown
@@ -75,6 +75,11 @@ folder, if necessary (e.g., `../../gradlew buildService`).
 
 $$$
 
+If your module project uses Maven, you can build services running the following
+command from the module project's root folder:
+
+    mvn service-builder:build
+
 When the service has been successfully generated, a `BUILD SUCCESSFUL` message
 appears in your terminal window. You should also see that a large number of
 files have been generated in your project. These files include a model layer,


### PR DESCRIPTION
We never mentioned how to run Service Builder from Maven. The Dev Tools team renamed the command, which will be usable this week. I've added the new command to our SB tutorials, and it's referenced from our Maven SB tutorial.

Please hold on publishing this until Friday. Thanks!

https://issues.liferay.com/browse/LRDOCS-3497