### PR TITLE
LRDOCS-5770 Move 7.0 theme upgrade docs to new section

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/06-upgrading-themes/00-upgrading-themes-intro.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/06-upgrading-themes/00-upgrading-themes-intro.markdown
@@ -1,13 +1,12 @@
-# Upgrading Themes [](id=upgrading-themes-intro)
+# Upgrading 6.2 Themes [](id=upgrading-6-2-themes-intro)
 
-If you've developed themes in @product@ 7.0, as part of your upgrade you'll 
+If you've developed themes in @product@ 6.2, as part of your upgrade you'll 
 want to use them in @product-ver@. The upgrade process requires several 
 modifications. The 
 [Liferay Theme Generator](/develop/tutorials/-/knowledge_base/7-1/creating-themes)
 helps automate this process. 
 
-The following tutorials show you how to upgrade your Liferay Portal themes to 
-@product-ver@:
+The following tutorials show you how to upgrade your Liferay Portal 6.2 themes 
+to @product-ver@:
 
 - [Upgrading 6.2 Themes to 7.1](/develop/tutorials/-/knowledge_base/7-1/upgrading-6-2-themes-to-7-1)
-- [Upgrading 7.0 Themes to 7.1](/develop/tutorials/-/knowledge_base/7-1/upgrading-7-0-themes-to-7-1)

--- a/develop/tutorials/articles/03-from-liferay-70-to-71/06-upgrading-themes/00-upgrading-themes-intro.markdown
+++ b/develop/tutorials/articles/03-from-liferay-70-to-71/06-upgrading-themes/00-upgrading-themes-intro.markdown
@@ -1,0 +1,12 @@
+# Upgrading 7.0 Themes [](id=upgrading-7-0-themes-intro)
+
+If you've developed themes in @product@ 7.0, as part of your upgrade you'll 
+want to use them in @product-ver@. The upgrade process requires several 
+modifications. The 
+[Liferay Theme Generator](/develop/tutorials/-/knowledge_base/7-1/creating-themes)
+helps automate this process. 
+
+The following tutorials show you how to upgrade your Liferay Portal 7.0 themes 
+to @product-ver@:
+
+- [Upgrading 7.0 Themes to 7.1](/develop/tutorials/-/knowledge_base/7-1/upgrading-7-0-themes-to-7-1)


### PR DESCRIPTION
@sez11a this moves the 7.0 theme upgrade link to the new 7.0-7.1 section and renames the original 
 theme upgrade tutorial to upgrading-6.2-themes.
cc @jbalsas