### PR TITLE
Remove pre-IDE 3.1 note

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/01-adapting-to-liferay-7s-api.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/01-adapting-to-liferay-7s-api.markdown
@@ -1,12 +1,5 @@
 # Adapting to @product-ver@'s API with the Code Upgrade Tool [](id=adapting-to-liferay-7s-api-with-the-code-upgrade-tool)
 
-+$$$
-
-**Important:** Liferay IDE's Code Upgrade Tool is not officially released and
-is unsupported. It's available in IDE 3.1 milestone versions only.
-
-$$$
-
 The first and easiest plugin upgrade step is adapting to 
 @product-ver@'s API. @product-ver@ is a major release whose new modular 
 architecture 


### PR DESCRIPTION
Now that IDE 3.1 GA1 is officially released, I've removed the note we had for the Code Upgrade tool being unsupported.