### PR TITLE
LRDOCS-4056 deleteWorkflowInstanceLinks in LP and Tutorial

### DIFF
--- a/develop/tutorials/articles/03-developing-a-web-application/11-workflow/01-supporting-workflow-status/01-setting-guestbook-status.markdown
+++ b/develop/tutorials/articles/03-developing-a-web-application/11-workflow/01-supporting-workflow-status/01-setting-guestbook-status.markdown
@@ -88,7 +88,25 @@ Asset Publisher or the Search portlet.
 Organize imports (*[CTRL]+[SHIFT]+O*) and save your work. Then run the
 `buildService` Gradle task.
 
-Now the guestbook entity's service layer populates the status fields in the
-database and sends the entity into the workflow framework. Do the same thing for
-guestbook entries next.
+There's one more update to make, this time in the `deleteGuestbook` method. Here
+you need to make sure the workflow system's database tables get cleaned up, to
+avoid leaving orphaned database entries when the backing entity is deleted.
+Before making the method call, open `service.xml` and add the following tag
+below the existing `<reference>` tags:
+
+    <reference entity="WorkflowInstanceLink" package-path="com.liferay.portal" />
+
+Save and run Service Builder. The `WorkflowInstanceLinkLocalService`
+service is injected into a protected variable in `GuesbookLocalServiceBaseImpl`.
+Since `GuestbookLocalServiceImpl` extends the base class, it's available to use
+directly. Back in `GuesbookLocalServiceImpl`, find the `deleteGuestbook` method
+and put this method call right before the `return` statement:
+
+    workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
+        guestbook.getCompanyId(), guestbook.getGroupId(),
+        Guestbook.class.getName(), guestbook.getGuestbookId());
+
+Save the file, and that's it. Now the guestbook entity's service layer populates
+the status fields in the database, sends the entity into the workflow framework,
+and cleans up when it's deleted. Do the same thing for guestbook entries next.
 

--- a/develop/tutorials/articles/03-developing-a-web-application/11-workflow/01-supporting-workflow-status/02-setting-entry-status.markdown
+++ b/develop/tutorials/articles/03-developing-a-web-application/11-workflow/01-supporting-workflow-status/02-setting-entry-status.markdown
@@ -60,7 +60,25 @@ service layer. Thus you'll need a corresponding `updateStatus` method here in
 
 Organize imports (*[CTRL]+[SHIFT]+O*), save your work, and run Service Builder.
 
-Now both entities support the status of the entity. There's one more update to
-make in the local service implementation classes: adding getter methods that
-take the status as a parameter. Later you'll use these methods in the view layer
-so you can display only approved guestbooks and entries. 
+As with Guestbooks, you must add a call  to `deleteWorkflowInstanceLinks` in the
+entry's delete method, to avoid leaving orhaned database entries in the
+`workflowinstancelinks` table. First add the following `<reference>` tag to
+`service.xml`, this time in the `entry` entity section, below the existing
+reference tags:
+
+    <reference entity="WorkflowInstanceLink" package-path="com.liferay.portal" />
+
+Save, run Service Builder, and then add the following method call to the
+`deleteEntry` method in `EntryLocalServiceImpl`, right before the `return`
+statement:
+
+    workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
+        entry.getCompanyId(), entry.getGroupId(),
+        Entry.class.getName(), entry.getEntryId());
+
+Now both entities support the status of the entity and can handle it as it
+enters the workflow framework and as it returns from the workflow framework.
+There's one more update to make in the local service implementation classes:
+adding getter methods that take the status as a parameter. Later you'll use
+these methods in the view layer so you can display only approved guestbooks and
+entries. 

--- a/develop/tutorials/articles/150-workflow/00-workflow-framework-intro.markdown
+++ b/develop/tutorials/articles/150-workflow/00-workflow-framework-intro.markdown
@@ -174,6 +174,18 @@ For an example of a fully implemented `updateStatus` method, see the
 `com.liferay.portlet.blogs.service.impl.BlogsEntryLocalServiceImpl` class in
 `portal-impl`.
 
