### PR TITLE
 LRDOCS-6649 7.2: Specifying dependencies

### DIFF
--- a/deployment/articles/04-securing-liferay/07-openid-connect-authentication.markdown
+++ b/deployment/articles/04-securing-liferay/07-openid-connect-authentication.markdown
@@ -5,13 +5,13 @@ header-id: authenticating-with-openid-connect
 # Authenticating with OpenID Connect
 
 OpenID Connect is a lightweight authentication layer built on top of the 
-[OAuth 2.0](/discover/deployment/-/knowledge_base/7-1/oauth-2-0) 
-authorization protocol. It compliments having local accounts by enabling users
-to authenticate using accounts they have on other systems. Users who avoid
-signing up for new accounts can then use an account they already have to sign
-into your website. By using OpenID Connect, you *delegate* user authentication
-to other providers, making it easy for users with existing accounts to
-authenticate to your system. 
+[OAuth 2.0](/docs/7-2/deploy/-/knowledge_base/d/oauth-2-0) 
+authorization protocol. It compliments local accounts by enabling users to
+authenticate using accounts they have on other systems. Users who avoid signing
+up for new accounts can then use an account they already have to sign into your
+website. By using OpenID Connect, you *delegate* user authentication to other
+providers, making it easy for users with existing accounts to authenticate to
+your system. 
 
 | **Note:** You can add multiple providers to your installation, but @product@
 | can't yet be an OpenID Connect provider.
@@ -34,7 +34,7 @@ This is an OAuth 2.0 client. The process varies by provider:
 
         https://[server.domain]/c/portal/login/openidconnect
 
-3.  The provider will send several pieces of information. Some of these, like
+3.  The provider sends several pieces of information. Some of these, like
     the Discovery Endpoint, Authorization Endpoint, or Issuer URL are the same
     regardless of the client. The two pieces of information unique to your
     request are the `client_id` and the `client_secret`. 
@@ -66,6 +66,9 @@ provider may offer other scopes of user information.
 **Discovery Endpoint:** Other URLs may be obtained from this URL, and they vary
 by provider. 
 
+**Discovery Endpoint Cache in Milliseconds:** Cache the endpoints (URLs)
+discovered for this amount of time. 
+
 **Authorization Endpoint:** This URL points to the provider's URL for
 authorizing the user (i.e., signing the user in). 
 
@@ -74,6 +77,10 @@ who is issuing the user information.
 
 **JWKS URI:** A URL that points to the provider's JSON Web Key Set that contains
 the public keys that can verify the provider's tokens. 
+
+**ID Token Signing Algorithms:** Set the supported ID token algorithms manually.
+Normally, this is "discovered" at the discovery endpoint. You can add as many of
+these as you need. 
 
 **Subject Types:** A Subject Identifier is a unique and never reassigned
 identifier the provider uses to establish who the user is, and is consumed by
@@ -108,7 +115,7 @@ virtual instance through the *Control Panel* &rarr; *Configuration* &rarr;
 | System Settings configuration file:
 | 
 |     com.liferay.portal.security.sso.openid.connect.configuration.OpenIdConnectConfiguration.config
-    
+
 Now users can sign in with OpenID Connect. 
 
 ## Signing In With OpenID Connect

--- a/developer/customization/articles/02-fundamentals/01-fundamentals-intro.markdown
+++ b/developer/customization/articles/02-fundamentals/01-fundamentals-intro.markdown
@@ -1,0 +1,3 @@
+# Fundamentals
+
+This is a placeholder for introducing @product@ customization fundamentals. 

--- a/developer/customization/articles/02-fundamentals/02-configuring-dependencies/01-configuring-dependencies-intro.markdown
+++ b/developer/customization/articles/02-fundamentals/02-configuring-dependencies/01-configuring-dependencies-intro.markdown
@@ -1,0 +1,9 @@
+---
+header-id: configuring-dependencies
+---
+
+# Configuring Dependencies
+
+[TOC levels=1-4]
+
+This is a placeholder for introducing dependency configuration in @product@. 

