### PR TITLE
Remove execution-type element from task-timer snippet

### DIFF
--- a/discover/portal/articles/12-using-workflow/02-creating-new-workflow-definitions.markdown
+++ b/discover/portal/articles/12-using-workflow/02-creating-new-workflow-definitions.markdown
@@ -501,7 +501,6 @@ were at their desk that hadn't reviewed content assigned to them.
 					]]>
 				</script>
 				<script-language></script-language>
-				<execution-type></execution-type>
 		</action>
     </timer-actions>
 


### PR DESCRIPTION
The erroneous inclusion of an execution-type element inside a task timer has apparently caused confusion and distress in a customer and support engineer. The sooner we remove it, the better.  cc @natocesarrego