### PR TITLE
Fix ref doc links to use 7.0-latest

### DIFF
--- a/develop/new-articles/12-recycle-bin/01-recycling-entities/02-implementing-trash-handlers.markdown
+++ b/develop/new-articles/12-recycle-bin/01-recycling-entities/02-implementing-trash-handlers.markdown
@@ -4,9 +4,9 @@ Like other Liferay frameworks--such as assets and
 indexing frameworks which you just enabled--you must implement a handler class 
 for Recycle Bin. A Recycle Bin handler class manages moving entries to the 
 Recycle Bin, viewing them in the Recycle Bin, restoring them, and permanently 
-deleting them. You must implement the [`TrashHandler`](http://docs.liferay.com/portal/7.0/javadocs/com/liferay/portal/kernel/trash/TrashHandler.html)
+deleting them. You must implement the [`TrashHandler`](@platform-ref@/7.0-latest/javadocs/com/liferay/portal/kernel/trash/TrashHandler.html)
 interface for each trash-enabled entity. As a convenience, Liferay provides the
-extensible abstract class [`BaseTrashHandler`](http://docs.liferay.com/portal/7.0/javadocs/com/liferay/portal/kernel/trash/BaseTrashHandler.html).
+extensible abstract class [`BaseTrashHandler`](@platform-ref@/7.0-latest/javadocs/com/liferay/portal/kernel/trash/BaseTrashHandler.html).
 
 First create the necessary files and classes:
 

--- a/develop/reference/articles/08-screenlets-in-liferay-screens-for-ios/21-file-display-screenlet-ios.markdown
+++ b/develop/reference/articles/08-screenlets-in-liferay-screens-for-ios/21-file-display-screenlet-ios.markdown
@@ -69,7 +69,7 @@ Here are the offline mode policies that you can use with this Screenlet:
 | Attribute | Data type | Explanation |
 |-----------|-----------|-------------|
 | `assetEntryId` | `number` | The primary key of the file. | 
-| `className` | `string` | The file's fully qualified class name. Since files in a Documents and Media Library are `DLFileEntry` objects, their `className` is [`com.liferay.document.library.kernel.model.DLFileEntry`](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/document/library/kernel/model/DLFileEntry.html). The `className` and `classPK` attributes are required to instantiate the Screenlet. |
+| `className` | `string` | The file's fully qualified class name. Since files in a Documents and Media Library are `DLFileEntry` objects, their `className` is [`com.liferay.document.library.kernel.model.DLFileEntry`](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/document/library/kernel/model/DLFileEntry.html). The `className` and `classPK` attributes are required to instantiate the Screenlet. |
 | `classPK` | `number` | The file's unique identifier. The `className` and `classPK` attributes are required to instantiate the Screenlet. |
 | `autoLoad` | `boolean` | Whether the file automatically loads when the Screenlet appears in the app's UI. The default value is `true`. |
 | `offlinePolicy` | `string` | The offline mode setting. See [the Offline section](/develop/reference/-/knowledge_base/7-0/file-display-screenlet-for-ios#offline) for details. |

--- a/develop/tutorials/articles-dxp/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles-dxp/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -546,7 +546,7 @@ to the original file in @product@:
 - `ext-web/docroot/WEB-INF/liferay-portlet-ext.xml`
     - **Description:** Overrides the Liferay-specific core portlets'
       declarations. It core portlets included in @product@. Refer to the
-      [liferay-portlet-app_7_0_0.dtd](@platform-ref@/7.0/definitions/liferay-portlet-app_7_0_0.dtd.html)
+      [liferay-portlet-app_7_0_0.dtd](@platform-ref@/7.0-latest/definitions/liferay-portlet-app_7_0_0.dtd.html)
       file for details on all the available options. Use this file with care;
       the code of the portlets may be assuming some of these options to be set
       to certain values. 

--- a/develop/tutorials/articles-dxp/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles-dxp/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -243,7 +243,7 @@ significant files:
 
 - `build.xml`: The Ant build file for the Ext plugin project. 
 
-- [`docroot/WEB-INF/liferay-plugin-package.properties`](https://docs.liferay.com/portal/7.0/propertiesdoc/liferay-plugin-package_7_0_0.properties.html):
+- [`docroot/WEB-INF/liferay-plugin-package.properties`](@platform-ref@/7.0-latest/propertiesdoc/liferay-plugin-package_7_0_0.properties.html):
 Contains plugin-specific properties, including the plugin's display name,
 version, author, and license type. 
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -228,7 +228,7 @@ significant files:
 
 - `build.xml`: The Ant build file for the Ext plugin project. 
 
-- [`docroot/WEB-INF/liferay-plugin-package.properties`](https://docs.liferay.com/portal/7.0/propertiesdoc/liferay-plugin-package_7_0_0.properties.html):
+- [`docroot/WEB-INF/liferay-plugin-package.properties`](@platform-ref@/7.0-latest/propertiesdoc/liferay-plugin-package_7_0_0.properties.html):
 Contains plugin-specific properties, including the plugin's display name,
 version, author, and license type. 
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -539,7 +539,7 @@ to the original file in @product@:
 - `ext-web/docroot/WEB-INF/liferay-portlet-ext.xml`
     - **Description:** Overrides the Liferay-specific core portlets'
       declarations. It core portlets included in @product@. Refer to the
-      [liferay-portlet-app_7_0_0.dtd](@platform-ref@/7.0/definitions/liferay-portlet-app_7_0_0.dtd.html)
+      [liferay-portlet-app_7_0_0.dtd](@platform-ref@/7.0-latest/definitions/liferay-portlet-app_7_0_0.dtd.html)
       file for details on all the available options. Use this file with care;
       the code of the portlets may be assuming some of these options to be set
       to certain values. 

--- a/develop/tutorials/articles/111-customizing/01-overriding-jsps/01-jsp-overrides-using-dynamic-includes.markdown
+++ b/develop/tutorials/articles/111-customizing/01-overriding-jsps/01-jsp-overrides-using-dynamic-includes.markdown
@@ -1,7 +1,7 @@
 # JSP Overrides Using Dynamic Includes [](id=jsp-overrides-using-dynamic-includes)
 
 The
-[`liferay-util:dynamic-include` tag](@platform-ref@/7.0/taglibs/util-taglib/liferay-util/dynamic-include.html)
+[`liferay-util:dynamic-include` tag](@platform-ref@/7.0-latest/taglibs/util-taglib/liferay-util/dynamic-include.html)
 is placeholder into which you can inject content. Every JSP's dynamic include
 tag can be dynamically replaced with content. All you have to do is create a
 module that has content you want to insert, register that content with the

--- a/develop/tutorials/articles/125-data-access/02-data-scopes.markdown
+++ b/develop/tutorials/articles/125-data-access/02-data-scopes.markdown
@@ -63,7 +63,7 @@ gives you techniques to do this. Your app's scope is available:
         ...
 
 2. By calling the `getScopeGroupId()` method on the request's 
-   [`ThemeDisplay` instance](https://docs.liferay.com/portal/7.0-ga3/javadocs/portal-kernel/com/liferay/portal/kernel/theme/ThemeDisplay.html). 
+   [`ThemeDisplay` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/theme/ThemeDisplay.html). 
    This method returns your app's current scope. For example, the 
    [`EditEntryMVCActionCommand` class](https://github.com/liferay/liferay-portal/blob/7.0.x/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java) 
    in Liferay's Blogs app does this in its `subscribe` and `unsubscribe` 

--- a/develop/tutorials/articles/193-adaptive-media/02-finding-adapted-images.markdown
+++ b/develop/tutorials/articles/193-adaptive-media/02-finding-adapted-images.markdown
@@ -61,7 +61,7 @@ images.
 
 To get adapted images for a specific file version, you must call the 
 `AMImageQueryBuilder` method `forFileVersion` with a 
-[`FileVersion` object](https://docs.liferay.com/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/repository/model/FileVersion.html) 
+[`FileVersion` object](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/repository/model/FileVersion.html) 
 as an argument: 
 
     Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
@@ -70,7 +70,7 @@ as an argument:
 
 To get the adapted images for the latest approved file version, use the 
 `forFileEntry` method with a 
-[`FileEntry` object](https://docs.liferay.com/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/repository/model/FileVersion.html): 
+[`FileEntry` object](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/repository/model/FileVersion.html): 
 
     Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
         _amImageFinder.getAdaptiveMediaStream(

--- a/develop/tutorials/articles/210-application-security/06-service-access-policies.markdown
+++ b/develop/tutorials/articles/210-application-security/06-service-access-policies.markdown
@@ -72,12 +72,12 @@ Liferay itself has used to implement
 [Liferay Sync](/discover/portal/-/knowledge_base/7-0/administering-liferay-sync). 
 
 1. The Interface and `ThreadLocal` are available in the 
-   [package `com.liferay.portal.kernel.security.service.access.policy`](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/security/service/access/policy/package-summary.html).
+   [package `com.liferay.portal.kernel.security.service.access.policy`](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/security/service/access/policy/package-summary.html).
    This package provides classes for basic access to policies. For example, you can
    use the
-   [singleton `ServiceAccessPolicyManagerUtil`](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/security/service/access/policy/ServiceAccessPolicyManagerUtil.html)
+   [singleton `ServiceAccessPolicyManagerUtil`](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/security/service/access/policy/ServiceAccessPolicyManagerUtil.html)
    to obtain Service Access Policies configured in the system. You can also use the
-   [`ServiceAccessPolicyThreadLocal` class](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/security/service/access/policy/ServiceAccessPolicyThreadLocal.html)
+   [`ServiceAccessPolicyThreadLocal` class](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/security/service/access/policy/ServiceAccessPolicyThreadLocal.html)
    to set and obtain Service Access Policies granted to the current request thread.
 
    At this level, you can get a list of the configured policies to let your
@@ -88,7 +88,7 @@ Liferay itself has used to implement
    thread. When a remote client accesses an API, something must tell the
    Liferay instance which policies are assigned to this call. This
    something is in most cases an
-   [`AuthVerifier` implementation](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/security/auth/verifier/AuthVerifier.html).
+   [`AuthVerifier` implementation](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/security/auth/verifier/AuthVerifier.html).
    For example, in the case of the OAuth app, an `AuthVerifier` implementation
    assigns the policy chosen by the user in the authorization step.
 

--- a/develop/tutorials/articles/230-wysiwyg-editors/01-adding-a-wysiwyg-editor-to-a-custom-portlet.markdown
+++ b/develop/tutorials/articles/230-wysiwyg-editors/01-adding-a-wysiwyg-editor-to-a-custom-portlet.markdown
@@ -61,7 +61,7 @@ tag:
 | placeholder | `java.lang.String` | Placeholder text to display in the input editor. |
 | showSource | `java.lang.String` | Whether to enable editing the HTML source code of the content. The default value  is `true`. |
 
-See the [taglibdocs](https://docs.liferay.com/portal/7.0-latest/taglibs/util-taglib/liferay-ui/input-editor.html) 
+See the [taglibdocs](@platform-ref@/7.0-latest/taglibs/util-taglib/liferay-ui/input-editor.html) 
 for the complete list of supported attributes.
 
 As you can see, it's easy to include WYSIWYG editors in your portlets! 

--- a/develop/tutorials/articles/248-front-end-taglibs/20-liferay-ui-taglib.markdown
+++ b/develop/tutorials/articles/248-front-end-taglibs/20-liferay-ui-taglib.markdown
@@ -26,7 +26,7 @@ Now you're good to go!
 
 Each taglib has a list of attributes that can be passed to the tag. Some of
 these are required and some are optional. See the
-[taglibdocs](https://docs.liferay.com/portal/7.0-latest/taglibs/util-taglib/liferay-ui/tld-summary.html) 
+[taglibdocs](@platform-ref@/7.0-latest/taglibs/util-taglib/liferay-ui/tld-summary.html) 
 to view the requirements for each tag.
 
 The example below uses the `<liferay-ui:alert>` taglib to create a success alert

--- a/develop/tutorials/articles/248-front-end-taglibs/30-liferay-util-taglib.markdown
+++ b/develop/tutorials/articles/248-front-end-taglibs/30-liferay-util-taglib.markdown
@@ -13,7 +13,7 @@ your JSP:
     <%@ taglib prefix="liferay-util" uri="http://liferay.com/tld/util" %>
 
 Each taglib has a list of attributes that can be passed to the tag. Some of 
-these are required and some are optional. See the [taglibdocs](https://docs.liferay.com/portal/7.0-latest/taglibs/util-taglib/liferay-util/tld-summary.html) 
+these are required and some are optional. See the [taglibdocs](@platform-ref@/7.0-latest/taglibs/util-taglib/liferay-util/tld-summary.html) 
 to view the requirements for each tag.
 
 Since each of the `<liferay-util>` taglibs is unique, each tag is covered

--- a/develop/tutorials/articles/260-themes-and-layout-templates/01-themes/04-using-developer-mode-with-themes.markdown
+++ b/develop/tutorials/articles/260-themes-and-layout-templates/01-themes/04-using-developer-mode-with-themes.markdown
@@ -9,7 +9,7 @@ How does Developer Mode let you see your changes more quickly? By default,
 @product@ is optimized for performance. Developer mode optimizes your
 configuration for development instead. Here is a list of Developer Mode's key
 behavior changes and the 
-[Portal Property](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html)
+[Portal Property](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html)
 override settings that trigger them (if applicable):
 
 - CSS files are loaded individually rather than being combined and loaded as a
@@ -114,7 +114,7 @@ can improve JavaScript file loading for development.
 
 By default, JavaScript fast loading is enabled in Developer Mode 
 (`javascript.fast.load=true`). This loads the packed version of files listed in 
-the [Portal Properties](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#JavaScript) 
+the [Portal Properties](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#JavaScript) 
 `javascript.barebone.files` or `javascript.everything.files`. You can, however, 
 disable JavaScript fast loading for easier debugging for development. Just set 
 `javascript.fast.load` to `false` in your `portal.properties`, or you can 

--- a/develop/tutorials/articles/360-other-backend-frameworks/01-device-recognition-api.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/01-device-recognition-api.markdown
@@ -29,7 +29,7 @@ One important thing that you'll want to get using the Device API is the
     Device device = themeDisplay.getDevice();
 
 You can view the
-[`Device` API](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/mobile/device/Device.html).
+[`Device` API](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/mobile/device/Device.html).
 Using some of the methods from the Javadocs, here's an example that obtains a
 device's dimensions:
 

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
@@ -56,18 +56,15 @@ instances](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/k
 The configuration specifies the destination type, name, and these destination-
 related attributes: 
 
-**Maximum Queue Size**: limits the number of queued messages for the
+- *Maximum Queue Size*: limits the number of queued messages for the
 destination. 
-
-**Rejected Execution Handler**: A 
+- *Rejected Execution Handler*: A 
 [`com.liferay.portal.kernel.concurrent.RejectedExecutionHandler` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/concurrent/RejectedExecutionHandler.html)
 can take action (e.g., log warnings) regarding rejected messages when the
 destination queue is full. 
-
-**Workers Core Size**: initial number of worker threads for processing
+- *Workers Core Size*: initial number of worker threads for processing
 messages.
-
-**Workers Max Size**: limits the number of worker threads for processing 
+- *Workers Max Size*: limits the number of worker threads for processing 
 messages.
 
 The `DestinationConfiguration` class provides these static methods for creating

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
@@ -44,7 +44,7 @@ Here are the primary destination types:
         listeners also.
 
 Liferay has preconfigured destinations for various purposes. The 
-[`DestinationNames` class](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationNames.html)
+[`DestinationNames` class](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationNames.html)
 defines `String` constants for each of them. For example,
 `DestinationNames.HOT_DEPLOY` (value is  `"liferay/hot_deploy"`) is for
 deployment event messages. Since destinations are tuned for specific purposes,
@@ -52,7 +52,7 @@ don't modify them.
 
 Destinations are based on 
 [`DestinationConfiguration`
-instances](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationConfiguration.html).
+instances](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationConfiguration.html).
 The configuration specifies the destination type, name, and these destination-
 related attributes: 
 
@@ -60,7 +60,7 @@ related attributes:
 destination. 
 
 **Rejected Execution Handler**: A 
-[`com.liferay.portal.kernel.concurrent.RejectedExecutionHandler` instance](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/concurrent/RejectedExecutionHandler.html)
+[`com.liferay.portal.kernel.concurrent.RejectedExecutionHandler` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/concurrent/RejectedExecutionHandler.html)
 can take action (e.g., log warnings) regarding rejected messages when the
 destination queue is full. 
 
@@ -96,7 +96,7 @@ class that follows demonstrates these steps.
     Set any attributes that apply to the destinations you'll create with it. 
 
 2.  Create a destination by invoking the 
-    [`DestinationFactory`](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationFactory.html)
+    [`DestinationFactory`](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationFactory.html)
     method `createDestination(DestinationConfiguration)`, passing in the
     destination configuration you created in the previous step. 
 
@@ -241,7 +241,7 @@ destinations and message listeners.
 
 The Message Bus notifies Message Bus Event Listeners when destinations are
 added and removed. To register these listeners, publish a
-[`MessageBusEventListener` instance](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageBusEventListener.html)
+[`MessageBusEventListener` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageBusEventListener.html)
 to the OSGi service registry (e.g., via an `@Component` annotation).
 
     @Component(
@@ -264,10 +264,10 @@ Listening for new message listeners is easy too.
 ### Listening for new Message Listeners [](id=listening-for-new-message-listeners)
 
 The Message Bus notifies 
-[`DestinationEventListener` instances](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationEventListener.html)
+[`DestinationEventListener` instances](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationEventListener.html)
 when message listeners are either registered or unregistered to destinations. To
 register a listener to a destination, publish a 
-[`DestinationEventListener` service](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationEventListener.html)
+[`DestinationEventListener` service](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationEventListener.html)
 to the OSGi service registry, making sure to specify the destination's
 `destination.name` property.
 

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
@@ -81,7 +81,7 @@ to create a configuration for any destination type, even your own.
 
 ## Creating a Destination [](id=creating-a-destination)
 
-Message Bus destinations are based on a destination configurations and
+Message Bus destinations are based on destination configurations and
 registered as OSGi services. Message Bus detects the destination services and
 manages their associated destinations.
 

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
@@ -98,7 +98,7 @@ class that follows demonstrates these steps.
     destination configuration you created in the previous step. 
 
 3.  Register the destination as an OSGi service by invoking the
-    [`BundleContext` method `registerService`](https://osgi.org/javadoc/r4v43/core/org/osgi/framework/BundleContext.html#registerService(java.lang.Class,%20S,%20java.util.Dictionary), passing in the following parameters.
+    [`BundleContext` method `registerService`](https://osgi.org/javadoc/r4v43/core/org/osgi/framework/BundleContext.html), passing in the following parameters.
     -   Destination class `Destination.class`
     -   Your `Destination` object
     -   A `Dictionary` of properties defining the destination, including the 

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/01-message-destinations.markdown
@@ -56,15 +56,18 @@ instances](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/k
 The configuration specifies the destination type, name, and these destination-
 related attributes: 
 
-- *Maximum Queue Size*: limits the number of queued messages for the
+**Maximum Queue Size**: limits the number of queued messages for the
 destination. 
-- *Rejected Execution Handler*: A 
+
+**Rejected Execution Handler**: A 
 [`com.liferay.portal.kernel.concurrent.RejectedExecutionHandler` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/concurrent/RejectedExecutionHandler.html)
 can take action (e.g., log warnings) regarding rejected messages when the
 destination queue is full. 
-- *Workers Core Size*: initial number of worker threads for processing
+
+**Workers Core Size**: initial number of worker threads for processing
 messages.
-- *Workers Max Size*: limits the number of worker threads for processing 
+
+**Workers Max Size**: limits the number of worker threads for processing 
 messages.
 
 The `DestinationConfiguration` class provides these static methods for creating

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/02-message-listeners.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/02-message-listeners.markdown
@@ -5,7 +5,7 @@ them. That is, you must create and register a message listener for the
 destination. 
 
 To create a message listener, implement the
-[`MessageListener` interface](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageListener.html)
+[`MessageListener` interface](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageListener.html)
 and override its `receive(Message)` method to process messages your way. 
 
     public void receive(Message message) {
@@ -27,7 +27,7 @@ Here are the ways to register your listener with Message Bus:
 
 +$$$
 
-**Note**: The [`DestinationNames` class](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationNames.html)
+**Note**: The [`DestinationNames` class](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/DestinationNames.html)
 defines `String` constants for Liferay's preconfigured destinations. 
 
 $$$
@@ -64,7 +64,7 @@ to destinations.
 
 ## Registering via MessageBus [](id=registering-via-messagebus)
 
-You can use the [`MessageBus` instance](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageBus.html)
+You can use the [`MessageBus` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageBus.html)
 directly to register message listeners to destinations. You might want to do
 this if, for example, you want to create some special proxy wrappers. Here's a
 registrator that demonstrates registering a listener this way:

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/03-sending-messages.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/03-sending-messages.markdown
@@ -22,7 +22,7 @@ Start by creating a message.
 
 Here's how to create a message:
 
-1.  Call the [`Message` constructor](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/Message.html).
+1.  Call the [`Message` constructor](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/Message.html).
 
     `Message message = new Message();`
 
@@ -52,7 +52,7 @@ First, let's consider using Message Bus directly.
 
 ### Directly Using the Message Bus [](id=directly-using-the-message-bus)
 
-This method involves obtaining a [`MessageBus` instance](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageBus.html)
+This method involves obtaining a [`MessageBus` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/MessageBus.html)
 and invoking it to send messages. Here's an example of directly using Message
 Bus to send a message.
 
@@ -80,7 +80,7 @@ To send messages asynchronously, consider using
  
 ### Using SingleDestinationMessageSender [](id=using-singledestinationmessagesender)
 
-The [`SingleDestinationMessageSender` class](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SingleDestinationMessageSender.html)
+The [`SingleDestinationMessageSender` class](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SingleDestinationMessageSender.html)
 wraps the Message Bus to send messages asynchronously. This class demonstrates
 using a `SynchronousMessageSender`:
 
@@ -115,10 +115,10 @@ sends the message through the sender.
 
 ### Using a SynchronousMessageSender [](id=using-a-synchronousmessagesender)
 
-A [`SynchronousMessageSender` instance](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SynchronousMessageSender.html)
+A [`SynchronousMessageSender` instance](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SynchronousMessageSender.html)
 sends a message to the Message Bus and blocks until receiving a response or the
 response times out. A `SynchronousMessageSender` has these
-[operating modes](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SynchronousMessageSender.Mode.html):
+[operating modes](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/messaging/sender/SynchronousMessageSender.Mode.html):
 
 -   `DEFAULT`: Delivers the message in a separate thread and also provides
     timeouts, in case the message is not delivered properly.
@@ -161,7 +161,7 @@ message listener to that destination.
 
 To ensure a message sent to a destination is received by all cluster nodes, you
 must register a
-[`ClusterBridgeMessageListener`](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/cluster/messaging/ClusterBridgeMessageListener.html)
+[`ClusterBridgeMessageListener`](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/cluster/messaging/ClusterBridgeMessageListener.html)
 at that destination. This bridges the local destination to the cluster.
 
 Here's a message listener registrator that bridges a destination for
@@ -199,7 +199,7 @@ field. The `activate` method creates a `ClusterBridgeMessageListener`, sets its
 priority queue, and registers it to the destination. Messages sent to the
 destination are distributed across the cluster's JVMs. 
 
-The [`com.liferay.portal.kernel.cluster.Priority` class](@platform-ref@/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/cluster/Priority.html)
+The [`com.liferay.portal.kernel.cluster.Priority` class](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/cluster/Priority.html)
 has ten levels (`Level_1` through `Level_10`, with `Level 10` being the most
 important). Each level is a priority queue for sending messages through the
 cluster. This is similar in concept to thread priorities: `Thread.MIN_PRIORITY`,

--- a/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/03-sending-messages.markdown
+++ b/develop/tutorials/articles/360-other-backend-frameworks/04-message-bus/03-sending-messages.markdown
@@ -95,7 +95,7 @@ using a `SynchronousMessageSender`:
 
             Message message = new Message();
             message.put("myId", 12345);
-            message.put("someValue", “abcdef��?);
+            message.put("someValue", "abcdef");
 
             SingleDestinationMessageSender messageSender = 
                _messageSenderFactory.createSingleDestinationMessageSender("myDestinationName");

--- a/discover/deployment/articles-dxp/02-installing-liferay/08-installing-liferay-on-weblogic.markdown
+++ b/discover/deployment/articles-dxp/02-installing-liferay/08-installing-liferay-on-weblogic.markdown
@@ -112,7 +112,7 @@ Before installing @product@, you must set the
 [*Liferay Home*](/discover/deployment/-/knowledge_base/7-0/installing-liferay-portal#liferay-home)
 folder's location via the `liferay.home` property in a `portal-ext.properties` 
 file. You can also use this file to override 
-[other @product@ properties](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html) 
+[other @product@ properties](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html) 
 that you may need. 
 
 First, decide which directory you want to serve as Liferay Home. In WebLogic, 

--- a/discover/deployment/articles-dxp/03-configuring-liferay/03-liferay-clustering.markdown
+++ b/discover/deployment/articles-dxp/03-configuring-liferay/03-liferay-clustering.markdown
@@ -210,7 +210,7 @@ designed to replicate the cache across a cluster. Cluster Link uses
 [Ehcache](http://www.ehcache.org), 
 which has robust distributed caching support. The cache is distributed across 
 multiple @product@ nodes running concurrently. The Ehcache global settings are in the
-[`portal.properties` file](@platform-ref@/7.0/propertiesdoc/portal.properties.html#Ehcache). 
+[`portal.properties` file](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Ehcache). 
 
 By default Liferay does not copy cached entities between nodes. If an entity is
 deleted or changed, for example, Cluster Link sends an *remove* message to the

--- a/discover/deployment/articles-dxp/03-configuring-liferay/06-securing-liferay/01-saml/00-intro.markdown
+++ b/discover/deployment/articles-dxp/03-configuring-liferay/06-securing-liferay/01-saml/00-intro.markdown
@@ -151,7 +151,7 @@ that requires authentication (for example, a document that is not viewable by
 the Guest role). If the user requests a protected resource, its URL is recorded
 in the `RelayState` parameter. If the user requested `/c/portal/login`, the
 `RelayState` can be set by providing the `redirect` parameter. Otherwise, if the
-[portal property](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html)
+[portal property](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html)
 `auth.forward.by.last.path` is set to true, the last accessed path is set as the
 `RelayState`. For non-@product@ SPs, consult the vendor documentation on initiating
 SSO.

--- a/discover/deployment/articles/02-installing-liferay/02-installing-liferay-bundle.markdown
+++ b/discover/deployment/articles/02-installing-liferay/02-installing-liferay-bundle.markdown
@@ -39,13 +39,13 @@ In the Liferay Home folder there are folders for various purposes:
 file repository, and @product@'s search indexes. @product@ is initially configured
 to use the embedded HSQL database but the HSQL database is primarily intended
 for demonstration and trial purposes.
-[Portal property `jdbc.default.url`](@platform-ref@/7.0/propertiesdoc/portal.properties.html#JDBC)
+[Portal property `jdbc.default.url`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#JDBC)
 sets the Hypersonic embedded HSQL database location. 
 
 `deploy`: To auto-deploy @product@ plugins, copy them to this folder. Legacy
 style `.war` files, @product-ver@ style `.jar` files, and `.lpkg` files from
 Liferay Marketplace are supported.
-[Portal property `auto.deploy.deploy.dir`](@platform-ref@/7.0/propertiesdoc/portal.properties.html#Auto%20Deploy)
+[Portal property `auto.deploy.deploy.dir`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Auto%20Deploy)
 sets the auto-deploy location. 
 
 `license`: @product@'s copyright and version files are here.
@@ -59,7 +59,7 @@ files. To override the log file location, you must
 
 `osgi`: All the JAR files and a few configuration files for @product@'s OSGi
 runtime belong in this folder.
-[Portal property `module.framework.base.dir`](@platform-ref@/7.0/propertiesdoc/portal.properties.html#Module%20Framework)
+[Portal property `module.framework.base.dir`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
 sets the OSGi folder location. Here are its subfolders:
 
 - `configs`: Component configuration files go here

--- a/discover/deployment/articles/02-installing-liferay/02-installing-liferay-bundle.markdown
+++ b/discover/deployment/articles/02-installing-liferay/02-installing-liferay-bundle.markdown
@@ -195,7 +195,7 @@ creates a `portal-setup-wizard.properties` file which stores the settings that
 you entered. When you begin customizing your portal's configuration, however,
 you should use the `portal-ext.properties` file you created earlier. All the
 possible properties that can be placed in this file are documented in [our
-reference documentation](http://docs.liferay.com/portal/7.0/propertiesdoc).
+reference documentation](@platform-ref@/7.0-latest/propertiesdoc).
 
 +$$$
 

--- a/discover/deployment/articles/03-configuring-liferay/02-document-repository.markdown
+++ b/discover/deployment/articles/03-configuring-liferay/02-document-repository.markdown
@@ -251,7 +251,7 @@ Note that this configuration doesn't perform as well as the advanced file system
 store, because you're storing documents in a database instead of on the file
 system. But it does have the benefit of clustering well.
 For example, you can store documents and media files in your @product@ instance's
-database using DBStore. To enable DBStore, add the following [`dl.store.impl`](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Document%20Library%20Service)
+database using DBStore. To enable DBStore, add the following [`dl.store.impl`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Document%20Library%20Service)
 portal property to a `portal-ext.properties` file in your [Liferay Home](/discover/deployment/-/knowledge_base/7-0/installing-product#liferay-home):
 
     dl.store.impl=com.liferay.portal.store.db.DBStore
@@ -379,7 +379,7 @@ limitation.
 
 $$$
 
-Please refer to the [Document Library property reference](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Document%20Library%20Portlet)
+Please refer to the [Document Library property reference](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Document%20Library%20Portlet)
 for a complete list of supported customizations. You can customize features such
 as the maximum allowed size of documents and media files, the list of allowed
 file extensions, which types of files should be indexed, and more.

--- a/discover/deployment/articles/03-configuring-liferay/03-liferay-clustering.markdown
+++ b/discover/deployment/articles/03-configuring-liferay/03-liferay-clustering.markdown
@@ -220,7 +220,7 @@ designed to replicate the cache across a cluster. Cluster Link uses
 [Ehcache](http://www.ehcache.org), 
 which has robust distributed caching support. The cache is distributed across 
 multiple @product@ nodes running concurrently. The Ehcache global settings are in the
-[`portal.properties` file](@platform-ref@/7.0/propertiesdoc/portal.properties.html#Ehcache). 
+[`portal.properties` file](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Ehcache). 
 
 By default Liferay does not copy cached entities between nodes. If an entity is
 deleted or changed, for example, Cluster Link sends an *remove* message to the

--- a/discover/deployment/articles/03-configuring-liferay/05-content-delivery-network.markdown
+++ b/discover/deployment/articles/03-configuring-liferay/05-content-delivery-network.markdown
@@ -74,7 +74,7 @@ and its properties using two different methods:
 To configure your CDN via properties file, you need to create a
 `portal-ext.properties` file in your Liferay Home directory and set the
 appropriate CDN properties. You can view the CDN properties and their
-descriptions by visiting the [Content Delivery Network](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Content%20Delivery%20Network)
+descriptions by visiting the [Content Delivery Network](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Content%20Delivery%20Network)
 section of the `portal.properties` HTML document.
 
 Once you configure your CDN host, @product@ generates URLs to the static assets

--- a/discover/deployment/articles/06-upgrading-liferay/02-preparing-for-upgrade.markdown
+++ b/discover/deployment/articles/06-upgrading-liferay/02-preparing-for-upgrade.markdown
@@ -95,7 +95,7 @@ Properties in features that have been modularized have changed and must now be
 deployed separately in
 [OSGi configuration files](/discover/portal/-/knowledge_base/7-0/system-settings#exporting-and-importing-configurations). 
 The
-[7.0 portal properties reference docs](@platform-ref@/7.0/propertiesdoc/portal.properties.html)
+[7.0 portal properties reference docs](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html)
 provide property details and examples. 
 
 ## Step 5: Configuring Your Documents and Media File Store [](id=configuring-your-documents-and-media-file-store)

--- a/discover/deployment/articles/06-upgrading-liferay/03-running-the-upgrade-process.markdown
+++ b/discover/deployment/articles/06-upgrading-liferay/03-running-the-upgrade-process.markdown
@@ -383,7 +383,7 @@ plugins intended for Liferay Portal version 6.2 or earlier).
 Verify processes make sure the upgrade executed successfully. Verify processes
 in the core are automatically executed after upgrading @product@. You can also
 execute them by configuring the
-[`verify.*` portal properties](http://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Verify)
+[`verify.*` portal properties](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Verify)
 and restarting your server.
 
 Also, some modules have verify processes. To check for available verify

--- a/discover/portal/articles-dxp/110-collaboration/01-managing-documents-and-media/03-using-a-sharepoint-repository.markdown
+++ b/discover/portal/articles-dxp/110-collaboration/01-managing-documents-and-media/03-using-a-sharepoint-repository.markdown
@@ -117,14 +117,14 @@ Connector app.
 
 Let's configure @product@ for authentication.  In your [Liferay Home](/discover/deployment/-/knowledge_base/7-0/installing-liferay-portal#liferay-home),
 create a `portal-ext.properties` file, if one doesn't already exist, and add a
-[`session.store.password`](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Session)
+[`session.store.password`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Session)
 portal property set to `true`:
 
     session.store.password=true
 
 Next, make sure to authenticate the same way on both @product@ and
 the external repository. You can do so by authenticating based on screen
-name. Add the following [`company.security.auth.type`]( https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Company)
+name. Add the following [`company.security.auth.type`]( @platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Company)
 portal property to your `portal-ext.properties` file: 
 
     company.security.auth.type=screenName

--- a/discover/portal/articles/100-web-experience-management/01-starting-site-development/01-creating-sites.markdown
+++ b/discover/portal/articles/100-web-experience-management/01-starting-site-development/01-creating-sites.markdown
@@ -66,7 +66,7 @@ to let every site administrator share content across sites they manage. Some
 examples of content you can share across site include web content structures and
 templates, categories, application display templates, etc.
 
-Please refer to the [Sites Admin Portlet](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Sites%20Admin%20Portlet)
+Please refer to the [Sites Admin Portlet](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Sites%20Admin%20Portlet)
 section of Liferay's `portal.properties` file for a list of relevant
 configurable properties. For example, the
 `sites.content.sharing.with.children.enabled` property allows you to disable
@@ -612,9 +612,9 @@ properties you can use to customize the automatically created pages. You can
 customize the names of the default pages, the applications that appear on the pages,
 the themes and layout templates of the default pages, and more. Please refer to
 the
-[Default User Public Layouts](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Default%20User%20Public%20Layouts)
+[Default User Public Layouts](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Default%20User%20Public%20Layouts)
 and
-[Default User Private Layouts](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Default%20User%20Private%20Layouts)
+[Default User Private Layouts](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Default%20User%20Private%20Layouts)
 sections of the `portal.properties` file for details.
 
 +$$$

--- a/discover/portal/articles/100-web-experience-management/02-creating-web-content/01-publishing-basic-web-content.markdown
+++ b/discover/portal/articles/100-web-experience-management/02-creating-web-content/01-publishing-basic-web-content.markdown
@@ -496,7 +496,7 @@ just the content, without any of the web site navigation. This is handy for
 printing the content. Enabling ratings shows one of two ratings interfaces
 @product@ has: five stars or thumbs up and thumbs down. This can be set globally
 in the `portal-ext.properties` file. See the
-[Properties Document](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Ratings%20Tag%20Library)
+[Properties Document](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Ratings%20Tag%20Library)
 for more details about this.
 
 Enabling comments creates a discussion forum attached to your content which

--- a/discover/portal/articles/100-web-experience-management/04-publishing-content-dynamically/06-publishing-rss-feeds.markdown
+++ b/discover/portal/articles/100-web-experience-management/04-publishing-content-dynamically/06-publishing-rss-feeds.markdown
@@ -99,7 +99,7 @@ this by setting the `rss.feeds.enabled` property to `false` in your
 `portal-ext.properties` file. By default, it's set to `true`. If you keep the
 default, RSS enabled, you can make several other RSS property customizations.
 Please refer to the
-[RSS section](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#RSS)
+[RSS section](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#RSS)
 of your `portal.properties` file for details.
 
 ## Using the RSS Publisher Application [](id=using-the-rss-feeds-application)

--- a/discover/portal/articles/100-web-experience-management/04-publishing-content-dynamically/07-restoring-deleted-assets.markdown
+++ b/discover/portal/articles/100-web-experience-management/04-publishing-content-dynamically/07-restoring-deleted-assets.markdown
@@ -65,7 +65,7 @@ for all sites in the portal (default is *true*).
 held before being permanently deleted.
 
 Visit the
-[portal.properties](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Trash)
+[portal.properties](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Trash)
 file to view all of the configurable properties for the Recycle Bin.
 
 Next, you should make sure permissions are set properly for users who can

--- a/discover/portal/articles/110-collaboration/01-managing-documents-and-media/04-using-external-repositories.markdown
+++ b/discover/portal/articles/110-collaboration/01-managing-documents-and-media/04-using-external-repositories.markdown
@@ -55,14 +55,14 @@ repository types.
 
 Let's configure Liferay Portal for what's required in authentication.
 In  a `portal-ext.properties` file in your [Liferay Home](/discover/deployment/-/knowledge_base/7-0/installing-product#liferay-home),
-set a [`session.store.password`](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Session)
+set a [`session.store.password`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Session)
 portal property to `true`:
 
     session.store.password=true
 
 Next, make sure to authenticate the same way on both @product@ and
 the repository. You can do so by authenticating based on screen name. Set the
-following [`company.security.auth.type`]( https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Company)
+following [`company.security.auth.type`]( @platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Company)
 portal property: 
 
     company.security.auth.type=screenName

--- a/discover/portal/articles/110-collaboration/02-collaborating/02-creating-forums-with-message-boards.markdown
+++ b/discover/portal/articles/110-collaboration/02-collaborating/02-creating-forums-with-message-boards.markdown
@@ -279,7 +279,7 @@ You are now ready to add categories to your message boards. Click the *Add* icon
 category and a description of the category. 
 
 Categories can have different display styles. The available categories must be
-set in [portal property](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Message%20Boards%20Portlet)
+set in [portal property](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Message%20Boards%20Portlet)
 `message.boards.category.display.styles` and the default category in
 `message.boards.category.display.styles.default`. When creating a new category,
 you can select the display style you like. By default, Message Boards provides

--- a/discover/portal/articles/110-collaboration/03-social-networking/01-leveraging-social-apps-activities-tracking-and-user-connections.markdown
+++ b/discover/portal/articles/110-collaboration/03-social-networking/01-leveraging-social-apps-activities-tracking-and-user-connections.markdown
@@ -72,7 +72,7 @@ applies changes to all users' personal sites. It does not, however, provide as
 much maintainability or as many customization options as user group sites does.
 User group sites allow you to choose what's modifiable by the user.  For
 more information on the `portal-ext.properties` method, search for *Default User
-Private Layouts* and *Default User Public Layouts* in the [properties documentation](http://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html).
+Private Layouts* and *Default User Public Layouts* in the [properties documentation](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html).
 
 Because it's the recommended method, use the user group method to create the
 layouts. As an administrator, go to the Control Panel and select
@@ -175,7 +175,7 @@ API. However, this only scratches the surface of the platform's capability. It's
 also possible to develop your own implementation of @product@'s social API to 
 use different social relationships. Please refer to 
 [the @product@ Developer Tutorials](/develop/tutorials/-/knowledge_base/7-0/introduction-to-liferay-development) 
-or the  [Javadocs](http://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/social/kernel/service/package-summary.html)
+or the  [Javadocs](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/social/kernel/service/package-summary.html)
 for information about @product@'s social API. 
 
 The core social application in @product@ is Activities. It displays information

--- a/discover/portal/articles/120-forms/01-forms/02-advanced-forms.markdown
+++ b/discover/portal/articles/120-forms/01-forms/02-advanced-forms.markdown
@@ -551,7 +551,7 @@ role represents unauthenticated visitors of your site, and it makes sense that
 if you want to allow Guest users to submit forms, you're fine with your site
 members and portal users submitting forms, as well. If you want to disable the
 automatic inheritance of the Guest role permissions, there's a
-[property](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Permissions) you can set in your `portal-ext.properties` file:
+[property](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Permissions) you can set in your `portal-ext.properties` file:
 
     permissions.check.guest.enabled=false
 

--- a/discover/portal/articles/130-managing-users/02-organizations.markdown
+++ b/discover/portal/articles/130-managing-users/02-organizations.markdown
@@ -275,7 +275,7 @@ reasons an enterprise wants to configure organization types:
 ![Figure x: Make additional organization types available in the Control Panel by adding them to the `organizations.types` portal property.](../../images/organization-new-type.png)
 
 Check out the portal properties that configure the default *Organization* type
-on [docs.liferay.com](https://docs.liferay.com/portal/7.0-latest/propertiesdoc/portal.properties.html#Organizations).
+on [docs.liferay.com](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Organizations).
 
 To add another organization type called *League*, add this to
 `portal-ext.properties`:

--- a/discover/portal/articles/130-managing-users/06-password-policies.markdown
+++ b/discover/portal/articles/130-managing-users/06-password-policies.markdown
@@ -73,7 +73,7 @@ you can change the default password policy and configure it using Liferay's
 ## Default Policy Properties [](id=default-policy-properties)
 
 The Default Password Policy is set as the default and configured in Liferay's
-[portal.properties](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html#Passwords)
+[portal.properties](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Passwords)
 file. If you want to make changes, including changing the default policy, add
 whichever properties and values you choose to modify in your
 `portal-ext.properties` file, as usual. Restart Liferay and your changes will

--- a/discover/portal/articles/140-managing-apps/03-installing-apps-manually.markdown
+++ b/discover/portal/articles/140-managing-apps/03-installing-apps-manually.markdown
@@ -40,7 +40,7 @@ You can, however, change these subfolders by setting the properties
 `portal-ext.properties` file. These properties define the `[Liferay_Home]/osgi` 
 folder and its hot deploy subfolders, respectively. The default settings for 
 these properties in 
-[Liferay's `portal.properties` file](https://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html) 
+[Liferay's `portal.properties` file](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html) 
 are as follows: 
 
     module.framework.base.dir=${liferay.home}/osgi

--- a/discover/portal/articles/150-setting-up-liferay/01-system-settings/03-server-admin.markdown
+++ b/discover/portal/articles/150-setting-up-liferay/01-system-settings/03-server-admin.markdown
@@ -123,8 +123,8 @@ for debugging purposes or to check the currently running configuration.
 The portal properties tab shows an exhaustive list of the current portal
 property values, so you don't have to shut down @product@ or open the properties
 file directly. Portal properties are customizable; you can peruse the full list
-of available properties at
-[https://docs.liferay.com/portal/7.0-latest/propertiesdoc/portal.properties.html](https://docs.liferay.com/portal/7.0-latest/propertiesdoc/portal.properties.html).
+of available
+[portal properties](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html).
 
 ## CAPTCHA [](id=captcha)
 

--- a/discover/portal/articles/150-setting-up-liferay/02-instance-settings/02-instance-settings.markdown
+++ b/discover/portal/articles/150-setting-up-liferay/02-instance-settings/02-instance-settings.markdown
@@ -103,8 +103,8 @@ redirect users to their personal pages upon login. Alternatively, you can set
 the default login or logout page in a `portal-ext.properties` file with the 
 properties `default.landing.page.path` and `default.logout.page.path`, 
 respectively. For more information, see the `portal.properties` documentation 
-entries for the [Default Landing Page](http://docs.liferay.com/portal/7.0-b1/propertiesdoc/portal.properties.html#Default%20Landing%20Page) 
-and [Default Logout Page](http://docs.liferay.com/portal/7.0-b1/propertiesdoc/portal.properties.html#Default%20Logout%20Page). 
+entries for the [Default Landing Page](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Default%20Landing%20Page) 
+and [Default Logout Page](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Default%20Logout%20Page). 
 
 Under the Additional Information heading, you can specify a Legal name, ID, 
 company type, SIC code, ticker symbol, industry and industry type.
@@ -265,4 +265,3 @@ and this behavior cannot be changed by a site administrator.
 
 Next, learn to integrate existing users from other environments, such as LDAP
 servers, into Liferay.
-

--- a/discover/reference/articles/01-configuration-reference.markdown
+++ b/discover/reference/articles/01-configuration-reference.markdown
@@ -8,7 +8,7 @@ definitions and configuration defaults as you customize your portal.
 
 <p>
 <span style="font-size:18px;">
-<a href="http://docs.liferay.com/portal/7.0/propertiesdoc/portal.properties.html">
+<a href="@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html">
 portal.properties<span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
 </span>
@@ -22,7 +22,7 @@ Describes the configuration defaults for Liferay Portal.
 
 <p>
 <span style="font-size:18px;">
-<a href="http://docs.liferay.com/portal/7.0/propertiesdoc/system.properties.html">
+<a href="@platform-ref@/7.0-latest/propertiesdoc/system.properties.html">
 system.properties<span class="opens-new-window-accessible">(Opens New Window)</span>
 </a>
 </span>

--- a/guidelines/06-javadoc-guidelines.markdown
+++ b/guidelines/06-javadoc-guidelines.markdown
@@ -32,7 +32,7 @@ You can provide documentation for Java packages by writing HTML in a
 Liferay's documentation is generated on
 [docs.liferay.com](https://docs.liferay.com/), the package description will be
 available when viewing the package. For example, view the
-[com.liferay.counter.kernel.model](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/counter/kernel/model/package-summary.html)
+[com.liferay.counter.kernel.model](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/counter/kernel/model/package-summary.html)
 package's description.
 
 ## Class Comments

--- a/guidelines/06-javadoc-guidelines.markdown
+++ b/guidelines/06-javadoc-guidelines.markdown
@@ -32,7 +32,7 @@ You can provide documentation for Java packages by writing HTML in a
 Liferay's documentation is generated on
 [docs.liferay.com](https://docs.liferay.com/), the package description will be
 available when viewing the package. For example, view the
-[com.liferay.counter.kernel.model](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/counter/kernel/model/package-summary.html)
+[com.liferay.counter.kernel.model](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/counter/kernel/model/package-summary.html)
 package's description.
 
 ## Class Comments

--- a/guidelines/07-advanced-javadoc-guidelines.markdown
+++ b/guidelines/07-advanced-javadoc-guidelines.markdown
@@ -58,7 +58,7 @@ Here are some rules of thumb for initial class descriptions:
 - **Start with a verb** - Whenever possible, start an initial class description
   with verb to describe the purpose of the class.
 
-    Example ([Localization](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
+    Example ([Localization](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
     interface): `Stores and retrieves localized strings from XML, and provides
     utility methods for updating localizations from JSON, portlet requests, and
     maps.`
@@ -176,7 +176,7 @@ The preferred format for common `@since` messages are listed below.
 | New class | @since *version*
 
 For a working example, see
-[StagedModelDataHandlerRegistryUtil](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerRegistryUtil.html).
+[StagedModelDataHandlerRegistryUtil](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerRegistryUtil.html).
 
 ### @deprecated tags
 
@@ -604,7 +604,7 @@ replacement method) to make sure the link works and that it is referring to the
 intended target.
 
 For a working example, see
-[UserImpl.getDisplayURL(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-impl/com/liferay/portal/model/impl/UserImpl.html#getDisplayURL(java.lang.String,%20java.lang.String)).
+[UserImpl.getDisplayURL(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/model/impl/UserImpl.html#getDisplayURL(java.lang.String,%20java.lang.String)).
 
 **Important:** You cannot link to classes/methods in Liferay modules unless
 you're providing a class/method link in the same module it resides in.
@@ -843,7 +843,7 @@ Contents for quick lookup.
 ### Class: Initial and detailed description
 
 The
-[Localization](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
+[Localization](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
 interface demonstrates our guidelines for initial and detailed class
 descriptions well.
 
@@ -893,7 +893,7 @@ public DayAndPosition(int d, int p)
 ```
 
 For a working example, see
-[StringParser.StringParser(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/util/StringParser.html#StringParser(java.lang.String))
+[StringParser.StringParser(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/StringParser.html#StringParser(java.lang.String))
 
 ### Method: Get by primary key
 
@@ -916,7 +916,7 @@ public Organization getOrganization(long organizationId)
 ```
 
 For a working example, see
-[OrganizationService.getOrganization(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
+[OrganizationService.getOrganization(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
 
 ### Method: Deletes/Removes something
 
@@ -948,7 +948,7 @@ public long getUserIdByEmailAddress( ... , String emailAddress)
 ```
 
 For a working example, see
-[UserService.getUserByEmailAddress(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#getUserByEmailAddress(long,%20java.lang.String)).
+[UserService.getUserByEmailAddress(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#getUserByEmailAddress(long,%20java.lang.String)).
 
 ### Method: Get/search/count matching multiple fields
 
@@ -971,7 +971,7 @@ public List<DDMStructure> getStructure(long groupId, String name, String descrip
 ```
 
 For working examples, see
-[ResourceLocalServiceImpl.updateResources(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-impl/com/liferay/portal/service/impl/ResourceLocalServiceImpl.html#updateResources(long,%20long,%20java.lang.String,%20long,%20com.liferay.portal.kernel.service.permission.ModelPermissions)).
+[ResourceLocalServiceImpl.updateResources(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/ResourceLocalServiceImpl.html#updateResources(long,%20long,%20java.lang.String,%20long,%20com.liferay.portal.kernel.service.permission.ModelPermissions)).
 
 ### Method: Get/search/count by field-to-keyword matching
 
@@ -1003,7 +1003,7 @@ public List<User> search(long companyId, String firstName, String middleName, St
 ```
 
 For a working example, see
-[UserLocalService.search(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
+[UserLocalService.search(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
 
 ### Method: Returning a boolean
 
@@ -1028,7 +1028,7 @@ public boolean hasGroupUser(long groupId, long userId)
 ```
 
 For a working example, see
-[UserService.hasGroupUser(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#hasGroupUser(long,%20long)).
+[UserService.hasGroupUser(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#hasGroupUser(long,%20long)).
 
 ### Method: Returning a count
 
@@ -1040,7 +1040,7 @@ Hint, if a method name contains the word "Count" or the method returns an `int`,
 it may qualify for this pattern.
 
 For a working example, see
-[OrganizationLocalService.searchCount(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#searchCount(long,%20long,%20java.lang.String,%20java.lang.String,%20java.lang.Long,%20java.lang.Long,%20java.util.LinkedHashMap)).
+[OrganizationLocalService.searchCount(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#searchCount(long,%20long,%20java.lang.String,%20java.lang.String,%20java.lang.Long,%20java.lang.Long,%20java.util.LinkedHashMap)).
 
 ### Method: Returning a collection
 
@@ -1062,7 +1062,7 @@ public List<Organization> getUserOrganizations(long userId)
 ```
 
 For a working example, see
-[OrganizationService.getUserOrganizations(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getUserOrganizations(long)).
+[OrganizationService.getUserOrganizations(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getUserOrganizations(long)).
 
 ### Method: Returning an ordered range of values
 
@@ -1087,7 +1087,7 @@ public List<User> getSocialUsers(long userId, int type, int start, int end, Orde
 ```
 
 For a working example, see
-[UserLocalService.getSocialUsers(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
+[UserLocalService.getSocialUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
 
 ### Method: Returning ordered values NOT as a range of values
 
@@ -1128,7 +1128,7 @@ public List<User> getSocialUsers(long userId, int type, int start, int end, Orde
 ```
 
 For a working example, see
-[UserLocalService.getSocialUsers(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
+[UserLocalService.getSocialUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
 
 ### Method: Describing overloaded methods
 
@@ -1157,7 +1157,7 @@ as having additional parameters.
     ```
 
     For a working example, see the `addOrganization` methods in
-    [OrganizationServiceImpl](https://docs.liferay.com/portal/7.0/javadocs/portal-impl/com/liferay/portal/service/impl/OrganizationServiceImpl.html).
+    [OrganizationServiceImpl](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/OrganizationServiceImpl.html).
 
 - If there are 3 or more overloaded methods, focus on their distinguishing
   parameters.
@@ -1214,7 +1214,7 @@ an entities to password policies.
     *&lt;entity(s)>*, removing any other currently assigned password policies.
 
     For a working example, see
-    [UserService.addPasswordPolicyUsers(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addPasswordPolicyUsers(long,%20long[])).
+    [UserService.addPasswordPolicyUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addPasswordPolicyUsers(long,%20long[])).
 
 - Password Policy - Has
 
@@ -1222,7 +1222,7 @@ an entities to password policies.
     password policy has been assigned to the *&lt;entity>*.
 
     For a working example, see
-    [UserLocalServiceImpl.hasPasswordPolicyUser(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-impl/com/liferay/portal/service/impl/UserLocalServiceImpl.html#hasPasswordPolicyUser(long,%20long)).
+    [UserLocalServiceImpl.hasPasswordPolicyUser(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/UserLocalServiceImpl.html#hasPasswordPolicyUser(long,%20long)).
 
 - Password Policy - Unset
 
@@ -1230,7 +1230,7 @@ an entities to password policies.
     password policy.
 
     For a working example, see
-    [UserService.unsetPasswordPolicyUsers(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#unsetPasswordPolicyUsers(long,%20long[])).
+    [UserService.unsetPasswordPolicyUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#unsetPasswordPolicyUsers(long,%20long[])).
 
 ### Method: Uses a property
 
@@ -1265,7 +1265,7 @@ public Organization getOrganization(long organizationId)
 ```
 
 For a working example, see
-[OrganizationService.getOrganization(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
+[OrganizationService.getOrganization(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
 
 ### Parameter: Attribute/field
 
@@ -1284,7 +1284,7 @@ public Organization addOrganization(..., String name, String type, …)
 ```
 
 For a working example, see
-[OrganizationService.addOrganization(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#addOrganization(long,%20java.lang.String,%20java.lang.String,%20long,%20long,%20long,%20java.lang.String,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
+[OrganizationService.addOrganization(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#addOrganization(long,%20java.lang.String,%20java.lang.String,%20long,%20long,%20long,%20java.lang.String,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
 
 ### Parameter: Boolean
 
@@ -1314,7 +1314,7 @@ public User addUser(
 ```
 
 For a working example, see
-[UserService.addUser(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addUser(long,%20boolean,%20java.lang.String,%20java.lang.String,%20boolean,%20java.lang.String,%20java.lang.String,%20long,%20java.lang.String,%20java.util.Locale,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20long,%20long,%20boolean,%20int,%20int,%20int,%20java.lang.String,%20long[],%20long[],%20long[],%20long[],%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
+[UserService.addUser(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addUser(long,%20boolean,%20java.lang.String,%20java.lang.String,%20boolean,%20java.lang.String,%20java.lang.String,%20long,%20java.lang.String,%20java.util.Locale,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20long,%20long,%20boolean,%20int,%20int,%20int,%20java.lang.String,%20long[],%20long[],%20long[],%20long[],%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
 
 ### Parameter: ClassNameId
 
@@ -1347,7 +1347,7 @@ public boolean isPasswordExpired(User user)
 ```
 
 For a working example, see
-[UserLocalService.isPasswordExpired(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#isPasswordExpired(com.liferay.portal.kernel.model.User)).
+[UserLocalService.isPasswordExpired(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#isPasswordExpired(com.liferay.portal.kernel.model.User)).
 
 ### Parameter: ServiceContext
 
@@ -1414,7 +1414,7 @@ public List<User> search( ... , String firstName, String middleName, … , boole
 ```
 
 For a working example, see
-[UserLocalService.search(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
+[UserLocalService.search(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
 
 ### Parameter: Refer reader to more information
 
@@ -1434,7 +1434,7 @@ to the parameter, add a sentence with a link to that information.
 ```
 
 This example is used in comments for several of the search methods in
-[OrganizationLocalService](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html).
+[OrganizationLocalService](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html).
 
 ### Field
 
@@ -1496,7 +1496,7 @@ For ordered collection returned, mention how or what determines the order
 
 For working examples, see `DDMStructure.getStructures(long groupId, long
 classNameId, int start, int end, OrderByComparator orderByComparator)` and
-[DLAppServiceImpl.getGroupFileEntries(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-impl/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.html#getGroupFileEntries(long,%20long,%20long,%20int,%20int)).
+[DLAppServiceImpl.getGroupFileEntries(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.html#getGroupFileEntries(long,%20long,%20long,%20int,%20int)).
 
 ### Return: Significantly varying values
 
@@ -1514,4 +1514,4 @@ describing return values. This convention is not to be used with the other tags
 (e.g. `@param`, `@throws`).
 
 For a working example, see
-[OrganizationLocalService.getOrganizationId(...)](https://docs.liferay.com/portal/7.0/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#getOrganizationId(long,%20java.lang.String)).
+[OrganizationLocalService.getOrganizationId(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#getOrganizationId(long,%20java.lang.String)).

--- a/guidelines/07-advanced-javadoc-guidelines.markdown
+++ b/guidelines/07-advanced-javadoc-guidelines.markdown
@@ -58,7 +58,7 @@ Here are some rules of thumb for initial class descriptions:
 - **Start with a verb** - Whenever possible, start an initial class description
   with verb to describe the purpose of the class.
 
-    Example ([Localization](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
+    Example ([Localization](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
     interface): `Stores and retrieves localized strings from XML, and provides
     utility methods for updating localizations from JSON, portlet requests, and
     maps.`
@@ -176,7 +176,7 @@ The preferred format for common `@since` messages are listed below.
 | New class | @since *version*
 
 For a working example, see
-[StagedModelDataHandlerRegistryUtil](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerRegistryUtil.html).
+[StagedModelDataHandlerRegistryUtil](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/exportimport/kernel/lar/StagedModelDataHandlerRegistryUtil.html).
 
 ### @deprecated tags
 
@@ -604,7 +604,7 @@ replacement method) to make sure the link works and that it is referring to the
 intended target.
 
 For a working example, see
-[UserImpl.getDisplayURL(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/model/impl/UserImpl.html#getDisplayURL(java.lang.String,%20java.lang.String)).
+[UserImpl.getDisplayURL(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-impl/com/liferay/portal/model/impl/UserImpl.html#getDisplayURL(java.lang.String,%20java.lang.String)).
 
 **Important:** You cannot link to classes/methods in Liferay modules unless
 you're providing a class/method link in the same module it resides in.
@@ -843,7 +843,7 @@ Contents for quick lookup.
 ### Class: Initial and detailed description
 
 The
-[Localization](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
+[Localization](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/Localization.html)
 interface demonstrates our guidelines for initial and detailed class
 descriptions well.
 
@@ -893,7 +893,7 @@ public DayAndPosition(int d, int p)
 ```
 
 For a working example, see
-[StringParser.StringParser(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/StringParser.html#StringParser(java.lang.String))
+[StringParser.StringParser(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/util/StringParser.html#StringParser(java.lang.String))
 
 ### Method: Get by primary key
 
@@ -916,7 +916,7 @@ public Organization getOrganization(long organizationId)
 ```
 
 For a working example, see
-[OrganizationService.getOrganization(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
+[OrganizationService.getOrganization(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
 
 ### Method: Deletes/Removes something
 
@@ -948,7 +948,7 @@ public long getUserIdByEmailAddress( ... , String emailAddress)
 ```
 
 For a working example, see
-[UserService.getUserByEmailAddress(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#getUserByEmailAddress(long,%20java.lang.String)).
+[UserService.getUserByEmailAddress(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#getUserByEmailAddress(long,%20java.lang.String)).
 
 ### Method: Get/search/count matching multiple fields
 
@@ -971,7 +971,7 @@ public List<DDMStructure> getStructure(long groupId, String name, String descrip
 ```
 
 For working examples, see
-[ResourceLocalServiceImpl.updateResources(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/ResourceLocalServiceImpl.html#updateResources(long,%20long,%20java.lang.String,%20long,%20com.liferay.portal.kernel.service.permission.ModelPermissions)).
+[ResourceLocalServiceImpl.updateResources(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/ResourceLocalServiceImpl.html#updateResources(long,%20long,%20java.lang.String,%20long,%20com.liferay.portal.kernel.service.permission.ModelPermissions)).
 
 ### Method: Get/search/count by field-to-keyword matching
 
@@ -1003,7 +1003,7 @@ public List<User> search(long companyId, String firstName, String middleName, St
 ```
 
 For a working example, see
-[UserLocalService.search(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
+[UserLocalService.search(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
 
 ### Method: Returning a boolean
 
@@ -1028,7 +1028,7 @@ public boolean hasGroupUser(long groupId, long userId)
 ```
 
 For a working example, see
-[UserService.hasGroupUser(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#hasGroupUser(long,%20long)).
+[UserService.hasGroupUser(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#hasGroupUser(long,%20long)).
 
 ### Method: Returning a count
 
@@ -1040,7 +1040,7 @@ Hint, if a method name contains the word "Count" or the method returns an `int`,
 it may qualify for this pattern.
 
 For a working example, see
-[OrganizationLocalService.searchCount(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#searchCount(long,%20long,%20java.lang.String,%20java.lang.String,%20java.lang.Long,%20java.lang.Long,%20java.util.LinkedHashMap)).
+[OrganizationLocalService.searchCount(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#searchCount(long,%20long,%20java.lang.String,%20java.lang.String,%20java.lang.Long,%20java.lang.Long,%20java.util.LinkedHashMap)).
 
 ### Method: Returning a collection
 
@@ -1062,7 +1062,7 @@ public List<Organization> getUserOrganizations(long userId)
 ```
 
 For a working example, see
-[OrganizationService.getUserOrganizations(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getUserOrganizations(long)).
+[OrganizationService.getUserOrganizations(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getUserOrganizations(long)).
 
 ### Method: Returning an ordered range of values
 
@@ -1087,7 +1087,7 @@ public List<User> getSocialUsers(long userId, int type, int start, int end, Orde
 ```
 
 For a working example, see
-[UserLocalService.getSocialUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
+[UserLocalService.getSocialUsers(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
 
 ### Method: Returning ordered values NOT as a range of values
 
@@ -1128,7 +1128,7 @@ public List<User> getSocialUsers(long userId, int type, int start, int end, Orde
 ```
 
 For a working example, see
-[UserLocalService.getSocialUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
+[UserLocalService.getSocialUsers(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#getSocialUsers(long,%20long,%20int,%20int,%20int,%20com.liferay.portal.kernel.util.OrderByComparator)).
 
 ### Method: Describing overloaded methods
 
@@ -1157,7 +1157,7 @@ as having additional parameters.
     ```
 
     For a working example, see the `addOrganization` methods in
-    [OrganizationServiceImpl](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/OrganizationServiceImpl.html).
+    [OrganizationServiceImpl](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/OrganizationServiceImpl.html).
 
 - If there are 3 or more overloaded methods, focus on their distinguishing
   parameters.
@@ -1214,7 +1214,7 @@ an entities to password policies.
     *&lt;entity(s)>*, removing any other currently assigned password policies.
 
     For a working example, see
-    [UserService.addPasswordPolicyUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addPasswordPolicyUsers(long,%20long[])).
+    [UserService.addPasswordPolicyUsers(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addPasswordPolicyUsers(long,%20long[])).
 
 - Password Policy - Has
 
@@ -1222,7 +1222,7 @@ an entities to password policies.
     password policy has been assigned to the *&lt;entity>*.
 
     For a working example, see
-    [UserLocalServiceImpl.hasPasswordPolicyUser(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/UserLocalServiceImpl.html#hasPasswordPolicyUser(long,%20long)).
+    [UserLocalServiceImpl.hasPasswordPolicyUser(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-impl/com/liferay/portal/service/impl/UserLocalServiceImpl.html#hasPasswordPolicyUser(long,%20long)).
 
 - Password Policy - Unset
 
@@ -1230,7 +1230,7 @@ an entities to password policies.
     password policy.
 
     For a working example, see
-    [UserService.unsetPasswordPolicyUsers(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#unsetPasswordPolicyUsers(long,%20long[])).
+    [UserService.unsetPasswordPolicyUsers(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#unsetPasswordPolicyUsers(long,%20long[])).
 
 ### Method: Uses a property
 
@@ -1265,7 +1265,7 @@ public Organization getOrganization(long organizationId)
 ```
 
 For a working example, see
-[OrganizationService.getOrganization(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
+[OrganizationService.getOrganization(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#getOrganization(long)).
 
 ### Parameter: Attribute/field
 
@@ -1284,7 +1284,7 @@ public Organization addOrganization(..., String name, String type, …)
 ```
 
 For a working example, see
-[OrganizationService.addOrganization(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#addOrganization(long,%20java.lang.String,%20java.lang.String,%20long,%20long,%20long,%20java.lang.String,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
+[OrganizationService.addOrganization(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationService.html#addOrganization(long,%20java.lang.String,%20java.lang.String,%20long,%20long,%20long,%20java.lang.String,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
 
 ### Parameter: Boolean
 
@@ -1314,7 +1314,7 @@ public User addUser(
 ```
 
 For a working example, see
-[UserService.addUser(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addUser(long,%20boolean,%20java.lang.String,%20java.lang.String,%20boolean,%20java.lang.String,%20java.lang.String,%20long,%20java.lang.String,%20java.util.Locale,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20long,%20long,%20boolean,%20int,%20int,%20int,%20java.lang.String,%20long[],%20long[],%20long[],%20long[],%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
+[UserService.addUser(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserService.html#addUser(long,%20boolean,%20java.lang.String,%20java.lang.String,%20boolean,%20java.lang.String,%20java.lang.String,%20long,%20java.lang.String,%20java.util.Locale,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20long,%20long,%20boolean,%20int,%20int,%20int,%20java.lang.String,%20long[],%20long[],%20long[],%20long[],%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20java.util.List,%20boolean,%20com.liferay.portal.kernel.service.ServiceContext)).
 
 ### Parameter: ClassNameId
 
@@ -1347,7 +1347,7 @@ public boolean isPasswordExpired(User user)
 ```
 
 For a working example, see
-[UserLocalService.isPasswordExpired(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#isPasswordExpired(com.liferay.portal.kernel.model.User)).
+[UserLocalService.isPasswordExpired(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#isPasswordExpired(com.liferay.portal.kernel.model.User)).
 
 ### Parameter: ServiceContext
 
@@ -1414,7 +1414,7 @@ public List<User> search( ... , String firstName, String middleName, … , boole
 ```
 
 For a working example, see
-[UserLocalService.search(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
+[UserLocalService.search(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/UserLocalService.html#search(long,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20java.util.LinkedHashMap,%20boolean,%20int,%20int,%20com.liferay.portal.kernel.search.Sort)).
 
 ### Parameter: Refer reader to more information
 
@@ -1434,7 +1434,7 @@ to the parameter, add a sentence with a link to that information.
 ```
 
 This example is used in comments for several of the search methods in
-[OrganizationLocalService](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html).
+[OrganizationLocalService](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html).
 
 ### Field
 
@@ -1496,7 +1496,7 @@ For ordered collection returned, mention how or what determines the order
 
 For working examples, see `DDMStructure.getStructures(long groupId, long
 classNameId, int start, int end, OrderByComparator orderByComparator)` and
-[DLAppServiceImpl.getGroupFileEntries(...)](@platform-ref@/7.0-latest/javadocs/portal-impl/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.html#getGroupFileEntries(long,%20long,%20long,%20int,%20int)).
+[DLAppServiceImpl.getGroupFileEntries(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-impl/com/liferay/portlet/documentlibrary/service/impl/DLAppServiceImpl.html#getGroupFileEntries(long,%20long,%20long,%20int,%20int)).
 
 ### Return: Significantly varying values
 
@@ -1514,4 +1514,4 @@ describing return values. This convention is not to be used with the other tags
 (e.g. `@param`, `@throws`).
 
 For a working example, see
-[OrganizationLocalService.getOrganizationId(...)](@platform-ref@/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#getOrganizationId(long,%20java.lang.String)).
+[OrganizationLocalService.getOrganizationId(...)](https://docs.liferay.com/ce/portal/7.0-latest/javadocs/portal-kernel/com/liferay/portal/kernel/service/OrganizationLocalService.html#getOrganizationId(long,%20java.lang.String)).


### PR DESCRIPTION
This affects the following 7.0 doc sets ...

- develop/tutorials/
- discover/deployment/
- discover/portal/
- discover/reference/

https://issues.liferay.com/browse/LRDOCS-5071

Thanks!

cc/  justinchoi001 