### PR TITLE
Remove whitepsaces from code block

### DIFF
--- a/discover/deployment/articles/08-liferay-enterprise-search/05-solr.markdown
+++ b/discover/deployment/articles/08-liferay-enterprise-search/05-solr.markdown
@@ -154,9 +154,7 @@ the Elasticsearch, Shield, and Marvel plugins.
 
     file with these contents:
 
-        blacklistBundleSymbolicNames=["com.liferay.portal.search.elasticsearch",
-            "com.liferay.portal.search.elasticsearch.shield",
-            "com.liferay.portal.search.elasticsearch.marvel.web"]
+        blacklistBundleSymbolicNames=["com.liferay.portal.search.elasticsearch","com.liferay.portal.search.elasticsearch.shield","com.liferay.portal.search.elasticsearch.marvel.web"]
 
 2.  Place the file in `Liferay Home/osgi/configs`.
 


### PR DESCRIPTION
removed white spaces so the .config property value in the Solr article is copyable. cc @lipusz