### PR TITLE
Broken links

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/02-benefits-of-liferay-7-for-liferay-6-developers.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/02-benefits-of-liferay-7-for-liferay-6-developers.markdown
@@ -134,7 +134,7 @@ The Plugins SDK is no longer available for @product-ver@.
 is now Liferay's opinionated development environment. You
 can transition from a Plugins SDK by adding it to your workspace and migrating
 projects at your own pace. See the
-[Using a Plugins SDK from Your Workspace](/develop/tutorials/-/knowledge_base/7-1/configuring-a-liferay-workspace#using-a-plugins-sdk-from-your-workspace)
+[Using a Plugins SDK from Your Workspace](/develop/tutorials/-/knowledge_base/7-0/configuring-a-liferay-workspace#using-a-plugins-sdk-from-your-workspace)
 article for more information.
 
 Finally, we have also developed a lightweight tool called

--- a/develop/tutorials/articles/110-portlets/07-using-javascript-in-your-portlets/03-using-npm-in-your-portlets/08-npmresolver-api/01-obtaining-osgi-bundle-npm-package-descriptors.markdown
+++ b/develop/tutorials/articles/110-portlets/07-using-javascript-in-your-portlets/03-using-npm-in-your-portlets/08-npmresolver-api/01-obtaining-osgi-bundle-npm-package-descriptors.markdown
@@ -33,7 +33,7 @@ Follow these steps:
           jsPackage.getResolvedId() + " as bootstrapRequire");
  
 3.  Include the reference to the 
-    [`NPMResolver`](ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html):
+    [`NPMResolver`](@app-ref@/foundation/latest/javadocs/com/liferay/frontend/js/loader/modules/extender/npm/NPMResolver.html):
 
         @Reference
         private NPMResolver _npmResolver;

--- a/develop/tutorials/articles/260-import-export-and-staging/03-understanding-staged-models.markdown
+++ b/develop/tutorials/articles/260-import-export-and-staging/03-understanding-staged-models.markdown
@@ -8,7 +8,7 @@ entities during the Staging process. For example, the Bookmarks application
 manages
 [BookmarksEntry](@app-ref@/collaboration/latest/javadocs/com/liferay/bookmarks/model/BookmarksEntry.html)s
 and
-[BookmarksFolder](@app-ref/collaboration/latest/javadocs/com/liferay/bookmarks/model/BookmarksFolder.html)s,
+[BookmarksFolder](@app-ref@/collaboration/latest/javadocs/com/liferay/bookmarks/model/BookmarksFolder.html)s,
 and both implement the `StagedModel` interface. Once you've configured your
 staged models, you can create staged model data handlers, which supply
 information about a staged model (entity) and its referenced content to the


### PR DESCRIPTION
One broken link came from a PR that was merged before the check-links target was integrated into the `check` task. The other two are easy token errors.