### PR TITLE
LRDOCS-5806 Remove repetitive intro text in samples | 7.0.x

### DIFF
--- a/develop/reference/articles/13-sample-projects/01-apps/01-greedy-policy-option-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/01-greedy-policy-option-portlet.markdown
@@ -1,7 +1,5 @@
 # Greedy Policy Option Application [](id=greedy-policy-option-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Greedy Policy Option sample provides two portlets that can be added to a
 @product@ page: Greedy Portlet and Reluctant Portlet.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/02-kotlin-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/02-kotlin-portlet.markdown
@@ -1,7 +1,5 @@
 # Kotlin Portlet [](id=kotlin-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Kotlin Portlet sample provides an input form that accepts a name. Once
 submitting a name, the portlet renders a greeting message.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/01-angular-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/01-angular-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # Angular npm Portlet [](id=angular-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Angular npm Portlet sample provides a portlet that uses the
 [Angular](https://angular.io/) framework to render its output.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/01-angular-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/01-angular-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # Angular npm Portlet [](id=angular-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The Angular npm Portlet sample provides a portlet that uses the
@@ -12,6 +9,9 @@ The Angular npm Portlet sample provides a portlet that uses the
 
 This portlet showcases Angular's speed and performance when rendering a user
 interface.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/02-billboardjs-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/02-billboardjs-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # Billboard.js npm Portlet [](id=billboard-js-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Billboard.js npm Portlet sample provides a portlet that uses the
 [Billboard.js](https://naver.github.io/billboard.js/) framework to render its
 output.

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/02-billboardjs-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/02-billboardjs-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # Billboard.js npm Portlet [](id=billboard-js-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The Billboard.js npm Portlet sample provides a portlet that uses the
@@ -13,6 +10,9 @@ output.
 
 This portlet showcases the power of graphing by displaying a set of default
 charts and a more advanced custom chart. These are all built using Billboard.js.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/03-isomorphic-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/03-isomorphic-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # Isomorphic npm Portlet [](id=isomorphic-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The Isomorphic npm Portlet sample provides a portlet that uses
@@ -14,6 +11,9 @@ can run from client and/or server side) on the client side.
 This portlet showcases running code designed to execute in the server
 in the browser. Note that this portlet does **not** run JavaScript code in the
 server; it's executing isomorphic JavaScript code in the browser.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/03-isomorphic-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/03-isomorphic-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # Isomorphic npm Portlet [](id=isomorphic-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Isomorphic npm Portlet sample provides a portlet that uses
 [isomorphic](https://en.wikipedia.org/wiki/Isomorphic_JavaScript) code (i.e.,
 can run from client and/or server side) on the client side. 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/04-jquery-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/04-jquery-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # jQuery npm Portlet [](id=jquery-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The jQuery npm Portlet sample provides a portlet that uses the
 [jQuery](https://jquery.com/) framework to render its output.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/04-jquery-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/04-jquery-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # jQuery npm Portlet [](id=jquery-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The jQuery npm Portlet sample provides a portlet that uses the
@@ -11,6 +8,9 @@ The jQuery npm Portlet sample provides a portlet that uses the
 ![Figure 1: Clicking on the portlet's hand symbol displays a message.](../../../../images/jquery-npm-sample.png)
 
 This portlet showcases the fast HTML document traversal jQuery offers.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/05-metaljs-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/05-metaljs-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # Metal.js npm Portlet [](id=metal-js-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The Metal.js npm Portlet sample provides a portlet that uses the
@@ -12,6 +9,9 @@ The Metal.js npm Portlet sample provides a portlet that uses the
 
 This portlet displays a Metal.js based dialog that has been rendered using SOY
 templates.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/05-metaljs-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/05-metaljs-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # Metal.js npm Portlet [](id=metal-js-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Metal.js npm Portlet sample provides a portlet that uses the
 [Metal.js](https://metaljs.com/) framework to render its output.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/06-react-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/06-react-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # React npm Portlet [](id=react-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The React npm Portlet sample provides a portlet that uses the
@@ -12,6 +9,9 @@ The React npm Portlet sample provides a portlet that uses the
 
 This portlet showcases the how efficiently React can render components based on
 user interaction.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/06-react-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/06-react-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # React npm Portlet [](id=react-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The React npm Portlet sample provides a portlet that uses the
 [React](https://reactjs.org/) framework to render its output.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/07-simple-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/07-simple-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # Simple npm Portlet [](id=simple-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Simple npm Portlet sample provides a portlet that uses the
 [isarray npm package](https://www.npmjs.com/package/isarray) when rendering its
 output.

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/07-simple-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/07-simple-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # Simple npm Portlet [](id=simple-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The Simple npm Portlet sample provides a portlet that uses the
@@ -10,6 +7,9 @@ The Simple npm Portlet sample provides a portlet that uses the
 output.
 
 ![Figure 1: The portlet's status and actions are displayed as output.](../../../../images/simple-npm-sample.png)
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/08-vuejs-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/08-vuejs-npm-portlet.markdown
@@ -1,8 +1,5 @@
 # Vue.js npm Portlet [](id=vue-js-npm-portlet)
 
-**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
-CE GA7+.
-
 ## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
 
 The Vue.js npm Portlet sample provides a portlet that uses the
@@ -12,6 +9,9 @@ The Vue.js npm Portlet sample provides a portlet that uses the
 
 This portlet showcases Vue.js's speed and performance when rendering a user
 interface.
+
+**Important:** This sample works for Liferay DXP Fix Pack 44+ and Liferay Portal
+CE GA7+.
 
 ## What API(s) and/or code components does this sample highlight? [](id=what-apis-and-or-code-components-does-this-sample-highlight)
 

--- a/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/08-vuejs-npm-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/03-npm-samples/08-vuejs-npm-portlet.markdown
@@ -1,7 +1,5 @@
 # Vue.js npm Portlet [](id=vue-js-npm-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Vue.js npm Portlet sample provides a portlet that uses the
 [Vue.js](https://vuejs.org/) framework to render its output.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/04-service-builder-samples/04-service-builder-adq.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/04-service-builder-samples/04-service-builder-adq.markdown
@@ -1,7 +1,5 @@
 # Service Builder Application Demonstrating Actionable Dynamic Query [](id=service-builder-application-demonstrating-actionable-dynamic-query)
 
-## What does this sample do when deployed? [](id=what-does-this-sample-do-when-deployed)
-
 This sample is similar to the
 [`basic` Service Builder sample](https://github.com/liferay/liferay-blade-samples/tree/7.0/gradle/apps/service-builder/basic),
 which lets you perform CRUD (create, read, update, delete) operations on service

--- a/develop/reference/articles/13-sample-projects/01-apps/05-service-builder-samples/02-service-builder-jdbc.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/05-service-builder-samples/02-service-builder-jdbc.markdown
@@ -1,7 +1,5 @@
 # Service Builder Application Using External Database via JDBC [](id=service-builder-application-using-external-database-via-jdbc)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 This sample demonstrates how to connect a Liferay Service Builder application to
 an external database via a JDBC connection. Here, an external database means any
 database other than @product@'s database. For this sample to work correctly, you

--- a/develop/reference/articles/13-sample-projects/01-apps/05-service-builder-samples/03-service-builder-jndi.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/05-service-builder-samples/03-service-builder-jndi.markdown
@@ -1,7 +1,5 @@
 # Service Builder Application Using External Database via JNDI [](id=service-builder-application-using-external-database-via-jndi)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 This sample demonstrates how to connect a Liferay Service Builder application to
 an external database via a JNDI connection. Here, an external database means any
 database other than @product@'s database. For this sample to work correctly, you

--- a/develop/reference/articles/13-sample-projects/01-apps/06-shared-language-keys.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/06-shared-language-keys.markdown
@@ -1,7 +1,5 @@
 # Shared Language Keys [](id=shared-language-keys)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Shared Language Keys sample provides a JSP portlet that displays language
 keys.
 

--- a/develop/reference/articles/13-sample-projects/01-apps/07-simulation-panel-app.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/07-simulation-panel-app.markdown
@@ -1,7 +1,5 @@
 # Simulation Panel App [](id=simulation-panel-app)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Simulation Panel App provides new functionality in @product's Simulation
 Menu. When deploying this sample with no customizations, the *Simulation Sample*
 feature is provided in the Simulation Menu with four options.

--- a/develop/reference/articles/13-sample-projects/01-apps/08-spring-mvc-portlet.markdown
+++ b/develop/reference/articles/13-sample-projects/01-apps/08-spring-mvc-portlet.markdown
@@ -1,7 +1,5 @@
 # Spring MVC Portlet [](id=spring-mvc-portlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Spring MVC portlet provides a way to add various different fields into the
 database and display them in a table. This project is a Spring MVC based portlet
 WAR that implements the same functionality as the

--- a/develop/reference/articles/13-sample-projects/02-extensions/01-control-menu-entry.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/01-control-menu-entry.markdown
@@ -1,7 +1,5 @@
 # Control Menu Entry [](id=control-menu-entry)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Control Menu Entry sample provides a customizable button that is added to
 Liferay Portal's default Control Menu. When deploying this sample with no
 customizations, an additional button is added to the User (right side) portion

--- a/develop/reference/articles/13-sample-projects/02-extensions/02-document-action.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/02-document-action.markdown
@@ -1,7 +1,5 @@
 # Document Action [](id=document-action)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Document Action sample shows how to add a context menu option to an entry in
 the Documents and Media portlet. When deploying this sample with no
 customizations, an additional menu option is available in the Documents and

--- a/develop/reference/articles/13-sample-projects/02-extensions/03-gogo-shell-command.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/03-gogo-shell-command.markdown
@@ -1,7 +1,5 @@
 # Gogo Shell Command [](id=gogo-shell-command)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Gogo Shell Command sample demonstrates adding a custom command to
 @product@'s Gogo shell environment. All @product@ installations have a Gogo
 shell environment, which lets system administrators interact with @product@'s

--- a/develop/reference/articles/13-sample-projects/02-extensions/04-indexer-post-processor.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/04-indexer-post-processor.markdown
@@ -1,7 +1,5 @@
 # Indexer Post Processor [](id=indexer-post-processor)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Indexer Post Processor sample demonstrates using the `IndexerPostProcessor`
 interface, which is provided to customize search queries and documents before
 they're sent to the search engine, and/or customize result summaries when

--- a/develop/reference/articles/13-sample-projects/02-extensions/05-model-listener.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/05-model-listener.markdown
@@ -1,7 +1,5 @@
 # Model Listener [](id=model-listener)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Model Listener sample demonstrates adding a custom model listener to a
 Liferay Portal out-of-the-box entity. When deploying this sample with no
 customizations, a custom model listener is added to the portal's layouts,

--- a/develop/reference/articles/13-sample-projects/02-extensions/06-screen-name-validator.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/06-screen-name-validator.markdown
@@ -1,7 +1,5 @@
 # Screen Name Validator [](id=screen-name-validator)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Screen Name Validator sample provides a way to validate a user's inputted
 screen name. During validation, the screen name is tested client-side and
 server-side.

--- a/develop/reference/articles/13-sample-projects/02-extensions/07-servlet.markdown
+++ b/develop/reference/articles/13-sample-projects/02-extensions/07-servlet.markdown
@@ -1,7 +1,5 @@
 # Servlet [](id=servlet)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Servlet sample provides an OSGi Whiteboard Servlet in @product@. When
 deploying this sample and configuring the servlet, a *Hello World* message is
 displayed when accessing the servlet page URL. Log info is also outputted to

--- a/develop/reference/articles/13-sample-projects/03-overrides/01-core-jsp-override.markdown
+++ b/develop/reference/articles/13-sample-projects/03-overrides/01-core-jsp-override.markdown
@@ -1,7 +1,5 @@
 # Core JSP Override [](id=core-jsp-hook)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Core JSP Override sample lets you override core/kernel JSPs by adding them
 to the module's `META-INF/jsps` folder. This module overrides the @product@'s
 `bottom.jsp` file by inserting the `bottom-ext.jsp` file in the

--- a/develop/reference/articles/13-sample-projects/03-overrides/02-module-jsp-override.markdown
+++ b/develop/reference/articles/13-sample-projects/03-overrides/02-module-jsp-override.markdown
@@ -1,7 +1,5 @@
 # Module JSP Override [](id=module-jsp-override)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Module JSP Override sample conveys Liferay's recommended approach to
 override an application's JSP by leveraging OSGi fragment modules. This example
 overrides the default `login.jsp` file in the `com.liferay.login.web` bundle by

--- a/develop/reference/articles/13-sample-projects/03-overrides/03-resource-bundle-override.markdown
+++ b/develop/reference/articles/13-sample-projects/03-overrides/03-resource-bundle-override.markdown
@@ -1,7 +1,5 @@
 # Resource Bundle Override [](id=resource-bundle-override)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 This example overrides the default `add-blog-entry` language key (English and
 Spanish) for @product@'s default Blogs application. After deploying this sample
 hook to @product@, the Blogs application's *Add Blog Entry* button is modified

--- a/develop/reference/articles/13-sample-projects/04-themes/01-simple-theme.markdown
+++ b/develop/reference/articles/13-sample-projects/04-themes/01-simple-theme.markdown
@@ -1,7 +1,5 @@
 # Simple Theme [](id=theme)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Simple Theme sample provides the base files for a theme, using the
 [Theme Builder Gradle plugin](/develop/reference/-/knowledge_base/7-0/theme-builder-gradle-plugin).
 When deploying this sample with no customizations, a theme based off of the 

--- a/develop/reference/articles/13-sample-projects/04-themes/02-template-context-contributor.markdown
+++ b/develop/reference/articles/13-sample-projects/04-themes/02-template-context-contributor.markdown
@@ -1,7 +1,5 @@
 # Template Context Contributor [](id=template-context-contributor)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Template Context Contributor sample injects a new variable into @product@'s
 theme context. When deploying this sample with no customizations, you can use
 the `${sample_text}` variable from any theme.

--- a/develop/reference/articles/13-sample-projects/04-themes/03-theme-contributor.markdown
+++ b/develop/reference/articles/13-sample-projects/04-themes/03-theme-contributor.markdown
@@ -1,7 +1,5 @@
 # Theme Contributor [](id=theme-contributor)
 
-## What does this sample do when it's deployed? [](id=what-does-this-sample-do-when-its-deployed)
-
 The Theme Contributor sample contributes updates to the UI of the theme
 body, Control Menu, Product Menu, and Simulation Panel. When deploying this
 sample with no customizations, the colors of the theme and aforementioned menus


### PR DESCRIPTION
This came as a suggestion from a community member. The repetitive intro text in our samples is causing unhelpful preview text in LDN's article tiles (e.g., see [here](https://dev.liferay.com/develop/reference/-/knowledge_base/7-0/npm-samples)).

https://issues.liferay.com/browse/LRDOCS-5806