### PR TITLE
LRDOCS-3588 JSF updates due to repo reorganization | 6.2.x

### DIFF
--- a/develop/tutorials/articles/03-jsf/02-writing-a-data-driven-jsf-application/03-creating-managed-beans-to-use-services.markdown
+++ b/develop/tutorials/articles/03-jsf/02-writing-a-data-driven-jsf-application/03-creating-managed-beans-to-use-services.markdown
@@ -73,7 +73,7 @@ Now you're ready to create  the `AbstractBacking` class.
 
     These two methods deal with the success and error messaging of your
     guestbook portlet. They both create an instance of
-    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces/blob/master/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
+    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
     and add the success/error messaging to it. You'll use the
     `LiferayFacesContext` throughout your Guestbook and Entry beans, and now
     it'll be equipped with success/error messaging. 
@@ -283,7 +283,7 @@ methods to the guestbook bean.
     These methods deal directly with the `Guestbook` entities, and are triggered
     from the views, which you'll create later. Notice the `add()` and `save()`
     methods use
-    [LiferayFacesContext](https://github.com/liferay/liferay-faces/blob/master/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
+    [LiferayFacesContext](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
     to set certain parameters. You can visit the
     [Using the LiferayFacesContext with Liferay Faces Portal](/develop/tutorials/-/knowledge_base/6-2/using-the-liferayfacescontext-with-liferay-faces-portal)
     tutorial for more information on how the `LiferayFacesContext` can be used.

--- a/develop/tutorials/articles/03-jsf/03-setting-permissions/02-adding-permissions-resources-to-the-service-layer.markdown
+++ b/develop/tutorials/articles/03-jsf/03-setting-permissions/02-adding-permissions-resources-to-the-service-layer.markdown
@@ -124,7 +124,7 @@ implementing this permission check in the guestbook.
     entity.
     
     The method uses the
-    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces/blob/master/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
+    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
     to grab the
     [`ThemeDisplay`](https://github.com/liferay/liferay-portal/blob/master/portal-service/src/com/liferay/portal/theme/ThemeDisplay.java),
     and then checks if the user has the appropriate permissions to view the

--- a/develop/tutorials/articles/03-jsf/03-setting-permissions/04-updating-the-ui-with-extended-permissions-scheme.markdown
+++ b/develop/tutorials/articles/03-jsf/03-setting-permissions/04-updating-the-ui-with-extended-permissions-scheme.markdown
@@ -38,7 +38,7 @@ implementing this permission check in the guestbook.
     entity.
     
     The method uses the
-    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces/blob/6.2.x/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
+    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
     to grab the
     [`ThemeDisplay`](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-service/src/com/liferay/portal/theme/ThemeDisplay.java),
     and then checks if the user has the appropriate permissions to view the

--- a/develop/tutorials/articles/03-jsf/04-creating-entity-actions/04-adding-permissions-to-your-action-buttons.markdown
+++ b/develop/tutorials/articles/03-jsf/04-creating-entity-actions/04-adding-permissions-to-your-action-buttons.markdown
@@ -66,7 +66,7 @@ entry permissioning!
     that can be granted to users. For example, the `getDeleteable()` method
     checks if the current user has the appropriate permissions to use the Delete
     action button for the entry. The method uses the
-    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces/blob/6.2.x/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
+    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
     to grab the
     [`ThemeDisplay`](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-service/src/com/liferay/portal/theme/ThemeDisplay.java),
     and then checks if the user has the appropriate permissions to access the

--- a/develop/tutorials/articles/03-jsf/05-adding-a-portlet-to-the-control-panel/03-defining-portlet-actions-and-permissions.markdown
+++ b/develop/tutorials/articles/03-jsf/05-adding-a-portlet-to-the-control-panel/03-defining-portlet-actions-and-permissions.markdown
@@ -234,7 +234,7 @@ Guestbook Admin's `view.xhtml` file, which you'll create in the next section.
     that can be granted to users. For example, the `getUpdateable()` method
     checks if the current user has the appropriate permissions to use the Edit
     action button for the guestbook. The method uses the
-    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces/blob/master/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
+    [`LiferayFacesContext`](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/context/LiferayFacesContext.java)
     to grab the
     [`ThemeDisplay`](https://github.com/liferay/liferay-portal/blob/6.2.x/portal-service/src/com/liferay/portal/theme/ThemeDisplay.java),
     and then checks if the user has the appropriate permissions to access the

--- a/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/11-communicating-between-jsf-portlets-using-ipc.markdown
+++ b/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/11-communicating-between-jsf-portlets-using-ipc.markdown
@@ -4,8 +4,8 @@ Liferay Faces Bridge supports Portlet 2.0 Inter Portlet Communication (IPC),
 using the JSR 329/378 approach for supporting Portlet 2.0 Events and Portlet 2.0
 Public Render Parameters. 
 
-You can visit the [Liferay Faces
-Demos](http://www.liferay.com/community/liferay-projects/liferay-faces/demos)
+You can visit the
+[Liferay Faces Demos](http://www.liferay.com/community/liferay-projects/liferay-faces/demos)
 home page to see portlets that demonstrate the IPC techniques described in this
 tutorial. At that location, you'll also find portlets that implement Ajax Push
 for IPC, using ICEfaces+ICEPush and PrimeFaces+PrimePush. 
@@ -48,7 +48,7 @@ JSF model managed-beans) after the `RESTORE_VIEW` phase completes. This is
 accomplished by evaluating the EL expressions found in the
 `<model-el>...</model-el>` section of the `WEB-INF/faces-config.xml` descriptor.
 The
-[`faces-config.xml`](https://github.com/liferay/liferay-faces/blob/3.2.4-ga5/demos/bridge/jsf2-ipc-pub-render-params-portlet/src/main/webapp/WEB-INF/faces-config.xml)
+[`faces-config.xml`](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-pub-render-params-portlet/src/main/webapp/WEB-INF/faces-config.xml)
 descriptor excerpt below demonstrates using this mechanism for the example
 Customers and Bookings portlets:
 
@@ -108,8 +108,8 @@ in the `WEB-INF/portlet.xml` descriptor:
 +$$$
 
 **Note:** For a complete example demonstrating public render parameters and a
-`bridgePublicRenderParameterHandler`, see the [JSF2 IPC Public Render Parameters
-Portlet](https://github.com/liferay/liferay-faces/tree/3.1.3-ga4/demos/bridge/jsf2-ipc-pub-render-params-portlet)
+`bridgePublicRenderParameterHandler`, see the
+[JSF2 IPC Public Render Parameters Portlet](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-pub-render-params-portlet)
 demo on GitHub.
  
 $$$
@@ -137,7 +137,7 @@ the `bookingsPortlet` portlet, that portlet publishes the event and the
 `customersPortlet` portlet is notified for processing the event. 
 
 Here's a snippet from the Customers portlet's
-[`portlet.xml`](https://github.com/liferay/liferay-faces/blob/3.2.4-ga5/demos/bridge/jsf2-ipc-events-customers-portlet/src/main/webapp/WEB-INF/portlet.xml)
+[`portlet.xml`](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-events-customers-portlet/src/main/webapp/WEB-INF/portlet.xml)
 descriptor: 
 
     <portlet>
@@ -159,7 +159,7 @@ descriptor:
     </event-definition>
 
 The snippet from the Bookings portlet's
-[`portlet.xml`](https://github.com/liferay/liferay-faces/blob/3.2.4-ga5/demos/bridge/jsf2-ipc-events-bookings-portlet/src/main/webapp/WEB-INF/portlet.xml)
+[`portlet.xml`](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-events-bookings-portlet/src/main/webapp/WEB-INF/portlet.xml)
 is similar, except it is specified as a publisher: 
 
     <portlet>
@@ -189,7 +189,7 @@ necessary.
 When the customer's details (such as first name/last name) are edited in the
 Bookings portlet, the event named `ipc.customerEdited` is sent back to the
 Customers portlet and is processed by the following
-[`CustomerEditedEventHandler`](https://github.com/liferay/liferay-faces/blob/3.2.4-ga5/demos/bridge/jsf2-ipc-events-customers-portlet/src/main/java/com/liferay/faces/demos/event/CustomerEditedEventHandler.java)
+[`CustomerEditedEventHandler`](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-events-customers-portlet/src/main/java/com/liferay/faces/demos/event/CustomerEditedEventHandler.java)
 class: 
 
     ...
@@ -222,7 +222,7 @@ class:
 And here's the descriptor for registering the `CustomerEditedEventHandler` class
 as a bridge event handler for the Customers portlet. The following
 `<init-param>` belongs in the Customers portlet's `<portlet>` element, in the
-[`WEB-INF/portlet.xml`](https://github.com/liferay/liferay-faces/blob/3.2.4-ga5/demos/bridge/jsf2-ipc-events-customers-portlet/src/main/webapp/WEB-INF/portlet.xml)
+[`WEB-INF/portlet.xml`](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-events-customers-portlet/src/main/webapp/WEB-INF/portlet.xml)
 descriptor. 
 
     <init-param>
@@ -232,11 +232,10 @@ descriptor.
 
 +$$$
 
-**Note:** For a complete example demonstrating JSF 2 IPC events, see the [JSF2
-IPC Events -
-Customers](https://github.com/liferay/liferay-faces/tree/3.2.4-ga5/demos/bridge/jsf2-ipc-events-customers-portlet)
-and [JSF2 IPC Events -
-Bookings](https://github.com/liferay/liferay-faces/tree/3.2.4-ga5/demos/bridge/jsf2-ipc-events-bookings-portlet)
+**Note:** For a complete example demonstrating JSF 2 IPC events, see the
+[JSF2 IPC Events - Customers](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-events-customers-portlet)
+and
+[JSF2 IPC Events - Bookings](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-ipc-events-bookings-portlet)
 demo portlets on GitHub. 
 
 $$$

--- a/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/14-leveraging-the-portal-users-locale-with-liferay-faces-portal.markdown
+++ b/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/14-leveraging-the-portal-users-locale-with-liferay-faces-portal.markdown
@@ -5,7 +5,7 @@ By default, the
 is normally used to present internationalized JSF views is based on the
 web-browser's locale settings. In order to use the portal user's language
 preference, Liferay Faces Portal automatically registers the
-[`LiferayLocalePhaseListener`](https://github.com/liferay/liferay-faces/blob/3.2.4-ga5/portal/src/main/java/com/liferay/faces/portal/lifecycle/LiferayLocalePhaseListener.java).
+[`LiferayLocalePhaseListener`](https://github.com/liferay/liferay-faces-portal/blob/3.0.0/portal/src/main/java/com/liferay/faces/portal/lifecycle/LiferayLocalePhaseListener.java).
 This phase listener modifies the locale inside the
 [`UIViewRoot`](http://docs.oracle.com/cd/E17802_01/j2ee/javaee/javaserverfaces/2.0/docs/api/javax/faces/component/UIViewRoot.html),
 based on the user's language preference, which is accessed via the

--- a/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/97-migrating-from-liferay-faces-31-to-liferay-faces-32-42.markdown
+++ b/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/97-migrating-from-liferay-faces-31-to-liferay-faces-32-42.markdown
@@ -58,9 +58,9 @@ Turning off the parameter namespace requirement is all you need to do to upgrade
 your JSF portlets to Liferay Faces 3.2 or 4.2, for use in Liferay Portal 6.2. 
 
 As an example JSF portlet that runs on Liferay Portal 6.2, check out the
-[demo JSF2-portlet](https://github.com/liferay/liferay-faces/blob/3.2.x/demos/bridge/jsf2-portlet)
+[demo JSF Applicant portlet](https://github.com/liferay/liferay-faces-bridge-impl/tree/3.0.0/demo/jsf-applicant-portlet)
 and its 
-[`liferay-portlet.xml`](https://github.com/liferay/liferay-faces/blob/3.2.x/demos/bridge/jsf2-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml)
+[`liferay-portlet.xml`](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-applicant-portlet/src/main/webapp/WEB-INF/liferay-portlet.xml)
 file. 
 
 Your `liferay-portlet.xml` file is now migrated to Liferay Faces 3.2/4.2.

--- a/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/99-building-liferay-faces-from-source.markdown
+++ b/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/99-building-liferay-faces-from-source.markdown
@@ -7,20 +7,27 @@ project source code:
 - To investigate a suspected bug
 - To learn how Liferay Faces is implemented
 
-For this tutorial, you'l learn how to access the Liferay Faces source code and
-build it yourself. 
+For this tutorial, you'll learn how to access the Liferay Faces source code and
+build it yourself. The Liferay Faces source code is organized into several
+different Github repositories:
 
-First, you'll start with installing the liferay-faces project. 
+- [liferay-faces-alloy](https://github.com/liferay/liferay-faces-alloy)
+- [liferay-faces-bridge-api](https://github.com/liferay/liferay-faces-bridge-api)
+- [liferay-faces-bridge-ext](https://github.com/liferay/liferay-faces-bridge-ext)
+- [liferay-faces-bridge-impl](https://github.com/liferay/liferay-faces-bridge-impl)
+- [liferay-faces-maven](https://github.com/liferay/liferay-faces-maven)
+- [liferay-faces-portal](https://github.com/liferay/liferay-faces-portal)
+- [liferay-faces-showcase](https://github.com/liferay/liferay-faces-showcase)
+- [liferay-faces-util](https://github.com/liferay/liferay-faces-util)
 
-## Installing the liferay-faces Project [](id=installing-the-liferay-faces-project)
+First, you'll start with installing a Liferay Faces project. 
+
+## Installing a Liferay Faces Project [](id=installing-the-liferay-faces-project)
 
 It's important to install the version of Liferay Faces that you want. So, it's a
-good idea to check the [Liferay Faces Version
-Scheme](/develop/tutorials/-/knowledge_base/6-2/understanding-the-liferay-faces-version-scheme)
+good idea to check the
+[Liferay Faces Version Scheme](/develop/tutorials/-/knowledge_base/6-2/understanding-the-liferay-faces-version-scheme)
 to confirm the version of Liferay Faces. 
-
-<!-- Verify above link is correct, once Liferay Faces tutorials are published to
-dev.liferay.com -Cody -->
 
 You can either install the project by cloning it from GitHub or by downloading
 it as a `.zip` file. Both options are demonstrated below. 
@@ -28,51 +35,54 @@ it as a `.zip` file. Both options are demonstrated below.
 **Cloning the project from GitHub**
 
 Cloning the project requires that you [set up Git](https://help.github.com/articles/set-up-git) 
-on your machine. Once you've set up Git, you can download the liferay-faces
+on your machine. Once you've set up Git, you can download a Liferay Faces
 project from GitHub and work with a particular branch of the project, following
 these instructions: 
 
 1. Execute the following command from your terminal:
 
-        git clone https://github.com/liferay/liferay-faces.git
+        git clone https://github.com/liferay/liferay-faces-[PROJECT]
 
-2. Navigate into that directory by executing `cd liferay-faces`.
+    Replace the `[PROJECT]` variable with the Liferay Faces project you desire
+    (e.g., `liferay-faces-bridge-impl.`).
+
+2. Navigate into that directory by executing `cd liferay-faces-[PROJECT]`.
 
 3. Checkout the branch (`master` is the default branch) you want to use.
 
-    For example, to use the first milestone release of version 4.2.0, execute
-    the following command:
+    For example, to use the 3.x version of source code, execute the following
+    command:
 
-        git checkout 4.2.0-m1
+        git checkout 3.x
 
 **Downloading the project as a `.zip` file**
 
-To download the liferay-faces project as a `.zip` file, follow these
+To download the Liferay Faces project as a `.zip` file, follow these
 instructions: 
 
-1. Visit the Liferay Faces project page:
-   [https://github.com/liferay/liferay-faces](https://github.com/liferay/liferay-faces). 
+1. Visit the Liferay Faces project's Github page.
 
 2. Click on the *branch* drop-down menu and select the branch or tag for the
-   version of the liferay-faces project that you'd like to use. 
+   version of the project that you'd like to use. 
 
-3. Click on the *Download Zip* button on that right side of the page to download
-   the `[branch/tag name].zip` file for that branch or tag. 
+3. Click on the *Clone or download* &rarr; *Download ZIP* button on that right
+   side of the page to download the `[branch/tag name].zip` file for that branch
+   or tag. 
 
 4.  Extract the `.zip` file contents to a location on your machine.
 
-5. In a terminal window, navigate into the liferay-faces project's root
+5. In a terminal window, navigate into the Liferay Faces project's root
    directory: 
 
-        cd liferay-faces-[version]
+        cd liferay-faces-[PROJECT]
 
-Now that you've installed the liferay-faces project, you can configure your
+Now that you've installed the Liferay Faces project, you can configure your
 environment for building the project. In the next section of this tutorial,
 you'll explore building Liferay Faces with Maven. 
 
 ## Building Liferay Faces with Maven [](id=building-liferay-faces-with-maven)
 
-Maven is required to build the liferay-faces project. You can download Maven
+Maven is required to build the Liferay Faces project. You can download Maven
 from
 [http://maven.apache.org/download.cgi](http://maven.apache.org/download.cgi). It
 is recommended to place your Maven installation's `bin` directory in your
@@ -91,13 +101,11 @@ terminal.
 
         mvn clean package
 
-Maven builds the following Liferay Faces artifacts: 
-
-- `alloy/target/liferay-faces-alloy-[version].jar`
-- `bridge-api/target/liferay-faces-bridge-api-[version].jar`
-- `bridge-impl/target/liferay-faces-bridge-impl-[version].jar`
-- `portal/target/liferay-faces-portal-[version].jar`
-- `util/target/liferay-faces-util-[version].jar`
+Maven builds the Liferay Faces artifacts contained in that project. For example,
+running `mvn clean package` in the root folder of the
+`liferay-faces-bridge-impl` project produces the
+`bridge-impl/target/liferay-faces-bridge-impl-[version].jar`. Artifacts
+generated in other Liferay Faces projects follow a similar folder path.
 
 That's it; you've built Liferay Faces from source! 
 

--- a/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/99-building-liferay-faces-from-source.markdown
+++ b/develop/tutorials/articles/106-jsf-portlets-with-liferay-faces/99-building-liferay-faces-from-source.markdown
@@ -89,15 +89,22 @@ is recommended to place your Maven installation's `bin` directory in your
 system's `$PATH`, so you can run the Maven executable (`mvn`) easily from your
 terminal. 
 
-1. Copy the `externalLiferayFacesRepositories` `<profile>` from
-   [`settings.xml`](https://github.com/liferay/liferay-faces/blob/master/settings.xml)
-   into your local `$HOME/.m2/settings.xml` file. If you do not already have a
-   `settings.xml` file in your Maven configuration, create a `settings.xml`
-   file in your `$HOME/.m2` folder and copy the contents of the
-   [`settings.xml`](https://github.com/liferay/liferay-faces/blob/master/settings.xml)
-   file into it. 
+1. Some Liferay Faces project should rely on Liferay's repository to download
+   Maven artifacts over using Maven Central. To configure your Liferay Faces project
+   to download from Liferay's repo, add the following code snippet to your
+   `$HOME/.m2/settings.xml` file:
 
-2. Make sure you're in the liferay-faces directory and, then, build the source with Maven by executing the following command: 
+        <repositories>
+            <repository>
+                <id>liferay-public</id>
+                <url>https://repository.liferay.com/nexus/content/groups/public</url>
+        </repository>
+
+    If a `settings.xml` file does not exist in your `$HOME/.m2` folder, create
+    it and add the code snippet.
+
+2. Make sure you're in your Liferay Faces project directory and, then, build the
+   source with Maven by executing the following command: 
 
         mvn clean package
 

--- a/develop/tutorials/articles/118-liferay-faces-alloy-ui-components/00-liferay-faces-alloy-ui-components-intro.markdown
+++ b/develop/tutorials/articles/118-liferay-faces-alloy-ui-components/00-liferay-faces-alloy-ui-components-intro.markdown
@@ -13,7 +13,7 @@ a set of Facelet `UIComponent` tags as part of its component suite.
 For listings, demos, and code examples of Liferay Faces Alloy components, check
 out the [Liferay Faces Showcase](www.liferayfaces.org). To view a working
 example using Liferay Faces Alloy components, visit the
-[Liferay Faces 3 Portlet](https://github.com/liferay/liferay-faces/tree/3.2.5-ga6/demos/bridge/liferayfaces3-portlet). 
+[Alloy Applicant Portlet](https://github.com/liferay/liferay-faces-bridge-impl/tree/3.0.0/demo/alloy-applicant-portlet). 
 
 The Liferay Faces Alloy project home page can be found at
 <http://www.liferay.com/community/liferay-projects/liferay-faces/alloy>. 

--- a/discover/deployment/articles/01-installation-and-setup/16-installing-liferay-on-oracle-weblogic-12c.markdown
+++ b/discover/deployment/articles/01-installation-and-setup/16-installing-liferay-on-oracle-weblogic-12c.markdown
@@ -290,7 +290,7 @@ file:
 4. In order for JSF 2.1 portlets to deploy correctly in WebLogic, the
    `WEB-INF/weblogic.xml` descriptor must be configured to fine-tune how class
    loading takes place. For a working example, please refer to the
-   [weblogic.xml](https://github.com/liferay/liferay-faces/blob/3.2.x/demos/bridge/jsf2-portlet/src/main/webapp/WEB-INF/weblogic.xml)
+   [weblogic.xml](https://github.com/liferay/liferay-faces-bridge-impl/blob/3.0.0/demo/jsf-applicant-portlet/src/main/webapp/WEB-INF/weblogic.xml)
    descriptor from a demo JSF portlet. 
 
 5. Due to a deficiency in the XML parser that ships with WebLogic, it is


### PR DESCRIPTION
Hey Rich; due to the Liferay Faces repo being reorganized, links we pointed to were outdated. I've updated these links to point to the new repositories. I also updated the *Building from Source* article to incorporate all active repos.

@stiemannkj1 Sorry for the delay; I was on vacation last week. There are still a couple links in the learning path I need to update that references the sample [guestbook-jsf-portlet](https://github.com/codyhoag/liferay-docs/tree/6.2.x/develop/tutorials/code/02-jsf/learning-sdk/portlets/guestbook-jsf-portlet). This will take a bit more time, but I've added it to my TO-DO list.

https://issues.liferay.com/browse/LRDOCS-3588