### PR TITLE
LRDOCS-6294 7.1: fix sidebar syntax

### DIFF
--- a/develop/tutorials/articles/130-service-builder/02-service-builder-persistence/01-defining-an-object-relational-map-with-service-builder/04-defining-the-columns-attributes-for-each-service-entity.markdown
+++ b/develop/tutorials/articles/130-service-builder/02-service-builder-persistence/01-defining-an-object-relational-map-with-service-builder/04-defining-the-columns-attributes-for-each-service-entity.markdown
@@ -25,13 +25,13 @@ Bookmarks application. However, it's possible to use multiple columns as the
 primary key for an entity. In this case, the combination of columns makes up
 a compound primary key for the entity.
 
-+###
++$$$
 
 **Note:** The
 [Implementing an Add Method](/develop/tutorials/-/knowledge_base/7-1/implementing-an-add-method#generate-a-primary-key)
 article demonstrates how to generate unique primary keys for entity instances. 
 
-###
+$$$
 
 ## Create Entity Columns [](id=create-entity-columns)
 


### PR DESCRIPTION
In my snippet, I used the wrong characters for sidebars--- used `+###` instead of `+$$$`, and same for closing sidebar chars.

https://issues.liferay.com/browse/LRDOCS-6294