### PR TITLE
Ext Plugins Temporary change

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -10,10 +10,7 @@ The following app servers should be used for Ext plugin development in
 
 - Tomcat 8.0
 <!--
-- JBoss EAP 7.0
 - Wildfly 10.0
-- WebLogic 12.2
-- WebSphere 8.5.5
 -->
 
 In most cases, Ext plugins are no longer necessary. There are, however, certain

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -9,10 +9,12 @@ The following app servers should be used for Ext plugin development in
 @product@:
 
 - Tomcat 8.0
+<!--
 - JBoss EAP 7.0
 - Wildfly 10.0
 - WebLogic 12.2
 - WebSphere 8.5.5
+-->
 
 In most cases, Ext plugins are no longer necessary. There are, however, certain
 cases that require the use of an Ext plugin. Liferay only supports the following


### PR DESCRIPTION
QA is having new problems with app servers when testing Ext plugins. We now want to only show Tomcat as the supported app server until things are resolved. Can you publish this change at your earliest convenience? Thanks!