### PR TITLE
LRDOCS-4678  LRDOCS-5626 port the Troubleshooting intro and DB sort order tutorial

### DIFF
--- a/develop/tutorials/articles/380-troubleshooting/00-troubleshooting-intro.markdown
+++ b/develop/tutorials/articles/380-troubleshooting/00-troubleshooting-intro.markdown
@@ -16,9 +16,9 @@ Click a question to view the answer.
 ## Modules [](id=troubleshooting-modules)
 
 <div class="ldn-faq-question">
-  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I configure dependencies on Liferay Portal artifacts?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I configure dependencies on Liferay artifacts?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/configuring-dependencies">Configuring Dependencies</a>. </p>
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-1/configuring-dependencies">Configuring Dependencies</a>. </p>
   </div>
 </div>
 
@@ -26,7 +26,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">What are optional package imports and how can I specify them?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>When developing Liferay Portal modules, you can declare <em>optional</em> package imports. An optional package import is one your module can use if it's available, but can still function without it. <a href="/develop/tutorials/-/knowledge_base/7-0/declaring-optional-import-package-requirements">Specifying optional package imports</a> is straightforward. </p>
+    <p>When developing modules, you can declare <em>optional</em> package imports. An optional package import is one your module can use if it's available, but can still function without it. <a href="/develop/tutorials/-/knowledge_base/7-1/declaring-optional-import-package-requirements">Specifying optional package imports</a> is straightforward. </p>
   </div>
 </div>
 
@@ -34,16 +34,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I connect to a JNDI data source from my module?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>Connecting to an application server's JNDI data sources from Liferay Portal's OSGi environment is almost the same as connecting to them from the Java EE environment. In an OSGi environment, the only difference is that you must <a href="/develop/tutorials/-/knowledge_base/7-0/connecting-to-data-sources-using-jndi">use Liferay Portal's class loader to load the application server's JNDI classes</a>. </p>
-  </div>
-</div>
-
-<br/>
-<div class="ldn-faq-question">
-  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I make sure my module works?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
-  <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/testing">The Testing tutorials demonstrate several ways to test Liferay Portal modules</a>:</p>
-    <ul> <li>Unit testing</li> <li>Integration testing</li> <li>Functional testing</li> </ul>
+    <p>Connecting to an application server's JNDI data sources from Liferay's OSGi environment is almost the same as connecting to them from the Java EE environment. In an OSGi environment, the only difference is that you must <a href="/develop/tutorials/-/knowledge_base/7-1/connecting-to-data-sources-using-jndi">use @product@'s class loader to load the application server's JNDI classes</a>. </p>
   </div>
 </div>
 
@@ -51,13 +42,13 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">My module has an unresolved requirement. What can I do?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>If one of your bundles imports a package that no other bundle in the Liferay OSGi runtime exports, Liferay Portal reports an unresolved requirement:</p>
+    <p>If one of your bundles imports a package that no other bundle in the Liferay OSGi runtime exports, @product@ reports an unresolved requirement:</p>
     <pre><code>! could not resolve the bundles: ...
     Unresolved requirement: Import-Package: ...
     ...
     Unresolved requirement: Require-Capability ...
     </code></pre>
-    <p>To satisfy the requirement, <a href="/develop/tutorials/-/knowledge_base/7-0/resolving-bundle-requirements">find a module that provides the capability, add it to your build file's dependencies, and deploy it</a>. </p>
+    <p>To satisfy the requirement, <a href="/develop/tutorials/-/knowledge_base/7-1/resolving-bundle-requirements">find a module that provides the capability, add it to your build file's dependencies, and deploy it</a>. </p>
   </div>
 </div> 
 
