### PR TITLE
PTR-893 Add examples for "inner parameters" to the Invoking JSON WebServices article

### DIFF
--- a/develop/tutorials/articles/150-web-services/05-service-builder-web-services/05-invoking-json-web-services.markdown
+++ b/develop/tutorials/articles/150-web-services/05-service-builder-web-services/05-invoking-json-web-services.markdown
@@ -361,6 +361,30 @@ method is executed.
 Inner parameters aren't counted as regular parameters for matching methods and 
 are ignored during matching. 
 
+Let's extend the JSON-RPC object paramater example from above with also populating its inner paramaters:
+
+    "+foo" : "com.liferay.impl.FooBean",
+    "foo.field1" : "test",
+    "foo.field2" : "true",
+    "foo.field3" : 123
+
+Here's the same with JavaScript (assuming we have a remote service under the `foo` context which accepts one argument with type `com.liferay.impl.FooBean` and it has the specified fields):
+
+```javascript
+    Liferay.Service(
+        '/foo/update-foo',
+	{
+            "+foo": "com.liferay.impl.FooBean",
+	    "foo.field1" : "test",
+	    "foo.field2" : "true",
+	    "foo.field3": 123
+        },
+        function(obj) {
+            console.log(obj);
+        }
+    );
+```
+
 +$$$
 
 **Tip:** Use inner parameters with object parameters to set inner contents of


### PR DESCRIPTION
 because it's been come up multiple time in questions and escalations (a recent [example](https://issues.liferay.com/browse/PTR-893)).

Thanks,
Tibor