### PR TITLE
Gradle/Maven Plugin version updates | 7.1.x

### DIFF
--- a/develop/reference/articles/07-gradle/gulp-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/gulp-gradle-plugin.markdown
@@ -12,7 +12,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.gulp", version: "2.0.46"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.gulp", version: "2.0.54"
     }
 
     repositories {

--- a/develop/reference/articles/07-gradle/javadoc-formatter-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/javadoc-formatter-gradle-plugin.markdown
@@ -21,7 +21,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.javadoc.formatter", version: "1.0.25"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.javadoc.formatter", version: "1.0.27"
     }
 
     repositories {
@@ -102,7 +102,7 @@ manually adding a dependency to the `javadocFormatter` configuration:
 
 ```gradle
 dependencies {
-    javadocFormatter group: "com.liferay", name: "com.liferay.javadoc.formatter", version: "1.0.30"
+    javadocFormatter group: "com.liferay", name: "com.liferay.javadoc.formatter", version: "1.0.32"
 }
 ```
 

--- a/develop/reference/articles/07-gradle/js-module-config-generator-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/js-module-config-generator-gradle-plugin.markdown
@@ -14,7 +14,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.js.module.config.generator", version: "2.1.45"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.js.module.config.generator", version: "2.1.53"
     }
 
     repositories {

--- a/develop/reference/articles/07-gradle/js-transpiler-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/js-transpiler-gradle-plugin.markdown
@@ -13,7 +13,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.js.transpiler", version: "2.4.24"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.js.transpiler", version: "2.4.32"
     }
 
     repositories {

--- a/develop/reference/articles/07-gradle/jsdoc-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/jsdoc-gradle-plugin.markdown
@@ -12,7 +12,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.jsdoc", version: "2.0.21"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.jsdoc", version: "2.0.29"
     }
 
     repositories {

--- a/develop/reference/articles/07-gradle/node-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/node-gradle-plugin.markdown
@@ -12,7 +12,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.node", version: "4.6.7"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.node", version: "4.6.15"
     }
 
     repositories {

--- a/develop/reference/articles/07-gradle/rest-builder-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/rest-builder-gradle-plugin.markdown
@@ -1,0 +1,95 @@
+# REST Builder Gradle Plugin
+
+The REST Builder Gradle plugin lets you generate a REST layer defined in the
+REST Builder `rest-config.yaml` and `rest-openapi.yaml` files.
+
+The plugin has been successfully tested with Gradle 4.10.2.
+
+## Usage
+
+To use the plugin, include it in your build script:
+
+```gradle
+buildscript {
+    dependencies {
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.rest.builder", version: "1.0.20"
+    }
+
+    repositories {
+        maven {
+            url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+        }
+    }
+}
+
+apply plugin: "com.liferay.portal.tools.rest.builder"
+```
+
+The REST Builder plugin automatically applies the [`java`](https://docs.gradle.org/current/userguide/java_plugin.html)
+plugin.
+
+Since the plugin automatically resolves the [Liferay REST Builder](https://github.com/liferay/liferay-portal/tree/master/modules/util/portal-tools-rest-builder)
+library as a dependency, you have to configure a repository that hosts the
+library and its transitive dependencies. The Liferay CDN repository hosts them
+all:
+
+```gradle
+repositories {
+    maven {
+        url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+    }
+}
+```
+
+## Tasks
+
+The plugin adds one task to your project:
+
+Name | Depends On | Type | Description
+---- | ---------- | ---- | -----------
+`buildREST` | \- | [`BuildRESTTask`](#buildresttask) | Runs the Liferay REST Builder.
+
+### BuildRESTTask
+
+Tasks of type `BuildRESTTask` extend [`JavaExec`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html),
+so all its properties and methods, such as [`args`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:args\(java.lang.Iterable\))
+and [`maxHeapSize`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:maxHeapSize)
+are available. They also have the following properties set by default:
+
+Property Name | Default Value
+------------- | -------------
+[`args`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:args) | REST Builder command line arguments
+[`classpath`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:classpath) | [`project.configurations.restBuilder`](#liferay-rest-builder-dependency)
+[`main`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main) | `"com.liferay.portal.tools.rest.builder.RESTBuilder"`
+[`systemProperties`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:systemProperties) | `[]`
+
+#### Task Properties
+
+Property Name | Type | Default Value | Description
+------------- | ---- | ------------- | -----------
+`copyrightFile` | `File` | `null` | The file that contains the copyright header.
+`restConfigDir` | `File` |`${project.projectDir}` | The directory that contains the `rest-config.yaml` and `rest-openapi.yaml` files.
+
+In the typical scenario, the `rest-config.yaml` and `rest-openapi.yaml` files
+are contained in the project directory of `my-rest-app-impl`. In the
+`build.gradle` of the same module, apply the `com.liferay.rest.builder` plugin.
+
+The properties of type `File` supports any type that can be resolved by
+[`project.file`](https://docs.gradle.org/current/dsl/org.gradle.api.Project.html#org.gradle.api.Project:file\(java.lang.Object\)).
+Moreover, it is possible to use Closures and Callables as values for the
+`String` properties, to defer evaluation until task execution.
+
+## Additional Configuration
+
+There are additional configurations added to use REST Builder.
+
+### Liferay REST Builder Dependency
+
+By default, the plugin creates a configuration called `restBuilder` and adds
+a dependency to the latest released version of Liferay REST Builder.
+
+```gradle
+dependencies {
+    restBuilder group: "com.liferay", name: "com.liferay.portal.tools.rest.builder", version: "1.0.21"
+}
+```

--- a/develop/reference/articles/07-gradle/service-builder-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/service-builder-gradle-plugin.markdown
@@ -13,7 +13,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.service.builder", version: "2.2.28"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.service.builder", version: "2.2.38"
     }
 
     repositories {
@@ -148,7 +148,7 @@ manually adding a dependency to the `serviceBuilder` configuration:
 
 ```gradle
 dependencies {
-    serviceBuilder group: "com.liferay", name: "com.liferay.portal.tools.service.builder", version: "1.0.276"
+    serviceBuilder group: "com.liferay", name: "com.liferay.portal.tools.service.builder", version: "1.0.286"
 }
 ```
 

--- a/develop/reference/articles/07-gradle/source-formatter-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/source-formatter-gradle-plugin.markdown
@@ -13,7 +13,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
     dependencies {
-        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "2.3.327"
+        classpath group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "2.3.370"
     }
 
     repositories {
@@ -122,7 +122,7 @@ manually adding a dependency to the `sourceFormatter` configuration:
 
 ```gradle
 dependencies {
-    sourceFormatter group: "com.liferay", name: "com.liferay.source.formatter", version: "1.0.798"
+    sourceFormatter group: "com.liferay", name: "com.liferay.source.formatter", version: "1.0.841"
 }
 ```
 

--- a/develop/reference/articles/07-gradle/target-platform-gradle-plugin.markdown
+++ b/develop/reference/articles/07-gradle/target-platform-gradle-plugin.markdown
@@ -13,7 +13,7 @@ To use the plugin, include it in your build script:
 ```gradle
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.target.platform", version: "1.1.11"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.target.platform", version: "1.1.13"
 	}
 
 	repositories {

--- a/develop/reference/articles/08-maven/javadoc-formatter-plugin.markdown
+++ b/develop/reference/articles/08-maven/javadoc-formatter-plugin.markdown
@@ -21,7 +21,7 @@ To use the plugin, include it in your project's root `pom.xml` file:
             <plugin>
                 <groupId>com.liferay</groupId>
                 <artifactId>com.liferay.javadoc.formatter</artifactId>
-                <version>1.0.30</version>
+                <version>1.0.32</version>
                 <configuration>
                 </configuration>
             </plugin>

--- a/develop/reference/articles/08-maven/rest-builder-plugin.markdown
+++ b/develop/reference/articles/08-maven/rest-builder-plugin.markdown
@@ -1,0 +1,45 @@
+# REST Builder Plugin
+
+The REST Builder plugin lets you generate a REST layer defined in the REST
+Builder `rest-config.yaml` and `rest-openapi.yaml` files.
+
+## Usage
+
+To use the plugin, include it in your project's root `pom.xml` file:
+
+```xml
+<build>
+    <plugins>
+    ...
+        <plugin>
+            <groupId>com.liferay</groupId>
+            <artifactId>com.liferay.portal.tools.rest.builder</artifactId>
+            <version>1.0.21</version>
+            <configuration>
+            </configuration>
+        </plugin>
+    ...
+    </plugins>
+</build>
+```
+
+You can view an example POM containing the REST Builder configuration
+[here](https://github.com/liferay/liferay-portal/blob/master/modules/util/portal-tools-rest-builder/samples/pom.xml).
+
+## Goals
+
+The plugin adds one Maven goal to your project:
+
+Name | Description
+---- | -----------
+`rest-builder:build` | Runs the Liferay REST Builder.
+
+## Available Parameters
+
+You can set the following parameters in the `<configuration>` section of the
+POM:
+
+Parameter Name | Type | Default Value | Description
+------------- | ---- | ------------- | -----------
+`copyrightFile` | `File` | `null` | The file that contains the copyright header.
+`restConfigDir` | `File` | `${project.projectDir}` | The directory that contains the `rest-config.yaml` and `rest-openapi.yaml` files.

--- a/develop/reference/articles/08-maven/service-builder-plugin.markdown
+++ b/develop/reference/articles/08-maven/service-builder-plugin.markdown
@@ -16,7 +16,7 @@ To use the plugin, include it in your project's root `pom.xml` file:
             <plugin>
                 <groupId>com.liferay</groupId>
                 <artifactId>com.liferay.portal.tools.service.builder</artifactId>
-                <version>1.0.276</version>
+                <version>1.0.286</version>
                 <configuration>
                 </configuration>
             </plugin>

--- a/develop/reference/articles/08-maven/source-formatter-plugin.markdown
+++ b/develop/reference/articles/08-maven/source-formatter-plugin.markdown
@@ -16,7 +16,7 @@ To use the plugin, include it in your project's root `pom.xml` file:
             <plugin>
                 <groupId>com.liferay</groupId>
                 <artifactId>com.liferay.source.formatter</artifactId>
-                <version>1.0.798</version>
+                <version>1.0.841</version>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>


### PR DESCRIPTION
This includes the backported REST Builder plugin docs (sent for master in sez11a#4112). Peter informed me those plugins were applicable for 7.1 and 7.2.