### PR TITLE
LRDOCS-3742 removed server manager info and added kickstart gulp task.

### DIFF
--- a/develop/reference/articles/05-theme-gulp-tasks.markdown
+++ b/develop/reference/articles/05-theme-gulp-tasks.markdown
@@ -11,26 +11,15 @@ Here are the gulp tasks you can execute:
     server. 
 
 *  `deploy`: runs the `build` task and deploys the WAR file to the
-    configured local app server. 
+    configured local app server.
 
-    If you want to deploy to a live remote server, specify the `--live` flag
-    along with the `deploy` task (e.g., `gulp deploy --live`).
+    +$$$
 
-    Note that the
-    [server-manager app](https://github.com/liferay/liferay-portal/tree/master/modules/apps/foundation/server/server-manager)
-    must be deployed on the server you specify. The `--live` flag deploys
-    the theme to the remote server specified in the `init` task. The `init` task 
-    is explained later in this section.
+    **Note:** If you're running the [Felix Gogo shell](/develop/reference/-/knowledge_base/7-0/using-the-felix-gogo-shell), 
+    you can also deploy your theme using the `gulp deploy:gogo` command. **This 
+    task will NOT work for 6.2 themes.**
 
-    If you want to deploy to a different server without changing the default
-    server specified in `init`, you may use the `--url` flag.
-
-        gulp deploy --live --url http://some-host.com
-
-    You may also specify your login credentials using flags `-u` or `--username`
-    and flags `-p` or `--password`.
-
-        gulp deploy --live -u test@liferay.com -p test
+    $$$
 
 *  `extend`: allows you to specify a base theme to extend. By default, themes
     created with the [Liferay Theme Generator](https://github.com/liferay/generator-liferay-theme)
@@ -46,6 +35,12 @@ Here are the gulp tasks you can execute:
     added to your `package.json` file as dependencies. Run `npm install` to
     install them.
 
+*  `kickstart`: allows you to copy the css, images, js, and templates from 
+    another theme into the `src` directory of your own. While this is similar to 
+    the `extend` task, kickstarting from another theme is a one time inheritance, 
+    whereas extending from another theme is a dynamic inheritance that applies 
+    your src files on top of the base theme on every build.
+
 *  `init`: prompts you for local and remote app server information to use in
     theme deployment.
 
@@ -56,8 +51,8 @@ Here are the gulp tasks you can execute:
     save any changes to a file in your theme, applicable changes are compiled
     and they're copied directly to your app server. **Note:** In order for the
     `watch` task to work, you must have [Developer
-    Mode](/develop/tutorials/-/knowledge_base/6-2/using-developer-mode-with-themes)
-    enabled. <!--Update link to 7.0 URL once it's updated-->
+    Mode](/develop/tutorials/-/knowledge_base/7-0/using-developer-mode-with-themes)
+    enabled.
 
 **Related Topics**
 


### PR DESCRIPTION
@sez11a removed the remote server information since that task will not work without the Server Manager Web App (which has not been modularized for Liferay 7.0) I'm following up on this for an alternative.

Thx!