### PR TITLE
Port enterprise name change for 7.0

### DIFF
--- a/release-site.properties
+++ b/release-site.properties
@@ -16,7 +16,7 @@
     product.token=product
 
     product.name.version=Liferay Portal CE 7.0
-    product.name.enterprise.version=Liferay Digital Enterprise 7.0
+    product.name.enterprise.version=Liferay DXP 7.0
     product.token.version=product-ver
 
     product.ide.name=IDE


### PR DESCRIPTION
Based on JR's comments in the email thread about updating our official product names for the 7.0 README, we have decided to update *Digital Enterprise* to *DXP* for 7.0.

It appears we hadn't done this yet in our docs, so I've updated the token accordingly.