### PR TITLE
LRDOCS-4070 NPMResolver APIs

### DIFF
--- a/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/00-using-npmresolver-api-intro.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/00-using-npmresolver-api-intro.markdown
@@ -3,7 +3,7 @@
 If you're developing an npm-based portlet, your OSGi bundle's `package.json` is 
 a treasure-trove of information. It contains everything that's stored in the 
 npm registry about your bundle: default entry point, dependencies, modules, 
-package names, versions, and more. @product@'s 
+package names, versions, and more. Since Liferay DXP Fix Pack 37 and Liferay Portal 7.0 CE GA6, @product@'s 
 [`NPMResolver` APIs](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html) 
 expose this information so you can access it in your portlet. If it's defined
 in the OSGi bundle's `package.json`, you can retrieve the information in your

--- a/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/00-using-npmresolver-api-intro.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/00-using-npmresolver-api-intro.markdown
@@ -1,0 +1,39 @@
+# Using the NPMResolver API in Your Portlets [](id=using-the-npmresolver-api-in-your-portlets)
+
+If you're developing an npm-based portlet, your OSGi bundle's `package.json` is 
+a treasure-trove of information. It contains everything that's stored in the 
+npm registry about your bundle: default entry point, dependencies, modules, 
+package names, versions, and more. @product@'s 
+[`NPMResolver` APIs](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html) 
+expose this information so you can access it in your portlet. If it's defined
+in the OSGi bundle's `package.json`, you can retrieve the information in your
+portlet with the `NPMResolver` API. For instance, you can use this API to 
+[reference an npm package's static resources](/develop/tutorials/-/knowledge_base/7-0/obtaining-dependency-npm-package-descriptors) 
+(such as CSS files) and even to
+[make your code more maintainable](/develop/tutorials/-/knowledge_base/7-0/obtaining-npm-package-descriptors#using-an-alias-to-reference-a-modules-package). 
+
+To enable the `NPMResolver` in your portlet, use the `@Reference` annotation to 
+inject the `NPMResolver` OSGi component into your portlet's Component class, as 
+shown below:
+
+    import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
+
+    public class MyPortlet extends MVCPortlet {
+      
+      @Reference
+      private NPMResolver `_npmResolver`;
+      
+    }
+
++$$$
+
+**Note:** Because the `NPMResolver` reference is tied directly to the OSGi 
+bundle's `package.json` file, it can only be used to retrieve npm module and 
+package information from that file. You can't use the `NPMResolver` to retrieve 
+npm package information for other OSGi bundles.
+
+$$$
+ 
+Now that the `NPMResolver` is added to your portlet, the tutorials in this
+section describe retrieving your OSGi bundle's npm package and module
+information.

--- a/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/01-obtaining-osgi-bundle-npm-package-descriptors.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/01-obtaining-osgi-bundle-npm-package-descriptors.markdown
@@ -1,0 +1,103 @@
+# Referencing an npm Module's Package to Improve Code Maintenance [](id=referencing-an-npm-modules-package)
+
+Once you've 
+[exposed your modules](/develop/tutorials/-/knowledge_base/7-0/preparing-your-javascript-files-for-es2015), 
+you can use them in your portlet via the `aui:script` tag's `require` 
+attribute. By default, @product@ automatically composes an npm module's 
+JavaScript variable based on its name. For example, the module 
+`my-package@1.0.0` translates to the variable `myPackage100` for the 
+`<aui:script>` tag's `require` attribute. This means that each time a new 
+version of the OSGi bundle's npm package is released, you must update your 
+code's variable to reflect the new version. You can use the
+[`JSPackage` interface](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/JSPackage.html) 
+to obtain the module's package name and create an alias to reference it, so the 
+variable name always reflects the latest version number! 
+
+Follow these steps:
+
+1.  Retrieve a reference to the OSGi bundle's npm package using the 
+    [`getJSPackage()` method](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html#getJSPackage): 
+
+        JSPackage jsPackage = _npmResolver.getJSPackage();
+
+2.  Grab the npm package's resolved ID (the current package version, 
+    in the format `<package name>@<version>`, defined in the OSGi module's 
+    `package.json`) using the 
+    [`getResolvedId()` method](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/JSPackage.html#getResolvedId) 
+    and alias it with the `as myVariableName` pattern. The example below 
+    retrieves the npm module's resolved ID, sets it to the `bootstrapRequire` 
+    variable, and assigns the entire value to the attribute `bootstrapRequire`. 
+    This ensures that the package version is always up to date:
+
+        renderRequest.setAttribute(
+          "bootstrapRequire",
+          jsPackage.getResolvedId() + " as bootstrapRequire");
+ 
+3.  Include the reference to the 
+    [`NPMResolver`](ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html):
+
+        @Reference
+        private NPMResolver _npmResolver;
+ 
+4.  Resolve the `JSPackage` and `NPMResolver` imports:
+
+        import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
+        import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
+
+5.  In the portlet's JSP, retrieve the aliased attribute (`bootstrapRequire` in 
+    the example):
+
+        <%
+        String bootstrapRequire =
+        	(String)renderRequest.getAttribute("bootstrapRequire");
+        %>
+
+6.  Finally, use the attribute as the `<aui:script>` require attribute's value:
+
+        <aui:script require="<%= bootstrapRequire %>">
+        	bootstrapRequire.default();
+        </aui:script>
+
+Below is the full example `*Portlet` class:
+	
+    public class MyPortlet extends MVCPortlet {
+    	
+    	@Override
+    	public void doView(
+    			RenderRequest renderRequest, RenderResponse renderResponse)
+    		throws IOException, PortletException {
+
+    		JSPackage jsPackage = _npmResolver.getJSPackage();
+
+    		renderRequest.setAttribute(
+    			"bootstrapRequire",
+    			jsPackage.getResolvedId() + " as bootstrapRequire");
+
+    		super.doView(renderRequest, renderResponse);
+    	}
+    	
+    	@Reference
+    	private NPMResolver _npmResolver;
+    	
+    }
+    
+And here is the corresponding example `view.jsp`:
+
+    <%
+    String bootstrapRequire =
+      (String)renderRequest.getAttribute("bootstrapRequire");
+    %>
+
+    <aui:script require="<%= bootstrapRequire %>">
+      bootstrapRequire.default();
+    </aui:script>
+
+Now you know how to reference an npm module's package!
+
+## Related Topics [](id=related-topics)
+
+[Obtaining an OSGi bundle's Dependency npm Package Descriptors](/develop/tutorials/-/knowledge_base/7-0/obtaining-dependency-npm-package-descriptors)
+
+[liferay-npm-bundler](/develop/tutorials/-/knowledge_base/7-0/liferay-npm-bundler)
+
+[How @product@ Publishes npm Packages](/develop/tutorials/-/knowledge_base/7-0/how-liferay-portal-publishes-npm-packages)

--- a/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/02-obtaining-dependency-npm-package-descriptors.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/04-npm/08-npmresolver-api/02-obtaining-dependency-npm-package-descriptors.markdown
@@ -1,0 +1,56 @@
+# Obtaining an OSGi bundle's Dependency npm Package Descriptors [](id=obtaining-dependency-npm-package-descriptors)
+
+While writing your npm portlet, you may need to reference a dependency package 
+or its modules. For instance, you can retrieve an npm dependency package 
+module's CSS file and use it in your portlet. The 
+[`NPMResolver` OSGi component](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html) 
+provides two methods for retrieving an OSGi bundle's dependency npm package 
+descriptors:
+[`getDependencyJSPackage()`](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html#getDependencyJSPackage) 
+to retrieve dependency npm packages and 
+[`resolveModuleName()`](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html#resolveModuleName) 
+to retrieve dependency npm modules. This tutorial references the `package.json` 
+below to help demonstrate these methods:
+
+    {
+    	"dependencies": {
+    		"react": "15.6.2",
+    		"react-dom": "15.6.2"
+    	},
+    	.
+    	.
+    	.
+    }
+ 
+To obtain an OSGi bundle's npm dependency package, pass the package's
+name in as the `getDependencyJSPackage()` method's argument. The example below 
+resolves the `react` dependency package:
+
+    String reactResolvedId = npmResolver.getDependencyJSPackage("react");
+ 
+`reactResolvedId`'s resulting value is `react@15.6.2`.
+
+You can use the `resolveModuleName()` method To obtain a module in an npm 
+dependency package. To do this, pass the module's relative path in as the 
+`resolveModuleName()` method's argument. The example below resolves a module 
+named `react-with-addons` for the `react` dependency package:
+
+    String resolvedModule = 
+    npmResolver.resolveModuleName("react/dist/react-with-addons");
+
+The `resolvedModule` variable evaluates to `react@15.6.2/dist/react-with-addons`. 
+You can also use this to reference static resources inside npm packages (like 
+CSS or image files), as shown in the example below:
+
+    String cssPath = npmResolver.resolveModuleName(
+          "react/lib/css/main.css"); 
+
+Now you know how to obtain an OSGi bundle's dependency npm packages descriptors!
+
+## Related Topics [](id=related-topics)
+
+[Obtaining an OSGi bundle's npm Package Descriptors](/develop/tutorials/-/knowledge_base/7-0/obtaining-npm-package-descriptors)
+
+[The Structure of OSGi Bundles Containing npm Packages](/develop/tutorials/-/knowledge_base/7-0/the-structure-of-osgi-bundles-containing-npm-packages)
+
+[How @product@ Publishes npm Packages](/develop/tutorials/-/knowledge_base/7-0/how-liferay-portal-publishes-npm-packages)


### PR DESCRIPTION
@sez11a this reverts the commit that removed the articles (so your wordsmithing and Neal's is included) and adds the proper version information. It was included in DXP FP 37 so it will be in GA6. Ready for publication. If this is not the proper way to do this please let me know.

cc @izaera cc@jbalsas