--- a/developer/customization/articles/02-fundamentals/02-configuring-dependencies/03-specifying-dependencies.markdown
+++ b/developer/customization/articles/02-fundamentals/02-configuring-dependencies/03-specifying-dependencies.markdown
@@ -1,0 +1,70 @@
+---
+header-id: specifying-dependencies
+---
+
+# Specifying Dependencies
+
+[TOC levels=1-4]
+
+Compiling your project and deploying it to @product@ requires satisfying its
+dependencies on external artifacts. After
+[finding the attributes of an artifact](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts), 
+set a dependency for it in your build file. Here's how: 
+
+1.  Determine whether @product@ provides the Java packages you use from the 
+    artifact. These files list the packages @product@ exports:
+
+    -   `modules/core/portal-bootstrap/system.packages.extra.bnd` file in the
+        [GitHub repository](https://github.com/liferay/liferay-portal/blob/7.2.x/modules/core/portal-bootstrap/system.packages.extra.bnd).
+        It lists exported packages on separate lines, making them easy to read. 
+
+    -   `META-INF/system.packages.extra.mf` file in
+        `[LIFERAY_HOME]/osgi/core/com.liferay.portal.bootstrap.jar`. The file is
+        available in @product@ bundles. It lists exported packages in a
+        paragraph wrapped at 70 columns--they're harder to read here than in the
+        `system.packages.extra.bnd` file. 
+
+2.  If @product@ exports all the packages you use from the artifact, specify the
+    artifact as a compile-only dependency. This prevents your build framework
+    from bundling the artifact with your project. Here's how to make the
+    dependency compile-only:
+
+    **Gradle:** Add the `compileOnly` directive to the dependency
+    
+    **Maven:** Add the `<scope>provided</scope>` element to the dependency. 
+
+3.  Add a dependency entry for the artifact. Here's the artifact terminology for
+    the Gradle and Maven build frameworks:
+
+    *Artifact Terminology*
+    | Framework | Group ID | Artifact ID | Version |
+    | :------------ | :----------- | :----------- | :-------- |
+    | Gradle | `group` | `name` | `version` 
+    | Maven | `groupId` | `artifactId` | `version` |
+
+    Here is an example dependency on Liferay's Journal API module for Gradle,
+    and Maven: 
+
+    *Gradle (`build.gradle` entry):*
+    
+        dependencies {
+            compileOnly group: "com.liferay", name: "com.liferay.journal.api", version: "1.0.1"
+            ...
+        }
+    
+    *Maven (`pom.xml` entry):*
+    
+    ```xml
+    <dependency>
+        <groupId>com.liferay</groupId>
+        <artifactId>com.liferay.journal.api</artifactId>
+        <version>1.0.1</version>
+        <scope>provided</scope>
+    </dependency>
+    ```
+
+| **Note**: To configure third-party libraries in a module, see
+| [Adding Third Party Libraries to a Module](/docs/7-1/customization/-/knowledge_base/c/adding-third-party-libraries-to-a-module). 
+
+Nice! You know how to specify artifact dependencies. Now that's a skill you can
+depend on! 

--- a/developer/customization/articles/02-fundamentals/02-configuring-dependencies/03-specifying-dependencies.markdown
+++ b/developer/customization/articles/02-fundamentals/02-configuring-dependencies/03-specifying-dependencies.markdown
@@ -64,7 +64,19 @@ set a dependency for it in your build file. Here's how:
     ```
 
 | **Note**: To configure third-party libraries in a module, see
-| [Adding Third Party Libraries to a Module](/docs/7-1/customization/-/knowledge_base/c/adding-third-party-libraries-to-a-module). 
+| [Adding Third Party Libraries to a Module](/docs/7-2/customization/-/knowledge_base/c/adding-third-party-libraries-to-a-module). 
 
 Nice! You know how to specify artifact dependencies. Now that's a skill you can
 depend on! 
+
+## Related Topics 
+
+[Finding Artifacts](/docs/7-2/customization/-/knowledge_base/c/finding-artifacts)
+
+[Importing Packages](/docs/7-2/customization/-/knowledge_base/c/importing-packages)
+
+[Exporting Packages](/docs/7-2/customization/-/knowledge_base/c/exporting-packages)
+
+[Resolving Third Party Library Package Dependencies](/docs/7-2/customization/-/knowledge_base/c/resolving-third-party-library-package-dependencies)
+
+[Deploying WARs \(WAB Generator\)](/docs/7-2/customization/-/knowledge_base/c/deploying-wars-wab-generator)


### PR DESCRIPTION
This is the second part of the former [Configuring Dependencies](https://dev.liferay.com/develop/tutorials/-/knowledge_base/7-1/configuring-dependencies#configuring-dependencies) article. I added a step on specifying compile-only if the dependency's packages are exported by Portal already.

https://issues.liferay.com/browse/LRDOCS-6649