@@ -65,23 +56,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">An IllegalContextNameException reports that my bundle's context name does not follow Bundle-SymbolicName syntax. How can I fix the context name?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/resolving-bundle-symbolicname-syntax-issues">Adjust the <code>Bundle-SymbolicName</code> to adhere to the syntax</a>. </p>
-  </div>
-</div>
-
-<br/>
-<div class="ldn-faq-question">
-  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">Why aren't my module's JavaScript and CSS changes showing?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
-  <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/why-arent-my-modules-javascript-and-css-changes-showing">Incorrect component properties or stale browser cache can prevent JavaScript and CSS changes from showing</a>. </p>
-  </div>
-</div>
-
-<br/>
-<div class="ldn-faq-question">
-  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">Why aren't my fragment's JSP overrides showing?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
-  <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/why-arent-jsp-overrides-i-made-using-fragments-showing">Make sure your <code>Fragment-Host</code>'s bundle version is compatible with the host's bundle version</a>. </p>
+    <p><a href="/develop/tutorials/-/knowledge_base/7-1/resolving-bundle-symbolicname-syntax-issues">Adjust the <code>Bundle-SymbolicName</code> to adhere to the syntax</a>. </p>
   </div>
 </div>
 
@@ -89,7 +64,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">The application server and database started, but @product@ failed to connect to the database. What happened and how can I fix this?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>Liferay Portal initialization can fail while attempting to connect to a database server that isn't ready. <a href="/develop/tutorials/-/knowledge_base/7-0/portal-failed-to-initialize-because-the-database-wasnt-ready">Configuring Liferay Portal startup to retry JDBC connections</a> facilitates connecting Liferay Portal to databases. </p>
+    <p>@product@ initialization can fail while attempting to connect to a database server that isn't ready. <a href="/develop/tutorials/-/knowledge_base/7-1/portal-failed-to-initialize-because-the-database-wasnt-ready">Configuring startup to retry JDBC connections</a> facilitates connecting @product@ to databases. </p>
   </div>
 </div>
 
@@ -97,7 +72,7 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I adjust my module's logging?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/adjusting-module-logging">Adjusting Module Logging</a>. </p>
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-1/adjusting-module-logging">Adjusting Module Logging</a>. </p>
   </div>
 </div>
 
@@ -105,28 +80,28 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I implement logging in my module or plugin?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/implementing-logging">Use Simple Logging Facade for Java (SLF4J) to log messages</a>.</p>
+    <p><a href="/develop/tutorials/-/knowledge_base/7-1/implementing-logging">Use Simple Logging Facade for Java (SLF4J) to log messages</a>.</p>
   </div>
 </div>
 
 ### Why did the entity sort order change when I migrated to a new database type? [](id=why-did-the-entity-sort-order-change-when-i-migrated-to-a-new-database-type)
 
-[Your new database uses a different default query result order--you should be able to configure a different order](/develop/tutorials/-/knowledge_base/7-0/sort-order-changed-with-a-different-database).
+[Your new database uses a different default query result order--you should be able to configure a different order](/develop/tutorials/-/knowledge_base/7-1/sort-order-changed-with-a-different-database).
 
 ## Services and Components [](id=troubleshooting-services-and-components)
 
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I detect unresolved OSGi components?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>Liferay Portal module components that use Service Builder use Dependency Manager (DM) and most other Liferay Portal module components use Declarative Services (DS). <a href="/develop/tutorials/-/knowledge_base/7-0/detecting-unresolved-osgi-components">Gogo shell commands and tools help you find and inspect unsatisfied component references for DM and DS components</a>. </p>
+    <p>module components that use Service Builder use Dependency Manager (DM) and most other module components use Declarative Services (DS). <a href="/develop/tutorials/-/knowledge_base/7-1/detecting-unresolved-osgi-components">Gogo shell commands and tools help you find and inspect unsatisfied component references for DM and DS components</a>. </p>
   </div>
 </div>
 
 <br/>
 <div class="ldn-faq-question">
