### PR TITLE
Remove all special char apostrophes in docs | 7.0.x

### DIFF
--- a/develop/tutorials/articles-dxp/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles-dxp/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -415,7 +415,7 @@ targets report success or failure.
 Frequently, you'll want to add further customizations to your original Ext
 plugin. You can make unlimited customizations to an Ext plugin that has already
 been deployed, but the redeployment process is different from other project
-types. You’ll learn more on redeploying your Ext plugin next.
+types. You'll learn more on redeploying your Ext plugin next.
 
 ### Redeployment [](id=redeployment)
 
@@ -556,7 +556,7 @@ to the original file in @product@:
       for adding applications and the categories in which they're organized.
     - **Original file in @product@:** `portal-web/docroot/WEB-INF/liferay-display.xml`
 
-You’ll learn how to deploy your Ext plugin in production next.
+You'll learn how to deploy your Ext plugin in production next.
 
 ## Deploying in Production [](id=deploying-in-production)
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/00-from-liferay-6-to-liferay-7-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/00-from-liferay-6-to-liferay-7-intro.markdown
@@ -39,4 +39,4 @@ interested in upgrading your plugins first, skip to
 $$$
 
 You'll start by seeing the familiar, good things that remain the same and then
-examine what’s changed the most since Liferay Portal 6. 
+examine what's changed the most since Liferay Portal 6. 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/05-upgrading-hook-plugins/09-converting-struts-action-wrappers-to-mvc-commands.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/05-upgrading-hook-plugins/09-converting-struts-action-wrappers-to-mvc-commands.markdown
@@ -57,7 +57,7 @@ legacy struts action.
 
 Using the beginning login example once again, the `struts-action-path` mapping, 
 `/login/login`, remains the same for the `MVCCommand` mapping in @product-ver@, but
-some of the mappings may have changed. It’s best to check Liferay's source code
+some of the mappings may have changed. It's best to check Liferay's source code
 to determine the correct mapping.
 
 Depending on the URL it is a different parameter:

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/06-upgrading-themes/01-upgrading-liferay-6-themes.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/06-upgrading-themes/01-upgrading-liferay-6-themes.markdown
@@ -9,7 +9,7 @@ tutorial.
 
 ## Setting Up Your Theme With Liferay Theme Generator [](id=setting-up-your-theme-with-liferay-theme-generator)
 
-You’ll use Liferay Theme Generator to get the upgrade process started. Liferay 
+You'll use Liferay Theme Generator to get the upgrade process started. Liferay 
 Theme Generator supplies your theme with the necessary tools to deploy and make 
 quick modifications.
 
