### PR TITLE
LRDOCS-4709 de-emphasize PACL and clarify when to use it.

### DIFF
--- a/distribute/publish/articles/01-publishing-your-app/01-planning-your-apps-distribution/04-app-versioning-and-target-liferay-editions-and-versions.markdown
+++ b/distribute/publish/articles/01-publishing-your-app/01-planning-your-apps-distribution/04-app-versioning-and-target-liferay-editions-and-versions.markdown
@@ -25,12 +25,12 @@ files that are designed for those different versions. The next article in this
 guide explains how to go about
 [specifying packaging directives](/distribute/how-to-publish/-/knowledge_base/how-to-publish/preparing-your-app). 
 
-Note that apps on the Liferay Marketplace must be designed for Liferay Portal 6.1 or
-later. That's not to say that they can't work with prior versions. However, only
-Liferay Portal 6.1 and later versions support installing apps directly from the
-Marketplace and provide safeguards against malicious apps. If you want to use an
-app with an earlier version of Liferay, make sure that version of Liferay
-provides what your app needs from Liferay. 
+Note that apps on the Liferay Marketplace must be designed for Liferay Portal
+6.1 GA3 or later. That's not to say that they can't work with prior versions.
+However, only Liferay Portal 6.1 GA3 and later versions support installing apps
+directly from the Marketplace and provide safeguards against malicious apps. If
+you want to use an app with an earlier version of Liferay, make sure that
+version of Liferay provides what your app needs from Liferay. 
 
 Lastly, you should determine a versioning scheme for your app. How will you
 refer to the first version of your app, the second version, and so on. 

--- a/distribute/publish/articles/01-publishing-your-app/02-preparing-your-app/00-preparing-your-app-intro.markdown
+++ b/distribute/publish/articles/01-publishing-your-app/02-preparing-your-app/00-preparing-your-app-intro.markdown
@@ -21,11 +21,6 @@ for OSGi modules) are uploaded as part of the publication process, along with
 information (name, description, version, icon, etc.) that identifies the app.
 The publication process is described in detail later.
 
-At this point in preparing to publish your app, you've developed your app. And
-if you're preparing a paid app for Liferay Portal 6.2, you've specified a
-permission descriptor (a [portal access control list](/develop/tutorials/-/knowledge_base/6-2/plugin-security-and-pacl)
-for traditional plugins), so that your app can be deployed on Liferay instances
-that have their
-[Plugin Security Manager](/develop/tutorials/-/knowledge_base/6-2/plugin-security-and-pacl#enabling-the-security-manager) 
-running. But before you start the formal publishing process, you must prepare 
-your app's files and app metadata. 
+At this point in preparing to publish your app, you've developed your app. But
+before you start the formal publishing process, you must prepare your app's
+files and app metadata. 

--- a/distribute/publish/articles/01-publishing-your-app/02-preparing-your-app/02-packaging-your-marketplace-app.markdown
+++ b/distribute/publish/articles/01-publishing-your-app/02-preparing-your-app/02-packaging-your-marketplace-app.markdown
@@ -60,10 +60,11 @@ keep in mind:
   file:**
     - Property `recommended.deployment.context` must not be set.
     - Setting property `security-manager-enabled` to `true` is mandatory for all
-      paid apps on 6.1 EE/CE GA3 and later and on 6.2 EE/CE; the setting is
-      optional for free apps. Setting this property to `true` enables Liferay's
-      Plugin Security Manager. If you're enabling the security manager, you must
-      also define your Portal Access Control List (PACL) in this file. Read
+      paid apps that contain WAR-style plugins and that are for 6.1 EE/CE GA3
+      and 6.2 EE/CE; the setting is optional for free apps. Setting this
+      property to `true` enables Liferay's Plugin Security Manager. If you're
+      enabling the security manager, you must also define your Portal Access
+      Control List (PACL) in this file. Read
       [Plugins Security and PACL](/develop/tutorials/-/knowledge_base/6-2/plugin-security-and-pacl)
       for information on developing secure apps.
 - **Deployment contexts**:
@@ -93,8 +94,8 @@ Portal CE 7.x apps:
 +$$$
 
 **Important:** If you're developing a paid app or want your free app to satisfy
-Plugin Security Manager on Liferay 6.2 or 6.1, make sure to specify PACLs for
-your traditional plugins. See the article
+Plugin Security Manager on Liferay 6.2 or 6.1 GA3, make sure to specify PACLs
+for your traditional WAR-style plugins. See the article
 [Plugin Security and PACL](/develop/tutorials/-/knowledge_base/6-2/plugin-security-and-pacl) 
 for details. Give yourself adequate time to develop your app's permission
 descriptors and time to test your app thoroughly with the security manager

--- a/distribute/publish/articles/01-publishing-your-app/03-submitting-your-app/01-your-apps-initial-details.markdown
+++ b/distribute/publish/articles/01-publishing-your-app/03-submitting-your-app/01-your-apps-initial-details.markdown
@@ -75,12 +75,12 @@ do so here.
 
 **Labs:** You can denote an app as experimental by checking the appropriate box.
 
-**Security:** If your app is for Liferay 7.x or does *not* use Liferay's PACL 
-Security Manager, check the appropriate box. Otherwise, make sure to enable the
-security manager in your app by including the setting
-`security-manager-enabled=true` in the
+**Security:** If your app is only for Liferay 7.0 or later, or does not contain 
+WAR-style plugins, or does *not* use Liferay's PACL Security Manager, check the
+appropriate box. Otherwise, enable the security manager in your app by including
+the setting `security-manager-enabled=true` in the
 [`liferay-plugin-package.properties`](http://docs.liferay.com/portal/6.2/propertiesdoc/liferay-plugin-package_6_2_0.properties.html)
-file in your WAR files. 
+file in your plugin WAR files. 
 
 **Tags:** A set of descriptive words that categorize your app. These tags are
 free-form and can help potential purchasers find your app through keyword


### PR DESCRIPTION
PACL is only applicable for apps that have WAR-style plugins and are for 6.1 GA3 or 6.2 releases.

https://issues.liferay.com/browse/LRDOCS-4709 