### PR TITLE
Fix Remaining Links

### DIFF
--- a/develop/reference/articles/07-screenlets-in-liferay-screens-for-android/00-intro.markdown
+++ b/develop/reference/articles/07-screenlets-in-liferay-screens-for-android/00-intro.markdown
@@ -3,7 +3,7 @@
 Liferay Screens for Android contains several Screenlets that you can use in your 
 Android apps. This section contains the reference documentation for each. If 
 you're looking for instructions on using Screens, see the 
-[Screens tutorials](/develop/tutorials/-/knowledge_base/7-0/mobile-apps-with-liferay-screens). 
+[Screens tutorials](/develop/tutorials/-/knowledge_base/7-0/android-apps-with-liferay-screens). 
 The Screens tutorials contain instructions on 
 [using Screenlets](/develop/tutorials/-/knowledge_base/7-0/using-screenlets-in-android-apps) 
 and 

--- a/develop/reference/articles/07-screenlets-in-liferay-screens-for-android/10-image-gallery-screenlet-for-android.markdown
+++ b/develop/reference/articles/07-screenlets-in-liferay-screens-for-android/10-image-gallery-screenlet-for-android.markdown
@@ -79,7 +79,7 @@ instance:
 |-----------|-----------|-------------|
 | `repositoryId` | `number` | The ID of the Liferay instance's Documents and Media repository that contains the image gallery. If you're using a site's default Documents and Media repository, then the `repositoryId` matches the site ID (`groupId`). |
 | `folderId` | `number` | The ID of the Documents and Media repository folder that contains the image gallery. When accessing the folder in your browser, the `folderId` is at the end of the URL. |
-| `cachePolicy` | `string` | The offline mode setting. See the [Offline section](/develop/reference/-/knowledge_base/7-0/gallery-screenlet-for-android#offline) for details. |
+| `cachePolicy` | `string` | The offline mode setting. See the [Offline section](/develop/reference/-/knowledge_base/7-0/image-gallery-screenlet-for-android#offline) for details. |
 | `firstPageSize` | `number` | The number of items to display on the first page. The default value is `50`. |
 | `pageSize` | `number` | The number of items to display on second and subsequent pages. The default value is `25`. |
 | `mimeTypes` | `string` | The comma-separated list of MIME types for the Screenlet to support. |

--- a/develop/reference/articles/08-screenlets-in-liferay-screens-for-ios/00-intro.markdown
+++ b/develop/reference/articles/08-screenlets-in-liferay-screens-for-ios/00-intro.markdown
@@ -3,7 +3,7 @@
 Liferay Screens for iOS contains several Screenlets that you can use in your iOS 
 apps. This section contains the reference documentation for each. If you're 
 looking for instructions on using Screens, see the 
-[Screens tutorials](/develop/tutorials/-/knowledge_base/7-0/mobile-apps-with-liferay-screens). 
+[Screens tutorials](/develop/tutorials/-/knowledge_base/7-0/ios-apps-with-liferay-screens). 
 The Screens tutorials contain instructions on 
 [using Screenlets](/develop/tutorials/-/knowledge_base/7-0/using-screenlets-in-ios-apps) 
 and 

--- a/develop/reference/articles/08-screenlets-in-liferay-screens-for-ios/10-image-gallery-screenlet-for-ios.markdown
+++ b/develop/reference/articles/08-screenlets-in-liferay-screens-for-ios/10-image-gallery-screenlet-for-ios.markdown
@@ -83,7 +83,7 @@ instance:
 | `folderId` | `number` | The ID of the Documents and Media repository folder that contains the image gallery. When accessing the folder in your browser, the `folderId` is at the end of the URL. |
 | `mimeTypes` | `string` | The comma-separated list of MIME types for the Screenlet to support. |
 | `filePrefix` | `string` | The prefix to use on uploaded image file names. |
-| `offlinePolicy` | `string` | The offline mode setting. The default value is `remote-first`. See the [Offline section](/develop/reference/-/knowledge_base/7-0/gallery-screenlet-for-ios#offline) for details. |
+| `offlinePolicy` | `string` | The offline mode setting. The default value is `remote-first`. See the [Offline section](/develop/reference/-/knowledge_base/7-0/image-gallery-screenlet-for-ios#offline) for details. |
 | `autoLoad` | `boolean` | Whether the list automatically loads when the Screenlet appears in the app's UI. The default value is `true`. |
 | `refreshControl` | `boolean` | Whether a standard [iOS `UIRefreshControl`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIRefreshControl_class/) appears when the user does the pull to refresh gesture. The default value is `true`. |
 | `firstPageSize` | `number` | The number of items to display on the first page. The default value is `50`. |

--- a/develop/tutorials/articles/160-import-export-and-staging/02-understanding-staged-models.markdown
+++ b/develop/tutorials/articles/160-import-export-and-staging/02-understanding-staged-models.markdown
@@ -97,7 +97,7 @@ Because the UUID always remains the same, it's unique across multiple systems.
 Why is this so important?
 
 Suppose you're using
-[remote staging](/discover/portal/-/knowledge_base/7-0/enabling-staging#enabling-remote-live-staging)
+[remote staging](/discover/portal/-/knowledge_base/7-0/enabling-remote-live-staging)
 and you create a new entity on your local staging site and publish it to your
 remote live site. What happens when you go back to modify the entity on your
 local site and want to publish those changes? Without a UUID, the Staging

--- a/distribute/publish/articles/01-publishing-your-app/02-preparing-your-app.markdown
+++ b/distribute/publish/articles/01-publishing-your-app/02-preparing-your-app.markdown
@@ -3,7 +3,7 @@
 As a Liferay developer, you're undoubtedly already familiar with the concept of
 plugins (portlets, themes, etc). If you're not familiar with Liferay
 plugins, see the 
-[introductory section of Liferay developer tutorials](/develop/tutorials/-/knowledge_base/7-0/introduction).
+[introductory section of Liferay developer tutorials](/develop/tutorials/-/knowledge_base/7-0/introduction-to-liferay-development).
 A *Liferay App* (sometimes just called an *app*) is a collection of one or more
 of these plugins, packaged together to represent the full functionality of an
 application on the Liferay platform. In addition to the plugins contained within
@@ -271,7 +271,7 @@ them. Therefore, most of the requirements are the same as those that exist for
 other Liferay plugins, as explained in the tutorials on creating
 [MVC Portlets](/develop/tutorials/-/knowledge_base/7-0/liferay-mvc-portlet)
 and 
-[JSF Portlets](/develop/tutorials/-/knowledge_base/7-0/packaging-a-jsf-application).
+[JSF Portlets](/develop/tutorials/-/knowledge_base/7-0/jsf-portlets-with-liferay-faces).
 
 In addition to those requirements, there are some Marketplace-specific ones to
 keep in mind:


### PR DESCRIPTION
This fixes the remainder of the broken relative links. All relative links are now correct in the `7.0.x` branch for the first time. This will give us a clean slate to work from for our upcoming migration to 7.1.