### PR TITLE
LRDOCS-4114

### DIFF
--- a/discover/portal/articles/07-setting-up-liferay/01-system-settings/02-configuration-files.markdown
+++ b/discover/portal/articles/07-setting-up-liferay/01-system-settings/02-configuration-files.markdown
@@ -201,6 +201,28 @@ additional configuration instance in this case, not just a renamed one.
 
 $$$
 
++$$$
+
+**Warning::** For configuration entries supporting factory configuration,
+omitting the subname from a `.config` file's name breaks the System Settings
+application's functionality (but only for the configuration entry targeted by
+the `.config` file). This is caused by a known bug. See
+[LPS-76352](https://issues.liferay.com/browse/LPS-76352) for more information.
+Once an improperly named configuration file is deployed, you won't be able to
+add any entries for the configuration in question from its System Settings
+entry. For example, if you deploy a 
+
+    com.liferay.portal.remote.cxf.common.configuration.CXFEndpointPublisherConfiguration.config
+
+file to configure a CXF Endpoint, not only will this not add a CXF Endpoint, it
+will also prevent you from adding any CXF Endpoints via System Settings.
+
+Deploying an erroneous (lacking a subname) `.config` file doesn't break anything
+permanently. Just rename the file using the proper convention described above, or
+remove it entirely and start over.
+
+$$$
+
 Now a note of warning. In many cases, configuration files can be used to force a
 factory configuration scenario, but not all configurations are designed to be
 used this way. It's best to stick to the intended use cases. Use System Settings


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-4114, bug in system settings that causes impaired functionalit when an improperly named .config file is deployed, for an entry that supports factory configuration.