### PR TITLE
LRDOCS-4051, fixed package names, removed non-groovy stuff

### DIFF
--- a/develop/tutorials/articles/120-service-builder/02-service-builder-persistence/03-understanding-service-context.markdown
+++ b/develop/tutorials/articles/120-service-builder/02-service-builder-persistence/03-understanding-service-context.markdown
@@ -116,12 +116,12 @@ for entities in Liferay.
 
 ## Creating and Populating a Service Context in JavaScript [](id=creating-and-populating-a-service-context-in-javascript)
 
-Liferay's API can be invoked in languages other than Java, such as Beanshell,
-Groovy, JavaScript, Python, Ruby, SOAP, and JSON. Some methods of Liferay's API
-require or allow a `ServiceContext` parameter. If you're invoking such a method
-via Liferay's JSON web services, you might want to create and populate a
-`ServiceContext` object in JavaScript. Creating a `ServiceContext` object in
-JavaScript is no different from creating any other object in JavaScript.
+Liferay's API can be invoked in languages other than Java. Some methods of
+Liferay's API require or allow a `ServiceContext` parameter. If you're invoking
+such a method via Liferay's JSON web services, you might want to create and
+populate a `ServiceContext` object in JavaScript. Creating a `ServiceContext`
+object in JavaScript is no different from creating any other object in
+JavaScript.
 
 Before examining a JSON web service invocation that uses a `ServiceContext`
 object, it helps to see a simple JSON web service example in JavaScript:

--- a/develop/tutorials/articles/130-web-services/01-service-builder-web-services/05-invoking-json-web-services.markdown
+++ b/develop/tutorials/articles/130-web-services/01-service-builder-web-services/05-invoking-json-web-services.markdown
@@ -1,11 +1,9 @@
 # Invoking JSON Web Services [](id=invoking-json-web-services)
 