@@ -458,7 +458,7 @@ For more in depth coverage, see [jQuery's documentation](http://api.jquery.com/)
 
 [Lodash](https://lodash.com/) is a modern JavaScript utility library delivering 
 modularity, performance & extras. It's used in @product@ to fill the void left 
-by YUI’s utility modules.
+by YUI's utility modules.
 
 For more in depth coverage, see [Lodash's documentation](http://lodash.com/docs/).
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/08-optimizing-existing-plugins-for-liferay-7/06-modularizing-plugins/00-modularizing-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/08-optimizing-existing-plugins-for-liferay-7/06-modularizing-plugins/00-modularizing-plugins-intro.markdown
@@ -23,12 +23,12 @@ application to modules.
 
 **When not to convert?**
 
--   You have a portlet that’s JSR-168/286 compatible and you still want to be
+-   You have a portlet that's JSR-168/286 compatible and you still want to be
     able to deploy it to another portlet container. In this case, it's best to
     stay with the traditional WAR model. (To eliminate this reason for not
     converting, Liferay is discussing with other vendors the possibility of
     making modular portlets a standard.) 
--   You’re using a complex web framework that is heavily tied to the Java EE
+-   You're using a complex web framework that is heavily tied to the Java EE
     programming model and the amount of effort necessary to make it work with
     OSGi is more than you feel is necessary or warranted. 
 -   You want to minimize effort to get your application to working on

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/09-customization-with-ext-plugins/09-customization-with-ext-plugins-intro.markdown
@@ -399,7 +399,7 @@ targets report success or failure.
 Frequently, you'll want to add further customizations to your original Ext
 plugin. You can make unlimited customizations to an Ext plugin that has already
 been deployed, but the redeployment process is different from other project
-types. You’ll learn more on redeploying your Ext plugin next.
+types. You'll learn more on redeploying your Ext plugin next.
 
 ### Redeployment [](id=redeployment)
 
@@ -549,7 +549,7 @@ to the original file in @product@:
       for adding applications and the categories in which they're organized.
     - **Original file in @product@:** `portal-web/docroot/WEB-INF/liferay-display.xml`
 
-You’ll learn how to deploy your Ext plugin in production next.
+You'll learn how to deploy your Ext plugin in production next.
 
 ## Deploying in Production [](id=deploying-in-production)
 

--- a/develop/tutorials/articles/05-developing-an-ios-app/03-creating-entry-list-screenlet/03-creating-the-connector.markdown
+++ b/develop/tutorials/articles/05-developing-an-ios-app/03-creating-entry-list-screenlet/03-creating-the-connector.markdown
@@ -36,7 +36,7 @@ you'll pass to the superclass initializer:
 
 - `startRow`: The number representing the page's first row. 
 - `endRow`: The number representing the page's last row. 
-- `computeRowCount`: Whether to call the Connector’s `doAddRowCountServiceCall` 
+- `computeRowCount`: Whether to call the Connector's `doAddRowCountServiceCall` 
   method. 
 
 Follow these steps to create Guestbook List Screenlet's Connector: 

--- a/develop/tutorials/articles/05-developing-an-ios-app/03-creating-entry-list-screenlet/04-creating-the-interactor.markdown
+++ b/develop/tutorials/articles/05-developing-an-ios-app/03-creating-entry-list-screenlet/04-creating-the-interactor.markdown
@@ -37,7 +37,7 @@ following properties, which it passes to the superclass initializer:
 - `screenlet`: A `BaseListScreenlet` reference. This ensures the Interactor 
   always has a Screenlet reference. 
 - `page`: The page number to retrieve. 
-- `computeRowCount`: Whether to call the Connector’s `doAddRowCountServiceCall` 
+- `computeRowCount`: Whether to call the Connector's `doAddRowCountServiceCall` 
   method. 
 
 Follow these steps to create Entry List Screenlet's Interactor: 

--- a/develop/tutorials/articles/110-portlets/02-liferay-soy-portlet/01-creating-a-soy-portlet.markdown
+++ b/develop/tutorials/articles/110-portlets/02-liferay-soy-portlet/01-creating-a-soy-portlet.markdown
@@ -288,7 +288,7 @@ Now that you understand the render logic, you can learn how the view layer works
 
 ## Configuring the View Layer [](id=configuring-the-view-layer)
 
-Your portlet also requires a view layer, and for that you’ll use Soy templates, 
+Your portlet also requires a view layer, and for that you'll use Soy templates, 
 which is the whole point of developing a Soy portlet, isn't it? This section 
 briefly covers how to get your view layer working, from including other Soy 
 templates, to creating a MetalJS component for rendering your views.

--- a/develop/tutorials/articles/110-portlets/15-javascript/04-npm/03-configuring-liferay-npm-bundler.markdown
+++ b/develop/tutorials/articles/110-portlets/15-javascript/04-npm/03-configuring-liferay-npm-bundler.markdown
@@ -249,7 +249,7 @@ use a configuration preset.
 Follow these steps to use a liferay-npm-bundler configuration preset in your 
 `.npmbundlerrc` file:
 
-1.  Create a `.npmbundlerrc` file in your project’s root folder, if it doesn't 
+1.  Create a `.npmbundlerrc` file in your project's root folder, if it doesn't 
     already exist.
 
 2.  Install the liferay-npm-bundler configuration preset. For example, you can 

--- a/develop/tutorials/articles/150-workflow/00-workflow-framework-intro.markdown
+++ b/develop/tutorials/articles/150-workflow/00-workflow-framework-intro.markdown
@@ -1,10 +1,10 @@
 # Liferay's Workflow Framework [](id=liferays-workflow-framework)
 
 Enabling your application's entities to support workflow is so easy, you could do it in
-your sleep (but don’t try). Workflow enabled entities require a few things:
+your sleep (but don't try). Workflow enabled entities require a few things:
 
--  A workflow handler class to interact with Liferay’s workflow back end and
-   the entity’s service layer.
+-  A workflow handler class to interact with Liferay's workflow back end and
+   the entity's service layer.
 
 -  Some extra fields in their database table that help keep track of their
    status.
@@ -17,8 +17,8 @@ your sleep (but don’t try). Workflow enabled entities require a few things:
     The service layer needs code to populate the new fields when entities are added to the
     database. 
 
-    The service layer needs to send the entity through Liferay’s workflow, and it needs
-    to handle the workflow status of the entity when it’s returned by the workflow. 
+    The service layer needs to send the entity through Liferay's workflow, and it needs
+    to handle the workflow status of the entity when it's returned by the workflow. 
 
     The service layer needs getters that return entities of the desired workflow
     status (usually *approved*).

--- a/develop/tutorials/articles/180-configuration/01-making-apps-configurable.markdown
+++ b/develop/tutorials/articles/180-configuration/01-making-apps-configurable.markdown
@@ -472,7 +472,7 @@ the provider:
     scope. These settings are specified by an admin via the System Settings
     application or with an OSGi configuration file.
 
-Here are a couple real world examples from Liferay’s source code:
+Here are a couple real world examples from Liferay's source code:
 
     JournalGroupServiceConfiguration configuration =
         configurationProvider.getGroupConfiguration(

--- a/develop/tutorials/articles/200-search/02-customizing-liferay-search.markdown
+++ b/develop/tutorials/articles/200-search/02-customizing-liferay-search.markdown
@@ -9,7 +9,7 @@ To add a new search engine adapter, developers must create the following
 components and publish them to Liferay's OSGi registry:
 
 1. Implement a new IndexSearcher that should convert the Liferay Search objects
-   to the underlying search engine’s dialects:
+   to the underlying search engine's dialects:
     - QueryTranslator: Translates Liferay Queries to the native search engine's
       queries.
     - FilterTranslator: Translates Liferay filters into native search engine's
@@ -24,7 +24,7 @@ components and publish them to Liferay's OSGi registry:
 2. Implement a new IndexWriter that should
     - Convert the Liferay Document to a format understood by the underlying
       search engine's Document Format.
-    - Use the search engine’s API to update, add, and delete documents.
+    - Use the search engine's API to update, add, and delete documents.
 
 3. Implement a new SearchEngineConfigurator that should extend
    `AbstractSearchEngineConfigurator` to perform proper wiring.

--- a/develop/tutorials/articles/210-application-security/06-service-access-policies.markdown
+++ b/develop/tutorials/articles/210-application-security/06-service-access-policies.markdown
@@ -24,7 +24,7 @@ has such permissions on the server. The client app doesn't even need
 access to the Calendar API methods that create, update, and delete
 appointments. It only needs access to the remote service methods for
 finding and retrieving appointments. A service access policy on the
-server can restrict the client’s access to only these service methods.
+server can restrict the client's access to only these service methods.
 Otherwise, once authenticated it would have access to all the remote
 services the user has permission to access when logged in: services that
 create, update, and delete calendar appointments, as well as those that

--- a/develop/tutorials/articles/310-troubleshooting/00-troubleshooting-intro.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/00-troubleshooting-intro.markdown
@@ -26,7 +26,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">What are optional package imports and how can I specify them?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>When developing Liferay Portal modules, you can declare <em>optional</em> package imports. An optional package import is one your module can use if it’s available, but can still function without it. <a href="/develop/tutorials/-/knowledge_base/7-0/declaring-optional-import-package-requirements">Specifying optional package imports</a> is straightforward. </p>
+    <p>When developing Liferay Portal modules, you can declare <em>optional</em> package imports. An optional package import is one your module can use if it's available, but can still function without it. <a href="/develop/tutorials/-/knowledge_base/7-0/declaring-optional-import-package-requirements">Specifying optional package imports</a> is straightforward. </p>
   </div>
 </div>
 
@@ -34,7 +34,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I connect to a JNDI data source from my module?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>Connecting to an application server’s JNDI data sources from Liferay Portal’s OSGi environment is almost the same as connecting to them from the Java EE environment. In an OSGi environment, the only difference is that you must <a href="/develop/tutorials/-/knowledge_base/7-0/connecting-to-data-sources-using-jndi">use Liferay Portal’s class loader to load the application server’s JNDI classes</a>. </p>
+    <p>Connecting to an application server's JNDI data sources from Liferay Portal's OSGi environment is almost the same as connecting to them from the Java EE environment. In an OSGi environment, the only difference is that you must <a href="/develop/tutorials/-/knowledge_base/7-0/connecting-to-data-sources-using-jndi">use Liferay Portal's class loader to load the application server's JNDI classes</a>. </p>
   </div>
 </div>
 
@@ -57,7 +57,7 @@ Click a question to view the answer.
     ...
     Unresolved requirement: Require-Capability ...
     </code></pre>
-    <p>To satisfy the requirement, <a href="/develop/tutorials/-/knowledge_base/7-0/resolving-bundle-requirements">find a module that provides the capability, add it to your build file’s dependencies, and deploy it</a>. </p>
+    <p>To satisfy the requirement, <a href="/develop/tutorials/-/knowledge_base/7-0/resolving-bundle-requirements">find a module that provides the capability, add it to your build file's dependencies, and deploy it</a>. </p>
   </div>
 </div> 
 
@@ -81,7 +81,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">Why aren't my fragment's JSP overrides showing?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/why-arent-jsp-overrides-i-made-using-fragments-showing">Make sure your <code>Fragment-Host</code>’s bundle version is compatible with the host’s bundle version</a>. </p>
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/why-arent-jsp-overrides-i-made-using-fragments-showing">Make sure your <code>Fragment-Host</code>'s bundle version is compatible with the host's bundle version</a>. </p>
   </div>
 </div>
 
@@ -89,7 +89,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">The application server and database started, but @product@ failed to connect to the database. What happened and how can I fix this?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>Liferay Portal initialization can fail while attempting to connect to a database server that isn’t ready. <a href="/develop/tutorials/-/knowledge_base/7-0/portal-failed-to-initialize-because-the-database-wasnt-ready">Configuring Liferay Portal startup to retry JDBC connections</a> facilitates connecting Liferay Portal to databases. </p>
+    <p>Liferay Portal initialization can fail while attempting to connect to a database server that isn't ready. <a href="/develop/tutorials/-/knowledge_base/7-0/portal-failed-to-initialize-because-the-database-wasnt-ready">Configuring Liferay Portal startup to retry JDBC connections</a> facilitates connecting Liferay Portal to databases. </p>
   </div>
 </div>
 

--- a/develop/tutorials/articles/310-troubleshooting/01-resolving-bundle-requirements.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/01-resolving-bundle-requirements.markdown
@@ -58,7 +58,7 @@ First, note the module's dependencies. Here is the `dependencies` section of the
 
 Then use
 [Felix Gogo Shell's `lb command`](/develop/reference/-/knowledge_base/7-0/using-the-felix-gogo-shell)
-to verify the dependencies in Liferay’s OSGi Runtime:
+to verify the dependencies in Liferay's OSGi Runtime:
 
     lb
     START LEVEL 1

--- a/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/06-adjusting-module-logging.markdown
@@ -52,10 +52,10 @@ samples (among others) leverage module logging.
 +$$$
 
 Note: If the log level configuration isn't appearing (e.g., you set the log
-level to `ERROR` but you’re still getting `WARN` messages), make sure the log
+level to `ERROR` but you're still getting `WARN` messages), make sure the log
 configuration file name prefix matches the module's symbolic name. If you have
 Bnd installed, output from command `bnd print [path-to-bundle]` includes the
-module’s symbolic name ([Here](https://github.com/bndtools/bnd/wiki/Install-bnd-on-the-command-line)
+module's symbolic name ([Here](https://github.com/bndtools/bnd/wiki/Install-bnd-on-the-command-line)
 are instructions for installing Bnd for the command line).
 
 $$$

--- a/discover/deployment/articles-dxp/02-installing-liferay/07-installing-liferay-on-tcserver.markdown
+++ b/discover/deployment/articles-dxp/02-installing-liferay/07-installing-liferay-on-tcserver.markdown
@@ -310,7 +310,7 @@ Before you deploy @product@, you should configure a Portal Access Control List
 
 ## Enabling PACL [](id=enabling-pacl)
 
-To enable PACL, you need to enable Tomcat’s security manager. Make sure
+To enable PACL, you need to enable Tomcat's security manager. Make sure
 `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/conf/catalina.policy` specifies the permissions
 
     grant {

--- a/discover/deployment/articles-dxp/02-installing-liferay/08-installing-liferay-on-weblogic.markdown
+++ b/discover/deployment/articles-dxp/02-installing-liferay/08-installing-liferay-on-weblogic.markdown
@@ -3,7 +3,7 @@
 Although it's possible to install @product@ in a WebLogic Admin
 Server, this isn't recommended. It's best practice to install web apps,
 including @product@, in a WebLogic Managed server. By deploying to a Managed
-Server, you’ll be able to start/shutdown @product@ more quickly, and you’ll
+Server, you'll be able to start/shutdown @product@ more quickly, and you'll
 more easily be able to extend @product@ into a cluster configuration. This article
 therefore focuses on installing @product@ in a Managed Server. 
 
@@ -153,7 +153,7 @@ now:
    it doesn't exist).
 
 If you don't want to use @product@'s built-in Hypersonic database, you must also 
-add your database's driver JAR file to your domain’s `lib` folder. Note that 
+add your database's driver JAR file to your domain's `lib` folder. Note that 
 although Hypersonic is fine for testing purposes, you **should not** use it for 
 production @product@ instances. 
 
@@ -205,7 +205,7 @@ Next, you'll configure your mail session.
 ## Mail Configuration [](id=mail-configuration)
 
 If you want WebLogic to manage your mail session, use the following procedure. 
-If you want to use Liferay’s built-in mail session (recommended), you can skip 
+If you want to use Liferay's built-in mail session (recommended), you can skip 
 this section. 
 
 1. Start WebLogic and log in to your Admin Server's console.

--- a/discover/deployment/articles-dxp/08-liferay-enterprise-search/06-backing-up-search/00-intro.markdown
+++ b/discover/deployment/articles-dxp/08-liferay-enterprise-search/06-backing-up-search/00-intro.markdown
@@ -5,7 +5,7 @@ configure the appropriate
 adapter](https://dev.liferay.com/discover/deployment/-/knowledge_base/7-0/installing-a-search-engine),
 you're using a standalone installation of the search engine (usually installed
 on a cluster of servers) to create and manage your search indices. That means
-there’s really nothing special to do in the @product@ installation when backing
+there's really nothing special to do in the @product@ installation when backing
 up your search engine's data. In large part, these articles summarize the
 process and point you to the relevant documentation on backing up Elasticsearch
 and Solr, the two search engines supported for plugging into Liferay.

--- a/discover/deployment/articles/08-liferay-enterprise-search/06-backing-up-search/00-intro.markdown
+++ b/discover/deployment/articles/08-liferay-enterprise-search/06-backing-up-search/00-intro.markdown
@@ -5,7 +5,7 @@ configure the appropriate
 adapter](https://dev.liferay.com/discover/deployment/-/knowledge_base/7-0/installing-a-search-engine),
 you're using a standalone installation of the search engine (usually installed
 on a cluster of servers) to create and manage your search indices. That means
-there’s really nothing special to do in the @product@ installation when backing
+there's really nothing special to do in the @product@ installation when backing
 up your search engine's data. In large part, these articles summarize the
 process and point you to the relevant documentation on backing up Elasticsearch
 and Solr, the two search engines supported for plugging into Liferay.

--- a/discover/portal/articles/100-web-experience-management/01-starting-site-development/07-creating-teams-for-advanced-site-membership-management.markdown
+++ b/discover/portal/articles/100-web-experience-management/01-starting-site-development/07-creating-teams-for-advanced-site-membership-management.markdown
@@ -65,7 +65,7 @@ the team in the Role column, and select the appropriate permissions.
 
 That's it! It's easy to give groups of site users appropriate permissions to
 perform their tasks. This chapter has provided an introduction to @product@ site
-management. You’ve learned how to use @product@ to create multiple sites with
+management. You've learned how to use @product@ to create multiple sites with
 different membership types. You've also seen how easy it is to create and manage
 sites and to create and manage pages within a site in @product@. Next, you'll
 begin working with web content.

--- a/discover/portal/articles/100-web-experience-management/02-creating-web-content/02-designing-uniform-content.markdown
+++ b/discover/portal/articles/100-web-experience-management/02-creating-web-content/02-designing-uniform-content.markdown
@@ -596,11 +596,11 @@ role with the ability to update the template and create a second role that can
 both update and delete. @product@ makes it possible to assign permissions based on
 the roles and responsibilities within your organization.
 
-Whether your site is small and static or large and dynamic, Liferay’s WCM
+Whether your site is small and static or large and dynamic, Liferay's WCM
 enables you to plan and manage it. With tools such as the WYSIWYG editor,
 structures and templates, you can quickly add and edit content. With the Web
 Content Display, you can rapidly select and configure what content to display.
-You'll find that managing your site becomes far easier when using @product@’s Web
+You'll find that managing your site becomes far easier when using @product@'s Web
 Content Management system.
 
 <div class="video-tag" data-name="Creating Content with Structures and Templates">

--- a/discover/portal/articles/100-web-experience-management/03-staging-content-for-publication/05-scheduling-web-content-publication.markdown
+++ b/discover/portal/articles/100-web-experience-management/03-staging-content-for-publication/05-scheduling-web-content-publication.markdown
@@ -27,8 +27,8 @@ growing inventory of content.
 
 You can enable staging on an individual site basis, depending on your needs.
 This makes it easy to put strict controls in place for your public web site,
-while opening things up for individual sites that don’t need such strict
-controls. @product@’s staging environment is extremely easy to use and makes
+while opening things up for individual sites that don't need such strict
+controls. @product@'s staging environment is extremely easy to use and makes
 maintaining a content-rich web site a snap. Another management feature used to
 control publishing of content is the web content schedular. Similar to staging,
 the schedular provides more control of your publishing process.

--- a/discover/portal/articles/110-collaboration/01-managing-documents-and-media/03-liferay-repository-types.markdown
+++ b/discover/portal/articles/110-collaboration/01-managing-documents-and-media/03-liferay-repository-types.markdown
@@ -9,7 +9,7 @@ Deployment Guide. Let's consider the ramifications of the various store options.
 
 By default, Liferay Portal uses a document library store option called
 Simple File Store to store documents and media files on the file system
-(local or mounted) of the server Liferay Portal’s running on. The
+(local or mounted) of the server Liferay Portal's running on. The
 store's default root folder is
 `[Liferay Home]/data/document_library`. You can specify a different root
 folder from within 
@@ -18,7 +18,7 @@ To access System Settings, open the *Menu*
 (![icon-menu.png](../../../images/icon-menu.png))
 and navigate to *Control Panel &rarr; Configuration &rarr; System Settings*. From
 System Settings, navigate to *Platform* and then search for and select
-the entry *Simple File System Store*. For the store’s *Root dir* value,
+the entry *Simple File System Store*. For the store's *Root dir* value,
 specify a path relative to the 
 [Liferay Home](/discover/deployment/-/knowledge_base/7-0/installing-product#liferay-home)
 or an absolute path; then click the *Update* button. The document


### PR DESCRIPTION
This removes that pesky special char apostrophe typically copied over from a Google doc.