### PR TITLE
LRDOCS-3581 Add ability to exclude articles from DXP dist zip

### DIFF
--- a/build-site-common.xml
+++ b/build-site-common.xml
@@ -320,7 +320,7 @@
 
 	<target name="dist-dxp" depends="dist-dxp-temp, prepare-dist, number-headers-dxp" description="Zips up the folder's CE and DXP articles and images for importing.">
 		<zip destfile="${dist.dir}/${product.abbrev}-${product.enterprise}-${product.version}-${purpose.dir}-${doc.dir}.zip">
-			<fileset dir="${temp.dir}" includes="articles/" />
+			<fileset dir="${temp.dir}" includes="articles/" excludes="${exclude}"/>
 			<fileset dir="${temp.dir}" includes="images/" />
 			<fileset dir="./" includes="${metadata.filename}" />
 		</zip>


### PR DESCRIPTION
Hey Rich;

No matter what happens with the current situation regarding the Code Upgrade Tool, I still think it's beneficial to have the capability to exclude articles from DXP Zips. This PR adds an `exclude` property, which we can set to exclude articles from a DXP Zip file.

Exclude single article:

```
ant dist-dxp -Dexclude=articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/01-adapting-to-liferay-7s-api.markdown
```

Exclude more than one article:

```
ant dist-dxp -Dexclude="articles\02-from-liferay-6-to-liferay-7\07-upgrading-plugins-to-liferay-7\01-adapting-to-liferay-7s-api.markdown, articles\02-from-liferay-6-to-liferay-7\07-upgrading-plugins-to-liferay-7\05-upgrading-themes.markdown"
```

If you think this is OK, I'll document this new property in our guidelines.

https://issues.liferay.com/browse/LRDOCS-3581