-You can invoke Liferay's JSON web service API in languages other than Java, such
-as Beanshell, Groovy, JavaScript, Python, and Ruby. You can also invoke it via 
-URL or 
-[cURL](http://curl.haxx.se/). 
-Additionally, Liferay provides a handy JSON web services page that allows you to 
-browse and invoke service methods. 
+If you know the URL and are connected to the internet, invoke Liferay's JSON web
+service API in any language you want or directly with the URL or
+[cURL](http://curl.haxx.se/). Additionally, Liferay provides a handy JSON web
+services page that allows you to browse and invoke service methods. 
 
 If you're running Liferay locally on port 8080, you can find the JSON web 
 services page at 

--- a/discover/portal/articles-dxp/04-business-productivity/03-using-workflow/02-kaleo-designer/00-intro.markdown
+++ b/discover/portal/articles-dxp/04-business-productivity/03-using-workflow/02-kaleo-designer/00-intro.markdown
@@ -6,16 +6,13 @@ publish must still be reviewed, for a variety of reasons. The Kaleo Designer in
 @product@ lets you design workflow definitions so your assets go through a
 review process before publication.
 
-Kaleo Designer lets you develop workflow definitions using a convenient drag
-and drop user interface, so you don't need to be familiar with any scripting
-languages or with writing XML by hand. However, some of the features can be
-enhanced if you're familiar with one of the supported scripting languages. All
-that is to say, don't be scared off when you come to a block of code in these
-articles. Just decide if you need the feature and find someone familiar with
-one of the supported scripting languages to help you out.
-
-Workflow definitions support scripting in Beanshell, DRL, Groovy, JavaScript,
-Python, or Ruby. 
+Kaleo Designer lets you develop workflow definitions using a convenient drag and
+drop user interface, so you don't need to be familiar with writing XML
+definitions by hand. However, some of the features can be enhanced if you're
+familiar with Groovy, a Java-based scripting language @product@ supports in
+its scripting engine. All that is to say, don't be scared off when you come to a
+block of code in these articles. Just decide if you need the feature and find
+someone familiar with Java or Groovy to help you out.
 
 +$$$
 

--- a/discover/portal/articles-dxp/04-business-productivity/03-using-workflow/02-kaleo-designer/04-kaleo-designer-task-nodes.markdown
+++ b/discover/portal/articles-dxp/04-business-productivity/03-using-workflow/02-kaleo-designer/04-kaleo-designer-task-nodes.markdown
@@ -16,8 +16,7 @@ already. Open its settings and give it a name as described above. Then double
 click *Actions* in the task's Settings pane.
 
 You can define a notification (often Task Assignee is appropriate), or write a
-script defining an action that's triggered for your task in Beanshell, DRL,
-Groovy, JavaScript, Python, or Ruby.
+Groovy script defining an action that's triggered for your task.
 
 Next learn about creating Assignments for your task nodes. 
 

--- a/discover/portal/articles/07-setting-up-liferay/04-scripting/01-invoking-liferay-services-from-scripts.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/04-scripting/01-invoking-liferay-services-from-scripts.markdown
@@ -1,16 +1,14 @@
 # Invoking Liferay Services From Scripts [](id=invoking-liferay-services-from-scripts)
 
-In many cases, you'll want to invoke one or more of Liferay's many services.
-This is possible from each of the supported scripting languages. Of course, the
-syntax is different for each language. 
+Many scripting scenarios require invoking @product@'s services.
 
-To illustrate the correct syntax for interacting with Liferay services, let's
-look at a simple example that uses Liferay's `UserLocalService` API to retrieve
-a list of users and then prints their names to Liferay's log file. We'll
-initially implement the example in Java pseudo-code:
+To illustrate the correct syntax for interacting with Liferay services, consider
+a simple example that uses the `UserLocalService` API to retrieve a list of
+users and print their names to Liferay's log file. We'll initially
+implement the example in Java pseudo-code:
 
-    import com.liferay.portal.model.User;
-    import com.liferay.portal.service.UserLocalServiceUtil;
+    import com.liferay.portal.kernel.model.User;
+    import com.liferay.portal.kernel.service.UserLocalServiceUtil;
     import java.util.List;
 
     ...
@@ -24,7 +22,10 @@ initially implement the example in Java pseudo-code:
 
     ...
 
-Remember that @product@'s script engine only supports Groovy by default. If you
+@product@'s script engine only supports Groovy by default. In later versions,
+support may be added for other scripting languages. 
+
+<!--If you
 want to try out the non-Groovy examples below, you need to install the
 appropriate modules:
 
@@ -58,16 +59,16 @@ because Beanshell doesn't support the use of Java Generics:
     }
  
 Next, we'll show the same thing in Groovy, another scripting language designed
-to be similar to Java. 
+to be similar to Java. -->
 
 ## Groovy [](id=groovy)
 
-Groovy is also based on Java. It's even easier than Beanshell because any code
-written in Java also runs in Groovy. This means we can execute the exact same
-code from our Java example without any changes:
+Groovy is based on Java, and code written in Java also runs in Groovy. This
+means we can execute the exact same code from our Java example without any
+changes:
 
-    import com.liferay.portal.model.User;
-    import com.liferay.portal.service.UserLocalServiceUtil;
+    import com.liferay.portal.kernel.model.User;
+    import com.liferay.portal.kernel.service.UserLocalServiceUtil;
     import java.util.List;
 
     int userCount = UserLocalServiceUtil.getUsersCount();
@@ -80,7 +81,7 @@ code from our Java example without any changes:
 Of course, we could make this somewhat Groovier by simplifying the program as
 follows: 
 
-    import com.liferay.portal.service.UserLocalServiceUtil
+    import com.liferay.portal.kernel.service.UserLocalServiceUtil
 
     userCount = UserLocalServiceUtil.getUsersCount()
     users = UserLocalServiceUtil.getUsers(0, userCount)
@@ -88,7 +89,10 @@ follows:
         System.out.println("User Name: " + user.getFullName())
     }
  
-Liferay's script engine supports more than just Java-like languages. Despite the
+Liferay's services can be easily accessed from the script console. Next, let's
+look at some practical uses for @product@'s script engine.
+
+<!-- Liferay's script engine supports more than just Java-like languages. Despite the
 name, you should be aware that JavaScript bears little resemblance to Java, but
 you can still use it in Liferay's script engine. 
 
@@ -133,11 +137,7 @@ implemented with the following code:
 
     for user in users:
         print user.getFullName()
-
-As you can see, Liferay's services can be accessed from any of these languages.
-Next, let's look at some practical examples of how you can use Liferay's script
-engine.
-
+-->
 ## Related Topics [](id=related-topics)
 
 [Running Scripts From the Script Console](/discover/portal/-/knowledge_base/7-0/running-scripts-from-the-script-console)

--- a/discover/portal/articles/07-setting-up-liferay/04-scripting/02-running-scripts-from-script-console.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/04-scripting/02-running-scripts-from-script-console.markdown
@@ -63,11 +63,8 @@ should see that all users (except the default user and your user) have been
 updated. 
 
 That's all that's needed to run scripts and to access the Liferay service layer.
-For an example of a script that accesses OSGi services from Liferay's module
-framework, please see
-[Using Custom Java Tools in the Script Engine](/discover/deployment/-/knowledge_base/7-0/using-custom-java-tools-in-the-script-engine).
-There are, however, some things to keep in mind when working with the script
-console: 
+
+Keep these things in mind when working with the script console: 
 
 - There is no undo.
 - There is no preview.


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-4051 some scripting information was wrong: package names needed to be fixed, non-groovy scripting examples removed (modules never released on MP). Some other minor fixes were made.