### PR TITLE
LRDOCS-4006 wrote intros and reorganized es2015 tutorials

### DIFF
--- a/develop/tutorials/articles/110-portlets/15-javascript/00-using-javascript-in-your-portlets-intro.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/00-using-javascript-in-your-portlets-intro.markdown
@@ -1,0 +1,7 @@
+# Using JavaScript in Your Portlets [](id=using-javascript-in-your-portlets)
+
+Would you like to use the latest ECMAScript features in your JavaScript files 
+and portlets? Do you wish you could use npm and npm packages in your portlets?
+
+In this section of tutorials you'll learn how to prepare your JavaScript files 
+to leverage these features in your portlets.

--- a/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/00-es2015-intro.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/00-es2015-intro.markdown
@@ -1,0 +1,9 @@
+# Using ES2015 in Your Portlets [](id=using-es2015-in-your-portlets)
+
+You can now write JavaScript that adheres to the new ECMAScript 2015 (ES2015)
+syntax, leverage ES2015 advanced features in your modules, and publish them. To
+do these things, you need make only minor adjustments to your JavaScript files
+and projects. 
+
+This section of tutorials shows how to prepare modules for ES2015 and use them 
+in your portlets.

--- a/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/01-preparing-your-js-files-for-es2015.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/01-preparing-your-js-files-for-es2015.markdown
@@ -1,10 +1,5 @@
 # Preparing Your JavaScript Files for ES2015 [](id=preparing-your-javascript-files-for-es2015)
 
-You can now write JavaScript that adheres to the new ECMAScript 2015 (ES2015)
-syntax, leverage ES2015 advanced features in your modules, and publish them. To
-do these things, you need make only minor adjustments to your JavaScript files
-and projects.
-
 To use the ES2015 syntax in a JavaScript file, add the extension `.es` to its
 name. For example, you rename file `filename.js` to `filename.es.js`. The
 extension indicates it uses ES2015 syntax and must therefore be transpiled by
@@ -37,7 +32,7 @@ The Module Config Generator creates the module based on this information. There
 you have it! In just a few steps you can prepare your module to leverage the
 latest JavaScript standard features and publish it.
 
-**Related Topics**
+## Related Topics [](id=related-topics)
 
 [Using ES2015 Modules in Your Portlet](/develop/tutorials/-/knowledge_base/7-0/using-es2015-modules-in-your-portlet)
 

--- a/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/02-using-es2015-modules-in-your-portlets.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/02-es2015/02-using-es2015-modules-in-your-portlets.markdown
@@ -46,7 +46,7 @@ Follow the steps below to use your exposed modules in your portlets.
 Thanks to the `aui:script` tag and its `require` attribute, using your modules
 in your portlet is a piece of cake!
 
-**Related Topics**
+## Related Topics [](id=related-topics)
 
 [Overriding a Module's JSPs](/develop/tutorials/-/knowledge_base/7-0/overriding-a-modules-jsps)
 

--- a/develop/tutorials/articles/110-portlets/15-javascript/04-npm/00-npm-portlets-intro.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/04-npm/00-npm-portlets-intro.markdown
@@ -1,4 +1,4 @@
-# Introduction [](id=introduction)
+# Using npm in Your Portlets [](id=introduction)
 
 Since Liferay DXP Fix Pack 30 and Liferay Portal 7.0 CE GA5, you can use 
 npm as your JavaScript package manager tool--including npm and npm


### PR DESCRIPTION
@sez11a this adds proper intros for the JavaScript portlets section and reorganizes them. This also reorganizes the ES2015 portlet tutorials into a their own sub-section. Please delete the old files so they are not duplicated. Thanks!