### PR TITLE
LRDOCS-6487 note how to create global editor configuration

### DIFF
--- a/develop/tutorials/articles/230-wysiwyg-editors/02-modifying-an-editor-configuration.markdown
+++ b/develop/tutorials/articles/230-wysiwyg-editors/02-modifying-an-editor-configuration.markdown
@@ -51,7 +51,8 @@ provided below.
             property = {
                 "editor.config.key=contentEditor", "editor.name=alloyeditor",
                 "javax.portlet.name=com_liferay_blogs_web_portlet_BlogsPortlet",
-                "javax.portlet.name=com_liferay_blogs_web_portlet_BlogsAdminPortlet", "service.ranking:Integer=100"
+                "javax.portlet.name=com_liferay_blogs_web_portlet_BlogsAdminPortlet", 
+                "service.ranking:Integer=100"
             },
 			
             service = EditorConfigContributor.class
@@ -63,6 +64,47 @@ provided below.
     to all editors in those portlets. Lastly, the service ranking is listed,
     which prioritizes this service over others that are currently deployed in
     @product@.
+
+    +$$$
+    
+    **NOTE:** If you want to create a global configuration that applies to an 
+    editor everywhere it's used, you must create two separate configurations: 
+    one configuration that targets just the editor and a second configuration 
+    that targets the Blogs and Blogs Admin portlets. For example, the two 
+    separate configurations below apply the updates to AlloyEditor everywhere 
+    it's used:
+    
+    Configuration one:
+    
+    ```java
+    @Component(
+        immediate = true, 
+        property = {
+            "editor.name=alloyeditor", 
+            "service.ranking:Integer=100"
+        },
+    
+        service = EditorConfigContributor.class
+    )
+    ```
+    
+    Configuration two:
+    
+    ```java
+    @Component(
+        immediate = true, 
+        property = {
+            "editor.name=alloyeditor",
+            "javax.portlet.name=com_liferay_blogs_web_portlet_BlogsPortlet",
+            "javax.portlet.name=com_liferay_blogs_web_portlet_BlogsAdminPortlet", 
+            "service.ranking:Integer=100"
+        },
+    
+        service = EditorConfigContributor.class
+    )
+    ```
+    
+    $$$
 
 4.  Now that you've specified which editor configurations you want to modify,
     you must specify what about them must change. Add the following method to

--- a/develop/tutorials/articles/230-wysiwyg-editors/02-modifying-an-editor-configuration.markdown
+++ b/develop/tutorials/articles/230-wysiwyg-editors/02-modifying-an-editor-configuration.markdown
@@ -59,11 +59,26 @@ provided below.
         )
 
     This annotation declares that the following service is applied for the
-    AlloyEditor identified by the `contentEditor` configuration key. Two portlet
-    names are specified (Blogs and Blogs Admin), which means the service applies
-    to all editors in those portlets. Lastly, the service ranking is listed,
-    which prioritizes this service over others that are currently deployed in
-    @product@.
+    AlloyEditor identified by the `contentEditor` configuration key. 
+    
+    +$$$
+    
+    **Note:** If you're targeting all editors for a portlet, the 
+    `editor.config.key` is not required. For example, if you just want to target 
+    the Web Content portlet's editors, you can provide the configuration below:
+    
+        @Component(
+          property = {"editor.name=ckeditor",
+          "javax.portlet.name=com_liferay_journal_web_portlet_JournalPortlet",
+          "service.ranking:Integer=100"
+        }
+    
+    $$$
+    
+    Two portlet names are specified (Blogs and Blogs Admin), which means the 
+    service applies to all editors in those portlets. Lastly, the service 
+    ranking is listed, which prioritizes this service over others that are 
+    currently deployed in @product@.
 
     +$$$
     


### PR DESCRIPTION
@sez11a  This include LRDOCS-6425 and LRDOCS-6487

cc@jbalsas I've spoken with the km-team member for blogs. For now, we will push the note through. We can plan to document Blogs and Blogs Admin configuration/framework separately after the release.