### PR TITLE
Add clarifying note to User Segment documentation

### DIFF
--- a/discover/portal/articles-dxp/08-targeting-content-to-your-audience/01-managing-user-segments.markdown
+++ b/discover/portal/articles-dxp/08-targeting-content-to-your-audience/01-managing-user-segments.markdown
@@ -8,8 +8,9 @@ campaigns.
 
 A user segment represents a subset of the total group of portal users (logged in
 or not). A user segment is defined by one or more rules that users have to match
-in order to belong to that user segment. Open the Site Administration menu and
-click *Configuration* &rarr; *Audience Targeting* &rarr; *Add User Segment*
+in order to belong to that user segment. Once the user segment is created,
+only users that visit the applicable site(s) will be added to it. Open the Site
+Administration menu and click *Configuration* &rarr; *Audience Targeting* &rarr; *Add User Segment*
 (![Add User Segment](../../images-dxp/icon-add.png)) to add a new user segment.
 All the rules that have been deployed appear under the Rules heading. Drag a
 rule to the right to apply the rule to the user segment. Once a rule has been


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-4116

The "Managing User Segments" article leaves out the clarifying point that only users that visit the Site once a User Segment has been created will be tracked.

Without this important detail documented, the only place within Liferay itself that points this out in some form appears to be the error message in a "Segment Users" report when there are no segment users. This error message makes it somewhat clear, but it's a bit hidden out of the way; users are probably not likely to check "Reports" first to find out why the user segment does not have some users (and besides if it has any data, the message will not appear).

We have a customer who is confused about this functionality, and it's hard to blame them as it's not well explained. Thus we want to improve the documentation by pointing out clearly within the appropriate article that only users visiting the Site will be added to a User Segment.

Please let me know if you have any concerns with this. Thank you.