### PR TITLE
LRDOCS-6316 7.1: Overriding and aggregating resource bundles using OSGi manifest headers

### DIFF
--- a/develop/tutorials/articles/120-customizing/04-overriding-language-keys/02-overriding-a-modules-language-keys.markdown
+++ b/develop/tutorials/articles/120-customizing/04-overriding-language-keys/02-overriding-a-modules-language-keys.markdown
@@ -131,7 +131,7 @@ and applies them to the `com.liferay.blogs.web` module.
         }
 
     	@Reference(
-    		target = "(&(bundle.symbolic.name=com.liferay.blogs.web)(!(component.name=com.liferay.docs.override.moduleresourcebundle.MyBlogsResourceBundleLoader)))"
+    		target = "(&(bundle.symbolic.name=com.liferay.blogs.web)(!(resource.bundle.aggregate=*))(!(component.name=com.liferay.docs.override.moduleresourcebundle.MyBlogsResourceBundleLoader)))"
     	)
     	public void setResourceBundleLoader(
     		ResourceBundleLoader resourceBundleLoader) {
@@ -192,7 +192,7 @@ The setter method `setResourceBundleLoader` assigns an aggregate of this class's
 resource bundle loader and the target resource bundle loader to the
 `_resourceBundleLoader` field. 
         
-    @Reference(target = "(&(bundle.symbolic.name=com.liferay.blogs.web)(!(component.name=com.liferay.docs.override.moduleresourcebundle.MyBlogsResourceBundleLoader)))"
+    @Reference(target = "(&(bundle.symbolic.name=com.liferay.blogs.web)(!(resource.bundle.aggregate=*))(!(component.name=com.liferay.docs.override.moduleresourcebundle.MyBlogsResourceBundleLoader)))"
     )
     public void setResourceBundleLoader(
         ResourceBundleLoader resourceBundleLoader) {

--- a/develop/tutorials/articles/300-internationalization/01-localizing-your-application.markdown
+++ b/develop/tutorials/articles/300-internationalization/01-localizing-your-application.markdown
@@ -125,11 +125,11 @@ application with multiple modules that provide the view layer. These modules are
 often called web modules.
 
     my-application/
-        my-application-web/
-        my-admin-application-web/
-        my-application-content-web/
-        my-application-api/
-        my-application-service/
+    my-application-web/
+    my-admin-application-web/
+    my-application-content-web/
+    my-application-api/
+    my-application-service/
 
 Each of these modules can have language keys and translations to maintain, and
 there will probably be duplicate keys. You don't want to end up with different
@@ -188,8 +188,8 @@ module and optionally include its own resource bundle. OSGi manifest headers
 especially easy in modules generated from Liferay project templates.
 Instructions for using a language module are divided into these environments:
 
--  [Modules generated from Liferay project templates](#using-a-language-module-from-a-module)
--  [Traditional plugins or modules that don't use Liferay's bnd plugin](#using-a-language-module-from-a-traditional-plugin)
+-  [Using a Language Module from a Module](#using-a-language-module-from-a-module)
+-  [Using a Language Module from a Traditional Plugin](#using-a-language-module-from-a-traditional-plugin)
 
 If you're using bnd with Maven or Gradle, you need only specify Liferay's
 `-liferay-aggregate-resource-bundle:` bnd instruction--at build time, Liferay's
@@ -206,7 +206,8 @@ Here's how to do it:
 1.  Open your module's `bnd.bnd` file.
 
 2.  Add the `-liferay-aggregate-resource-bundles:` bnd instruction and assign it
-    the bundle symbolic names of modules whose resource bundles to use. 
+    the bundle symbolic names of modules whose resource bundles to aggregate
+    with the current module's resource bundle. 
 
         -liferay-aggregate-resource-bundles: \
             [bundle.symbolic.name1],\
@@ -220,7 +221,7 @@ would set this in its `bnd.bnd` file:
         com.liferay.docs.l10n.myapp1.lang,\
         com.liferay.docs.l10n.myapp2.lang
 
-The current module's language keys are prioritized over those from the other
+The current module's resource bundle is prioritized over those of the listed
 modules. 
 
 +$$$
@@ -236,6 +237,13 @@ At build time, Liferay's bnd plugin converts the bnd instruction to
 `Require-Capability` and `Provide-Capability` parameters automatically. In
 traditional Liferay plugins, you must specify the parameters manually. 
 
++$$$
+
+**Note:** You can always specify the `Require-Capability` and `Provide-
+Capability` OSGi manifest headers manually, as the next section demonstrates.  
+
+$$$
+
 ### Using a Language Module from a Traditional Plugin [](id=using-a-language-module-from-a-traditional-plugin)
 
 To use a language module, from a traditional Liferay plugin you must specify the
@@ -248,63 +256,65 @@ module:
 1.  Open the plugin's `liferay-plugin-package.properties` file and add a 
     `Require-Capability` header that filters on the language module's resource
     bundle capability. For example, if the language module's symbolic name is
-    `com.liferay.docs.l10n.myapp.lang`, you'd specify the requirement like this:
+    `myapp.lang`, you'd specify the requirement like this:
 
-        Require-Capability: liferay.resource.bundle;filter:="(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)"
+        Require-Capability: liferay.resource.bundle;filter:="(bundle.symbolic.name=myapp.lang)"
 
 2.  In the same `liferay-plugin-package.properties` file, add a 
     `Provide-Capability` header that adds the language module's resource bundle
-    *as* this plugin's own resource bundle:
+    *as* this plugin's (the `myapp.web` plugin) own resource bundle:
 
-        Provide-Capability: liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)";resource.bundle.base.name="content.Language"
+        Provide-Capability:\
+        liferay.resource.bundle;resource.bundle.base.name="content.Language",\
+        liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=myapp.lang)";bundle.symbolic.name=myapp.web;resource.bundle.base.name="content.Language";service.ranking:Long="4";\
+        servlet.context.name=myapp-web
 
-In this case, the plugin solely uses the language module's resource bundle. 
+In this case, the `myapp.web` plugin solely uses the language module's resource
+bundle---the resource bundle aggregate only includes language module
+`myapp.lang`. 
 
-Aggregating resource bundles comes into play when you want to use your plugin's
-resource bundle *in addition to* a resource bundle from a module. These
-instructions show you how to do this, while prioritizing your plugin's resource
-bundle over the module resource bundle. In this way, the module's language keys
-compliment your plugin's language keys. 
+Aggregating resource bundles comes into play when you want to use your a
+language module's resource bundle *in addition to* your plugin's resource
+bundle. These instructions show you how to do this, while prioritizing your
+current plugin's resource bundle over the language module resource bundle. In
+this way, the language module's language keys compliment your plugin's language
+keys. 
 
-For example, a portlet whose bundle symbolic name is `my-portlet` uses
-keys from language module `com.liferay.docs.l10n.myapp.lang`, but overrides some
-of them. The portlet's `Provide-Capability` and `Web-ContextPath` OSGi
-headers accomplish this.
+For example, a portlet whose bundle symbolic name is `myapp.web` uses keys from
+language module `myapp.lang`, in addition to its own. The portlet's
+`Provide-Capability` and `Web-ContextPath` OSGi headers accomplish this.
 
     Provide-Capability:\
-    liferay.resource.bundle;resource.bundle.base.name:String="(bundle.symbolic.name=my-portlet)";resource.bundle.base.name="content.Language",\
-    liferay.resource.bundle;resource.bundle.aggregate:String="(&(bundle.symbolic.name=my-portlet)(!(aggregate=true))),(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)";bundle.symbolic.name=my-portlet;resource.bundle.base.name="content.Language";service.ranking:Long="1";aggregate=true;\
-    servlet.context.name=my-admin-application-web
+    liferay.resource.bundle;resource.bundle.base.name="content.Language",\
+    liferay.resource.bundle;resource.bundle.aggregate:String="(bundle.symbolic.name=myapp.web),(bundle.symbolic.name=myapp.lang)";bundle.symbolic.name=myapp.web;resource.bundle.base.name="content.Language";service.ranking:Long="4";\
+    servlet.context.name=myapp-web
 
-    Web-ContextPath:/my-admin-application-web
+Let's examine the example `Provide-Capability` header. 
 
-Each line is explained:
+1.  `liferay.resource.bundle;resource.bundle.base.name="content.Language"` 
+    declares that the module provides a resource bundle whose base name is
+    `content.language`. 
 
-1.  The first `Provide-Capability` line declares the portlet's resource
-    bundle. This portlet's bundle symbolic name is
-    `my-portlet`. 
+2.  The `liferay.resource.bundle;resource.bundle.aggregate:String=...` directive
+    specifies the list of bundles whose resource bundles are aggregated, the
+    target bundle, the target bundle's resource bundle name, and this service's
+    ranking:
 
-        liferay.resource.bundle;resource.bundle.base.name:String="(bundle.symbolic.name=my-portlet)";resource.bundle.base.name="content.Language",\
-
-2.  The second `Provide-Capability` line aggregates the portlet resource
-    bundle and the language module resource bundle, prioritizing the portlet
-    resource bundle over the language module resource bundle. The last part of
-    this capability declares the module's servlet context name. 
-
-        liferay.resource.bundle;resource.bundle.aggregate:String="(&(bundle.symbolic.name=my-portlet)(!(aggregate=true))),(bundle.symbolic.name=com.liferay.docs.l10n.myapp.lang)";bundle.symbolic.name=my-portlet;resource.bundle.base.name="content.Language";service.ranking:Long="1";aggregate=true;\
-        servlet.context.name=my-admin-application-web
-
-3.  The `Web-ContextPath` header declares the portlet's web context path.
-    @product@ uses the web context path and the servlet context declared in
-    the `Provide-Capability` header to make the aggregated resource bundle
-    available to the portlet's JSPs automatically.
-
-        Web-ContextPath:/my-admin-application-web
-
-To aggregate web module keys and language module keys, follow the pattern
-demonstrated by the example above. The example language module and web modules
-can be downloaded 
-[here](https://dev.liferay.com/documents/10184/656312/l10n-my-application.zip). 
+    -   `"(bundle.symbolic.name=myapp.web),(bundle.symbolic.name=myapp.lang)"`:
+        The service aggregates resource bundles from bundles
+        `bundle.symbolic.name=myapp.web` (the current
+        module) and `bundle.symbolic.name=myapp.lang`.
+        Aggregate as many bundles as desired. Listed bundles are prioritized in
+        descending order. 
+    -   `bundle.symbolic.name=myapp.web;resource.bundle.base.name="content.Language"`:
+        Override the `myapp.web` bundle's resource bundle named
+        `content.Language`.
+    -   `service.ranking:Long="4"`: The resource bundle's service ranking is 
+        `4`. The OSGi framework applies this service if it outranks all other
+        resource bundle services that target `myapp.web`'s
+        `content.Language` resource bundle. 
+    -   `servlet.context.name=myapp-web`: The target resource bundle is in 
+        servlet context `myapp-web`. 
 
 Now the language keys from the aggregated resource bundles compliment your
 plugin's language keys.


### PR DESCRIPTION
Resource bundle loaders are no longer needed for overriding language keys; OSGi manifest headers let you do everything. The articles on overriding language keys and using language keys are updated.

https://issues.liferay.com/browse/LRDOCS-6316