-  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">What is the safest way to call non-OSGi code that uses OSGi services?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">What is the safest way to call OSGi services from non-OSGi code?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/calling-non-osgi-code-that-uses-osgi-services">Calling Non-OSGi Code that Uses OSGi Services</a>. </p>
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-1/service-trackers">Calling Non-OSGi Code that Uses OSGi Services</a>. </p>
   </div>
 </div>
 
@@ -134,14 +109,6 @@ Click a question to view the answer.
 <div class="ldn-faq-question">
   <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I use files to configure components?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
   <div class="hide">  
-    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/using-files-to-configure-product-modules">Using Files to Configure Module Components</a>. </p>
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-1/using-files-to-configure-product-modules">Using Files to Configure Module Components</a>. </p>
   </div>
 </div>
-
-<br/>
-<div class="ldn-faq-question">
-  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I use OSGi services from Ext Plugins?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
-  <div class="hide">  
-    <p><a href="/develop/tutorials/-/knowledge_base/7-0/using-osgi-services-from-ext-plugins">The registry API lets Ext Plugins use OSGi services </a>. </p>
-  </div>
-</div> 

--- a/develop/tutorials/articles/380-troubleshooting/00-troubleshooting-intro.markdown
+++ b/develop/tutorials/articles/380-troubleshooting/00-troubleshooting-intro.markdown
@@ -5,3 +5,143 @@ clear resolution. This can be particularly frustrating. If you have issues
 building, deploying, or running modules, you want to resolve them fast. These
 frequently asked questions and answers help you troubleshoot and correct
 problems that arise based on the underlying OSGi platform.