+Before leaving the service layer, add a call to `deleteWorkflowInstanceLinks`
+in the `deleteEntity` method. Here's what it looks like:
+
+    workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
+        fooEntity.getCompanyId(), fooEntity.getGroupId(),
+        FooEntity.class.getName(), fooEntity.getFooEntityId());
+
+When an entity is sent to the workflow framework, (via the
+`startWorkflowInstance` call), an entry is created in the `workflowinstancelink`
+database table. This `delete` call ensures there are no orphaned entries in the
+`workflowinstancelinks` table.
+
 Once you've accounted for workflow status in your service layer, there's only
 one thing left to do: update the user interface.
 

--- a/develop/tutorials/articles/150-workflow/00-workflow-framework-intro.markdown
+++ b/develop/tutorials/articles/150-workflow/00-workflow-framework-intro.markdown
@@ -186,8 +186,15 @@ When an entity is sent to the workflow framework, (via the
 database table. This `delete` call ensures there are no orphaned entries in the
 `workflowinstancelinks` table.
 
-Once you've accounted for workflow status in your service layer, there's only
-one thing left to do: update the user interface.
+Note, to get the `WorkflowInstanceLocalService` injected into your
+`*LocalServiceBaseImpl`, so you can call its methods in the `LocalServiceImpl`,
+add this to your entity declaration in `service.xml`:
+
+		<reference entity="WorkflowInstanceLink" package-path="com.liferay.portal" />
+
+Save your work and runs Service Builder. Once you've accounted for workflow
+status in your service layer, there's only one thing left to do: update the user
+interface.
 
 ## Workflow Status and the View Layer [](id=workflow-status-and-the-view-layer)
 

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/service.xml
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/service.xml
@@ -50,6 +50,7 @@
 		
 		<reference package-path="com.liferay.portlet.asset" entity="AssetEntry" />
 		<reference package-path="com.liferay.portlet.asset" entity="AssetLink" />
+		<reference entity="WorkflowInstanceLink" package-path="com.liferay.portal" />
 		
 
 	</entity>
@@ -95,6 +96,7 @@
 
 		<reference package-path="com.liferay.portlet.asset" entity="AssetEntry" />
 		<reference package-path="com.liferay.portlet.asset" entity="AssetLink" />
+		<reference entity="WorkflowInstanceLink" package-path="com.liferay.portal" />
 		
 
 	</entity>

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/EntryLocalServiceBaseImpl.java
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/EntryLocalServiceBaseImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.service.BaseLocalServiceImpl;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.persistence.ClassNamePersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
+import com.liferay.portal.kernel.service.persistence.WorkflowInstanceLinkPersistence;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -649,6 +650,44 @@ public abstract class EntryLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
+	 * Returns the workflow instance link local service.
+	 *
+	 * @return the workflow instance link local service
+	 */
+	public com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService getWorkflowInstanceLinkLocalService() {
+		return workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Sets the workflow instance link local service.
+	 *
+	 * @param workflowInstanceLinkLocalService the workflow instance link local service
+	 */
+	public void setWorkflowInstanceLinkLocalService(
+		com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService) {
+		this.workflowInstanceLinkLocalService = workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Returns the workflow instance link persistence.
+	 *
+	 * @return the workflow instance link persistence
+	 */
+	public WorkflowInstanceLinkPersistence getWorkflowInstanceLinkPersistence() {
+		return workflowInstanceLinkPersistence;
+	}
+
+	/**
+	 * Sets the workflow instance link persistence.
+	 *
+	 * @param workflowInstanceLinkPersistence the workflow instance link persistence
+	 */
+	public void setWorkflowInstanceLinkPersistence(
+		WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence) {
+		this.workflowInstanceLinkPersistence = workflowInstanceLinkPersistence;
+	}
+
+	/**
 	 * Returns the asset entry local service.
 	 *
 	 * @return the asset entry local service
@@ -796,6 +835,10 @@ public abstract class EntryLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.kernel.service.UserLocalService userLocalService;
 	@ServiceReference(type = UserPersistence.class)
 	protected UserPersistence userPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService.class)
+	protected com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService;
+	@ServiceReference(type = WorkflowInstanceLinkPersistence.class)
+	protected WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence;
 	@ServiceReference(type = com.liferay.asset.kernel.service.AssetEntryLocalService.class)
 	protected com.liferay.asset.kernel.service.AssetEntryLocalService assetEntryLocalService;
 	@ServiceReference(type = AssetEntryPersistence.class)

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/EntryServiceBaseImpl.java
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/EntryServiceBaseImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServic
 import com.liferay.portal.kernel.service.BaseServiceImpl;
 import com.liferay.portal.kernel.service.persistence.ClassNamePersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
+import com.liferay.portal.kernel.service.persistence.WorkflowInstanceLinkPersistence;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 
@@ -321,6 +322,44 @@ public abstract class EntryServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the workflow instance link local service.
+	 *
+	 * @return the workflow instance link local service
+	 */
+	public com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService getWorkflowInstanceLinkLocalService() {
+		return workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Sets the workflow instance link local service.
+	 *
+	 * @param workflowInstanceLinkLocalService the workflow instance link local service
+	 */
+	public void setWorkflowInstanceLinkLocalService(
+		com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService) {
+		this.workflowInstanceLinkLocalService = workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Returns the workflow instance link persistence.
+	 *
+	 * @return the workflow instance link persistence
+	 */
+	public WorkflowInstanceLinkPersistence getWorkflowInstanceLinkPersistence() {
+		return workflowInstanceLinkPersistence;
+	}
+
+	/**
+	 * Sets the workflow instance link persistence.
+	 *
+	 * @param workflowInstanceLinkPersistence the workflow instance link persistence
+	 */
+	public void setWorkflowInstanceLinkPersistence(
+		WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence) {
+		this.workflowInstanceLinkPersistence = workflowInstanceLinkPersistence;
+	}
+
+	/**
 	 * Returns the asset entry local service.
 	 *
 	 * @return the asset entry local service
@@ -491,6 +530,10 @@ public abstract class EntryServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.UserService userService;
 	@ServiceReference(type = UserPersistence.class)
 	protected UserPersistence userPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService.class)
+	protected com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService;
+	@ServiceReference(type = WorkflowInstanceLinkPersistence.class)
+	protected WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence;
 	@ServiceReference(type = com.liferay.asset.kernel.service.AssetEntryLocalService.class)
 	protected com.liferay.asset.kernel.service.AssetEntryLocalService assetEntryLocalService;
 	@ServiceReference(type = com.liferay.asset.kernel.service.AssetEntryService.class)

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/GuestbookLocalServiceBaseImpl.java
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/GuestbookLocalServiceBaseImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.service.BaseLocalServiceImpl;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.persistence.ClassNamePersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
+import com.liferay.portal.kernel.service.persistence.WorkflowInstanceLinkPersistence;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -654,6 +655,44 @@ public abstract class GuestbookLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
+	 * Returns the workflow instance link local service.
+	 *
+	 * @return the workflow instance link local service
+	 */
+	public com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService getWorkflowInstanceLinkLocalService() {
+		return workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Sets the workflow instance link local service.
+	 *
+	 * @param workflowInstanceLinkLocalService the workflow instance link local service
+	 */
+	public void setWorkflowInstanceLinkLocalService(
+		com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService) {
+		this.workflowInstanceLinkLocalService = workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Returns the workflow instance link persistence.
+	 *
+	 * @return the workflow instance link persistence
+	 */
+	public WorkflowInstanceLinkPersistence getWorkflowInstanceLinkPersistence() {
+		return workflowInstanceLinkPersistence;
+	}
+
+	/**
+	 * Sets the workflow instance link persistence.
+	 *
+	 * @param workflowInstanceLinkPersistence the workflow instance link persistence
+	 */
+	public void setWorkflowInstanceLinkPersistence(
+		WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence) {
+		this.workflowInstanceLinkPersistence = workflowInstanceLinkPersistence;
+	}
+
+	/**
 	 * Returns the asset entry local service.
 	 *
 	 * @return the asset entry local service
@@ -801,6 +840,10 @@ public abstract class GuestbookLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.kernel.service.UserLocalService userLocalService;
 	@ServiceReference(type = UserPersistence.class)
 	protected UserPersistence userPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService.class)
+	protected com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService;
+	@ServiceReference(type = WorkflowInstanceLinkPersistence.class)
+	protected WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence;
 	@ServiceReference(type = com.liferay.asset.kernel.service.AssetEntryLocalService.class)
 	protected com.liferay.asset.kernel.service.AssetEntryLocalService assetEntryLocalService;
 	@ServiceReference(type = AssetEntryPersistence.class)

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/GuestbookServiceBaseImpl.java
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/base/GuestbookServiceBaseImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServic
 import com.liferay.portal.kernel.service.BaseServiceImpl;
 import com.liferay.portal.kernel.service.persistence.ClassNamePersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
+import com.liferay.portal.kernel.service.persistence.WorkflowInstanceLinkPersistence;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.spring.extender.service.ServiceReference;
 
@@ -321,6 +322,44 @@ public abstract class GuestbookServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the workflow instance link local service.
+	 *
+	 * @return the workflow instance link local service
+	 */
+	public com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService getWorkflowInstanceLinkLocalService() {
+		return workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Sets the workflow instance link local service.
+	 *
+	 * @param workflowInstanceLinkLocalService the workflow instance link local service
+	 */
+	public void setWorkflowInstanceLinkLocalService(
+		com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService) {
+		this.workflowInstanceLinkLocalService = workflowInstanceLinkLocalService;
+	}
+
+	/**
+	 * Returns the workflow instance link persistence.
+	 *
+	 * @return the workflow instance link persistence
+	 */
+	public WorkflowInstanceLinkPersistence getWorkflowInstanceLinkPersistence() {
+		return workflowInstanceLinkPersistence;
+	}
+
+	/**
+	 * Sets the workflow instance link persistence.
+	 *
+	 * @param workflowInstanceLinkPersistence the workflow instance link persistence
+	 */
+	public void setWorkflowInstanceLinkPersistence(
+		WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence) {
+		this.workflowInstanceLinkPersistence = workflowInstanceLinkPersistence;
+	}
+
+	/**
 	 * Returns the asset entry local service.
 	 *
 	 * @return the asset entry local service
@@ -491,6 +530,10 @@ public abstract class GuestbookServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.kernel.service.UserService userService;
 	@ServiceReference(type = UserPersistence.class)
 	protected UserPersistence userPersistence;
+	@ServiceReference(type = com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService.class)
+	protected com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService workflowInstanceLinkLocalService;
+	@ServiceReference(type = WorkflowInstanceLinkPersistence.class)
+	protected WorkflowInstanceLinkPersistence workflowInstanceLinkPersistence;
 	@ServiceReference(type = com.liferay.asset.kernel.service.AssetEntryLocalService.class)
 	protected com.liferay.asset.kernel.service.AssetEntryLocalService assetEntryLocalService;
 	@ServiceReference(type = com.liferay.asset.kernel.service.AssetEntryService.class)

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/impl/EntryLocalServiceImpl.java
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/impl/EntryLocalServiceImpl.java
@@ -189,6 +189,10 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 
 		assetEntryLocalService.deleteEntry(assetEntry);
 
+		workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
+			entry.getCompanyId(), entry.getGroupId(),
+			Entry.class.getName(), entry.getEntryId());
+
 		return entry;
 	}
 

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/impl/GuestbookLocalServiceImpl.java
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/java/com/liferay/docs/guestbook/service/impl/GuestbookLocalServiceImpl.java
@@ -190,6 +190,10 @@ public class GuestbookLocalServiceImpl extends GuestbookLocalServiceBaseImpl {
 
 		assetEntryLocalService.deleteEntry(assetEntry);
 
+		workflowInstanceLinkLocalService.deleteWorkflowInstanceLinks(
+			guestbook.getCompanyId(), guestbook.getGroupId(),
+			Guestbook.class.getName(), guestbook.getGuestbookId());
+
 		return guestbook;
 	}
 

--- a/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/resources/service.properties
+++ b/develop/tutorials/code/com-liferay-docs-guestbook/modules/guestbook/guestbook-service/src/main/resources/service.properties
@@ -13,6 +13,6 @@
 ##
 
     build.namespace=GB
-    build.number=42
-    build.date=1507328220980
+    build.number=45
+    build.date=1510258103003
     build.auto.upgrade=true


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-4056 added necessary call to deleteWorkflowInstanceLinks, in workflow framework tutorial and in the Learning Path Workflow section.