### PR TITLE
LRDOCS-5773 Open file limit (npm)

### DIFF
--- a/develop/reference/articles/10-sample-projects/01-apps/03-npm-samples/00-intro.markdown
+++ b/develop/reference/articles/10-sample-projects/01-apps/03-npm-samples/00-intro.markdown
@@ -19,15 +19,8 @@ of open files allowed by your operating system:
 
     Error: ENFILE: file table overflow
 
-You can fix this issue by running this set of commands:
-
-    $ echo kern.maxfiles=65536 | sudo tee -a /etc/sysctl.conf
-    $ echo kern.maxfilesperproc=65536 | sudo tee -a /etc/sysctl.conf
-    $ sudo sysctl -w kern.maxfiles=65536
-    $ sudo sysctl -w kern.maxfilesperproc=65536
-    $ ulimit -n 65536
-
-This fix only pertains to macOS and Linux.
+Consult your operating system vendor's documentation to learn how to configure
+the maximum number of open files for your OS.
 
 $$$
 

--- a/develop/reference/articles/10-sample-projects/01-apps/03-npm-samples/00-intro.markdown
+++ b/develop/reference/articles/10-sample-projects/01-apps/03-npm-samples/00-intro.markdown
@@ -15,12 +15,9 @@ preferred build tool:
 +$$$
 
 **Note:** When building the npm samples, an error can occur caused by the limit
-of open files allowed by your operating system:
-
-    Error: ENFILE: file table overflow
-
-Consult your operating system vendor's documentation to learn how to configure
-the maximum number of open files for your OS.
+of open files allowed by your operating system. Consult your operating system
+vendor's documentation to learn how to configure the maximum number of open
+files for your OS.
 
 $$$
 

--- a/develop/reference/articles/10-sample-projects/01-apps/03-npm-samples/00-intro.markdown
+++ b/develop/reference/articles/10-sample-projects/01-apps/03-npm-samples/00-intro.markdown
@@ -12,6 +12,25 @@ preferred build tool:
 - [Maven sample apps](https://github.com/liferay/liferay-blade-samples/tree/7.1/maven/apps/npm)
 -->
 
++$$$
+
+**Note:** When building the npm samples, an error can occur caused by the limit
+of open files allowed by your operating system:
+
+    Error: ENFILE: file table overflow
+
+You can fix this issue by running this set of commands:
+
+    $ echo kern.maxfiles=65536 | sudo tee -a /etc/sysctl.conf
+    $ echo kern.maxfilesperproc=65536 | sudo tee -a /etc/sysctl.conf
+    $ sudo sysctl -w kern.maxfiles=65536
+    $ sudo sysctl -w kern.maxfilesperproc=65536
+    $ ulimit -n 65536
+
+This fix only pertains to macOS and Linux.
+
+$$$
+
 The following npm samples are documented:
 
 - [Angular npm Portlet](angular-npm-portlet)


### PR DESCRIPTION
I ended up going with your *very generic* solution. A quick Google search presented many different blogs/forums/etc. for ways to tinker with a slew of different OS types and versions. It's probably better to keep it simple and let devs set their limits on their own.

https://issues.liferay.com/browse/LRDOCS-5773