+
+Here are the troubleshooting sections:
+
+-   [Modules](#troubleshooting-modules)
+-   [Services and Components](#troubleshooting-services-and-components)
+
+Click a question to view the answer.
+
+## Modules [](id=troubleshooting-modules)
+
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I configure dependencies on Liferay Portal artifacts?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/configuring-dependencies">Configuring Dependencies</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">What are optional package imports and how can I specify them?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>When developing Liferay Portal modules, you can declare <em>optional</em> package imports. An optional package import is one your module can use if it's available, but can still function without it. <a href="/develop/tutorials/-/knowledge_base/7-0/declaring-optional-import-package-requirements">Specifying optional package imports</a> is straightforward. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I connect to a JNDI data source from my module?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>Connecting to an application server's JNDI data sources from Liferay Portal's OSGi environment is almost the same as connecting to them from the Java EE environment. In an OSGi environment, the only difference is that you must <a href="/develop/tutorials/-/knowledge_base/7-0/connecting-to-data-sources-using-jndi">use Liferay Portal's class loader to load the application server's JNDI classes</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I make sure my module works?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/testing">The Testing tutorials demonstrate several ways to test Liferay Portal modules</a>:</p>
+    <ul> <li>Unit testing</li> <li>Integration testing</li> <li>Functional testing</li> </ul>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">My module has an unresolved requirement. What can I do?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>If one of your bundles imports a package that no other bundle in the Liferay OSGi runtime exports, Liferay Portal reports an unresolved requirement:</p>
+    <pre><code>! could not resolve the bundles: ...
+    Unresolved requirement: Import-Package: ...
+    ...
+    Unresolved requirement: Require-Capability ...
+    </code></pre>
+    <p>To satisfy the requirement, <a href="/develop/tutorials/-/knowledge_base/7-0/resolving-bundle-requirements">find a module that provides the capability, add it to your build file's dependencies, and deploy it</a>. </p>
+  </div>
+</div> 
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">An IllegalContextNameException reports that my bundle's context name does not follow Bundle-SymbolicName syntax. How can I fix the context name?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/resolving-bundle-symbolicname-syntax-issues">Adjust the <code>Bundle-SymbolicName</code> to adhere to the syntax</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">Why aren't my module's JavaScript and CSS changes showing?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/why-arent-my-modules-javascript-and-css-changes-showing">Incorrect component properties or stale browser cache can prevent JavaScript and CSS changes from showing</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">Why aren't my fragment's JSP overrides showing?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/why-arent-jsp-overrides-i-made-using-fragments-showing">Make sure your <code>Fragment-Host</code>'s bundle version is compatible with the host's bundle version</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">The application server and database started, but @product@ failed to connect to the database. What happened and how can I fix this?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>Liferay Portal initialization can fail while attempting to connect to a database server that isn't ready. <a href="/develop/tutorials/-/knowledge_base/7-0/portal-failed-to-initialize-because-the-database-wasnt-ready">Configuring Liferay Portal startup to retry JDBC connections</a> facilitates connecting Liferay Portal to databases. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I adjust my module's logging?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/adjusting-module-logging">Adjusting Module Logging</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I implement logging in my module or plugin?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/implementing-logging">Use Simple Logging Facade for Java (SLF4J) to log messages</a>.</p>
+  </div>
+</div>
+
+### Why did the entity sort order change when I migrated to a new database type? [](id=why-did-the-entity-sort-order-change-when-i-migrated-to-a-new-database-type)
+
+[Your new database uses a different default query result order--you should be able to configure a different order](/develop/tutorials/-/knowledge_base/7-0/sort-order-changed-with-a-different-database).
+
+## Services and Components [](id=troubleshooting-services-and-components)
+
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I detect unresolved OSGi components?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>Liferay Portal module components that use Service Builder use Dependency Manager (DM) and most other Liferay Portal module components use Declarative Services (DS). <a href="/develop/tutorials/-/knowledge_base/7-0/detecting-unresolved-osgi-components">Gogo shell commands and tools help you find and inspect unsatisfied component references for DM and DS components</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">What is the safest way to call non-OSGi code that uses OSGi services?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/calling-non-osgi-code-that-uses-osgi-services">Calling Non-OSGi Code that Uses OSGi Services</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I use files to configure components?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p>See <a href="/develop/tutorials/-/knowledge_base/7-0/using-files-to-configure-product-modules">Using Files to Configure Module Components</a>. </p>
+  </div>
+</div>
+
+<br/>
+<div class="ldn-faq-question">
+  <span class="ldn-faq-toggle-button" data-show="false" style="font-weight: normal;">How can I use OSGi services from Ext Plugins?&nbsp;<span class="icon-caret-right" style="pointer-events:none;"></span></span>
+  <div class="hide">  
+    <p><a href="/develop/tutorials/-/knowledge_base/7-0/using-osgi-services-from-ext-plugins">The registry API lets Ext Plugins use OSGi services </a>. </p>
+  </div>
+</div> 

--- a/develop/tutorials/articles/380-troubleshooting/12-sort-order-changed-with-different-database.markdown
+++ b/develop/tutorials/articles/380-troubleshooting/12-sort-order-changed-with-different-database.markdown
@@ -1,0 +1,31 @@
+# Sort Order Changed with a Different Database [](id=sort-order-changed-with-a-different-database)
+
+If you've been using @product@, but are switching it to use a different database
+type, consult your database vendor documentation to understand your old and new
+database's default query result order. The default order is either
+case-sensitive or case-insensitive. This affects entity sort order in @product@.
+
+Here are some examples of ascending alphabetical sort order. 
+
+Case-sensitive:
+
+    111
+    222
+    AAA
+    BBB
+    aaa
+    bbb
+
+Case-insensitive:
+
+    111
+    222
+    AAA
+    aaa
+    BBB
+    bbb
+
+Your new database's default query result order might differ from your current
+database's order. 
+
+Consult your vendor's documentation to configure the order the way you want. 


### PR DESCRIPTION
The Troubleshooting intro is now fleshed out with the dropdown text and links as we did in 7.0.

The DB sort order tutorial was one we added more recently for 7.0 that I'm porting to 7,1.

Thanks!

https://issues.liferay.com/browse/LRDOCS-4678  
https://issues.liferay.com/browse/LRDOCS-5626