### PR TITLE
LRDOCS-3656 removing 6.1 LCS links and mentions

### DIFF
--- a/discover/portal/articles/16-using-the-control-panel/04-server-administration.markdown
+++ b/discover/portal/articles/16-using-the-control-panel/04-server-administration.markdown
@@ -5,15 +5,6 @@ tasks related to the portal server itself, as opposed to the resources in the
 portal. Clicking the link makes this clear: you're immediately presented with a
 graph showing the resources available in the JVM.
 
-+$$$
-
-**Note:** You can use Liferay Connected Services (LCS) to obtain additional 
-performance metrics for your portal servers. See the 
-[LCS documentation](/discover/portal/-/knowledge_base/6-1/managing-liferay-with-liferay-connected-services) 
-for more information.
-
-$$$
-
 ## Resources [](id=resources)
 
 The first tab is called *Resources* . This tab contains the aforementioned graph

--- a/discover/portal/articles/17-advanced-portal-operation/05-patching-liferay.markdown
+++ b/discover/portal/articles/17-advanced-portal-operation/05-patching-liferay.markdown
@@ -126,10 +126,6 @@ replace files that are running, but of course that still leaves the old ones
 loaded in memory. So your best bet is to shut down the application server that's
 running Liferay before you install a patch. 
 
-**Note:** Liferay Connected Services (LCS) installs patches for you. See the 
-[LCS documentation](/discover/portal/-/knowledge_base/6-1/managing-liferay-with-liferay-connected-services) 
-for more information.
-
 Liferay distributes patches as `.zip` files, whether they are hotfixes or fix
 packs. When you receive one, either via a LESA ticket (hotfix) or through
 downloading a fix pack from the customer portal, you'll need to place it in the

--- a/discover/portal/articles/19-configuring-for-high-availability/02-performance-tuning.markdown
+++ b/discover/portal/articles/19-configuring-for-high-availability/02-performance-tuning.markdown
@@ -3,16 +3,7 @@
 Once you have your portal up and running, you may find a need to tune it for
 performance, especially if your site winds up generating more traffic than you'd
 anticipated. There are some definite steps you can take with regard to improving
-Liferay's performance.
-
-+$$$
-
-**Note:** You can use Liferay Connected Services (LCS) to obtain performance 
-metrics for your portal servers. See the 
-[LCS documentation](/discover/portal/-/knowledge_base/6-1/managing-liferay-with-liferay-connected-services) 
-for more information.
-
-$$$
+Liferay's performance. 
 
 ## Memory [](id=memory)
 


### PR DESCRIPTION
Since LCS is no longer supported in 6.1, this removes links and mentions to LCS in other articles.