### PR TITLE
Converting collab user links to new format

### DIFF
--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/02-adding-files.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/02-adding-files.markdown
@@ -22,7 +22,7 @@ You should carefully manage who can add, view, and update files. You can store
 files of all kinds for various purposes. For example, you may have one set of
 files intended for only specific site members and another intended for everyone,
 including guests. You can use 
-[Roles and Permissions](/discover/portal/-/knowledge_base/7-2/roles-and-permissions) 
+[Roles and Permissions](/docs/7-2/user/-/knowledge_base/u/roles-and-permissions) 
 to control access to Document Library files. The Document Library's folder
 permissions also help you organize files. 
 
@@ -47,7 +47,7 @@ and Media:
 
 5.  Assign this Role to the Users that should manage media. For more 
     information on this and other topics related to Roles, see 
-    [Roles and Permissions](/discover/portal/-/knowledge_base/7-2/roles-and-permissions). 
+    [Roles and Permissions](/docs/7-2/user/-/knowledge_base/u/roles-and-permissions). 
 
 ## Using the Add Menu
 
@@ -80,11 +80,11 @@ system.
 
 **Multiple Files Upload:** Upload several files at once. You can apply a single 
 description and document type to all the files. You can also 
-[categorize and tag](/discover/portal/-/knowledge_base/7-2/organizing-content-with-tags-and-categories) 
+[categorize and tag](/docs/7-2/user/-/knowledge_base/u/organizing-content-with-tags-and-categories) 
 the files, and assign them default permissions. 
 
 **Repository**: Add access to an external repository. See 
-[Store Types](/discover/portal/-/knowledge_base/7-2/store-types) 
+[Store Types](/docs/7-2/user/-/knowledge_base/u/store-types) 
 for more information. 
 
 **Shortcut**: Create a shortcut to any document that you can view. You 
@@ -92,9 +92,9 @@ can set permissions on the shortcut to specify who can access the
 original document via the shortcut. 
 
 Any additional items in the Add menu are 
-[document types](/discover/portal/-/knowledge_base/7-2/document-types) 
+[document types](/docs/7-2/user/-/knowledge_base/u/document-types) 
 described by a unique 
-[metadata set](/discover/portal/-/knowledge_base/7-2/metadata-sets). 
+[metadata set](/docs/7-2/user/-/knowledge_base/u/metadata-sets). 
 When you add a document belonging to a document type, a form appears that lets 
 you pick the file to upload and enter the data defined by the document type's 
 metadata set. 

--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/03-creating-folders.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/03-creating-folders.markdown
@@ -56,7 +56,7 @@ managing the folder. The following sections describe some of these options.
 
 After creating a folder, you can restrict what document types are allowed in it. 
 You can also choose what 
-[workflow](/discover/portal/-/knowledge_base/7-2/workflow) 
+[workflow](/docs/7-2/user/-/knowledge_base/u/workflow) 
 (if any) to use for approving files added to or edited in the folder. 
 
 Follow these steps to change a folder's document type restrictions and workflow: 

--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/04-dm-management-bar.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/04-dm-management-bar.markdown
@@ -33,7 +33,7 @@ the selected view type:
 card-like rendering of the item. If the item isn't an image, a generic image for 
 the item's type is displayed. For files, each card also contains the file's 
 suffix (e.g., JPG, PNG, etc.), timestamp, name, and 
-[workflow](/discover/portal/-/knowledge_base/7-2/workflow) 
+[workflow](/docs/7-2/user/-/knowledge_base/u/workflow) 
 status (e.g., Approved, Draft, etc.). 
 
 **List** (![List](../../../../images/icon-view-type-list.png)): Shows the same 
@@ -113,4 +113,4 @@ The Actions button
 (![Actions](../../../../images/icon-actions.png)) 
 contains all the actions displayed in the Management Bar, plus actions for file 
 checkin and checkout. File checkout and checkin is explained in 
-[Checking out and Editing Files](/discover/portal/-/knowledge_base/7-2/checking-out-and-editing-files). 
+[Checking out and Editing Files](/docs/7-2/user/-/knowledge_base/u/checking-out-and-editing-files). 

--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/05-file-previews.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/05-file-previews.markdown
@@ -47,7 +47,7 @@ harness the full power of document previews. These tools include:
 After installing these tools, you can configure them via portal properties in 
 the Control Panel's Server Administration screen, or in a 
 `portal-ext.properties` file. To learn how to use these tools, see 
-[Configuring @product@](/discover/portal/-/knowledge_base/7-2/setting-up). 
+[Configuring @product@](/docs/7-2/user/-/knowledge_base/u/setting-up). 
 
 With these tools installed and configured, a customized viewer displays 
 Documents and Media content, depending on the content type. For example, you can 
@@ -67,7 +67,7 @@ about the file. For more information on this, see
 [The Info Panel](#the-info-panel). 
 
 **Share**: Share the file with other users. For more information, see 
-[Sharing Files](/discover/portal/-/knowledge_base/7-2/sharing-files). 
+[Sharing Files](/docs/7-2/user/-/knowledge_base/u/sharing-files). 
 
 **Download**: Download the file. 
 
@@ -78,13 +78,13 @@ Opens a menu that lets you perform these actions on the file:
 
 -   **Edit:** Modify the file's name, description, document type, 
     categorization, and 
-    [related assets](/discover/portal/-/knowledge_base/7-2/defining-content-relationships).
+    [related assets](/docs/7-2/user/-/knowledge_base/u/defining-content-relationships).
     You can even upload a new file to replace it. Note that modifying the file
     increments its version. 
 
 -   **Edit with Image Editor:** Edit the image in the Image Editor. The Image 
     Editor is explained in 
-    [Editing Images](/discover/portal/-/knowledge_base/7-2/editing-images). 
+    [Editing Images](/docs/7-2/user/-/knowledge_base/u/editing-images). 
 
 -   **Checkout/Checkin:** Checkout prevents others from editing the document 
     while you are working on it. Other users can still view the current version 
@@ -112,7 +112,7 @@ comments on the file.
 As mentioned above, clicking the *Info* icon 
 (![Info](../../../../images/icon-information-dm.png)) opens the info panel. The 
 top of the info panel displays the file's name, version, and 
-[workflow status](/discover/portal/-/knowledge_base/7-2/workflow). 
+[workflow status](/docs/7-2/user/-/knowledge_base/u/workflow). 
 There are two tabs in the info panel: Details, and Versions. Details is selected 
 by default and shows the following: 
 
@@ -149,4 +149,4 @@ To instead view the file's version history, select the *Versions* tab near the
 top of the info panel. The info panel then changes to list the different 
 versions of the file and lets you view, download, remove, and revert to specific 
 file versions. File version history actions are explained in 
-[Checking Out and Editing Files](/discover/portal/-/knowledge_base/7-2/checking-out-and-editing-files). 
+[Checking Out and Editing Files](/docs/7-2/user/-/knowledge_base/u/checking-out-and-editing-files). 

--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/07-publishing-files.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/07-publishing-files.markdown
@@ -26,7 +26,7 @@ way, your media takes center stage.
 
 Follow these steps to create a page that contains a Media Gallery widget: 
 
-1.  [Create a page](/discover/portal/-/knowledge_base/7-2/creating-and-managing-pages) 
+1.  [Create a page](/docs/7-2/user/-/knowledge_base/u/creating-and-managing-pages) 
     and navigate to it in your site. 
 
 2.  At the top-right of the screen, click the *Add* icon

--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/08-checkout-edit-files.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/08-checkout-edit-files.markdown
@@ -14,9 +14,9 @@ the checkout. Checking in a file also increments its version, which lets you
 keep track of changes. 
 
 Unless you're using 
-[Liferay Sync](/discover/portal/-/knowledge_base/7-2/using-liferay-sync-on-your-desktop) 
+[Liferay Sync](/docs/7-2/user/-/knowledge_base/u/using-liferay-sync-on-your-desktop) 
 or a 
-[local drive mapped to the file's WebDAV URL](/discover/portal/-/knowledge_base/7-2/desktop-access-to-documents-and-media), 
+[local drive mapped to the file's WebDAV URL](/docs/7-2/user/-/knowledge_base/u/desktop-access-to-documents-and-media), 
 follow these steps to edit a Document Library file from your machine: 
 
 1.  Checkout the file by clicking its Actions icon 

--- a/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/10-configuring-sharing.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/02-publishing-files/10-configuring-sharing.markdown
@@ -7,7 +7,7 @@ header-id: configuring-sharing
 [TOC levels=1-4]
 
 Administrators can choose whether 
-[file sharing](/discover/portal/-/knowledge_base/7-2/sharing-files) 
+[file sharing](/docs/7-2/user/-/knowledge_base/u/sharing-files) 
 is enabled at the global, instance, and Site levels. 
 
 ## Global Configuration

--- a/user/articles/110-collaboration/02-managing-documents-and-media/04-document-types.markdown
+++ b/user/articles/110-collaboration/02-managing-documents-and-media/04-document-types.markdown
@@ -58,7 +58,7 @@ Follow these steps to create a document type:
     can be created only via the form and can't be used with other document 
     types. You create and edit these metadata fields in the form the same way 
     that you do when creating 
-    [metadata sets](/discover/portal/-/knowledge_base/7-2/metadata-sets). 
+    [metadata sets](/docs/7-2/user/-/knowledge_base/u/metadata-sets). 
 
     **Additional Metadata Fields:** Select a metadata set to associate with the 
     document type. Each document type must be associated with one or more 

--- a/user/articles/110-collaboration/03-sync/02-administering-sync/02-prerequisites.markdown
+++ b/user/articles/110-collaboration/03-sync/02-administering-sync/02-prerequisites.markdown
@@ -13,7 +13,7 @@ across the instance or on a site-by-site basis. Note that Sync is enabled by
 default for all Sites. 
 
 For instructions on installing Marketplace apps, see 
-[the Liferay Marketplace documentation](/discover/portal/-/knowledge_base/7-2/using-the-liferay-marketplace). 
+[the Liferay Marketplace documentation](/docs/7-2/user/-/knowledge_base/u/using-the-liferay-marketplace). 
 
 | **Note:** The Liferay Sync Security module that Sync requires is included and 
 | enabled by default in @product@. You can verify this by ensuring that the 

--- a/user/articles/110-collaboration/03-sync/03-sync-desktop/03-using-sync-desktop.markdown
+++ b/user/articles/110-collaboration/03-sync/03-sync-desktop/03-using-sync-desktop.markdown
@@ -63,7 +63,7 @@ to add, delete, or edit an account, respectively. You should use caution when
 deleting an account from your Sync client, as doing so also deletes any local
 files and folders for that account. Adding an account takes you through the
 same set of steps you used to set up the Sync client. [Click
-here](/discover/portal/-/knowledge_base/7-2/installing-and-configuring-the-desktop-liferay-sync-client#configuring-the-liferay-sync-desktop-client) 
+here](/docs/7-2/user/-/knowledge_base/u/installing-and-configuring-the-desktop-liferay-sync-client#configuring-the-liferay-sync-desktop-client) 
 for instructions on this. 
 
 **Syncing Sites:** The Sites you have permission to sync with for the selected 
@@ -72,7 +72,7 @@ Other Sites available for syncing are shown under *Unselected Sites*. To
 change the Sites you sync with, click the *Manage Sites* button. The window 
 that appears lets you select and/or unselect Sites to sync with. This window 
 is identical to the one that appeared when you first configured the client. 
-[Click here](/discover/portal/-/knowledge_base/7-2/installing-and-configuring-the-desktop-liferay-sync-client#configuring-the-liferay-sync-desktop-client) 
+[Click here](/docs/7-2/user/-/knowledge_base/u/installing-and-configuring-the-desktop-liferay-sync-client#configuring-the-liferay-sync-desktop-client) 
 and see step two for instructions on using it. Use caution when de-selecting
 Sites. De-selecting a Site deletes its folder on your machine. 
 

--- a/user/articles/110-collaboration/03-sync/04-sync-mobile/01-intro.markdown
+++ b/user/articles/110-collaboration/03-sync/04-sync-mobile/01-intro.markdown
@@ -7,7 +7,7 @@ header-id: using-liferay-sync-on-your-mobile-device
 [TOC levels=1-4]
 
 Liferay Sync for Android and iOS contains most of the
-[desktop Sync client](/discover/portal/-/knowledge_base/7-2/using-liferay-sync-on-your-desktop)'s
+[desktop Sync client](/docs/7-2/user/-/knowledge_base/u/using-liferay-sync-on-your-desktop)'s
 functionality. The mobile client can, however, only be connected to one 
 @product@ account at a time. Also, mobile Sync doesn't automatically download
 files to your device. To save storage space on your device, the Sync mobile app

--- a/user/articles/110-collaboration/04-adaptive-media/02-installing-adaptive-media.markdown
+++ b/user/articles/110-collaboration/04-adaptive-media/02-installing-adaptive-media.markdown
@@ -72,7 +72,7 @@ problems, or your old content doesn't need adapted images.
 
 **Liferay Adaptive Media Document Library Thumbnails:** Lets thumbnails in 
 Documents and Media use adapted images. For this to work, you must first 
-[migrate the original thumbnails to adapted images](/discover/portal/-/knowledge_base/7-2/migrating-documents-and-media-thumbnails-to-adaptive-media). 
+[migrate the original thumbnails to adapted images](/docs/7-2/user/-/knowledge_base/u/migrating-documents-and-media-thumbnails-to-adaptive-media). 
 We highly recommend that you enable this module, but it's not mandatory. 
 
 Great! Now you know the mandatory and optional modules that come with Adaptive 
@@ -87,7 +87,7 @@ To process animated GIFs, Adaptive Media uses an external tool called
 This tool ensures that the animation works when the GIF is scaled to different 
 resolutions. You must manually install Gifsicle on the server and ensure that
 it's on the `PATH`. Once it's installed, you must enable it in Adaptive Media's
-[advanced configuration options](/discover/portal/-/knowledge_base/7-2/advanced-configuration-options). 
+[advanced configuration options](/docs/7-2/user/-/knowledge_base/u/advanced-configuration-options). 
 
 If Gifsicle isn't installed and `image/gif` is included as a supported MIME type
 in the advanced configuration options, Adaptive Media scales only a GIF's single

--- a/user/articles/110-collaboration/04-adaptive-media/03-adding-image-resolutions.markdown
+++ b/user/articles/110-collaboration/04-adaptive-media/03-adding-image-resolutions.markdown
@@ -20,7 +20,7 @@ resolutions.
 Once you create a resolution, Adaptive Media automatically generates copies of 
 newly uploaded images in that resolution. Images uploaded before you create the 
 resolution aren't affected and must be adapted separately (see the 
-[Generating Missing Image Resolutions](/discover/portal/-/knowledge_base/7-2/managing-image-resolutions#generating-missing-image-resolutions) 
+[Generating Missing Image Resolutions](/docs/7-2/user/-/knowledge_base/u/managing-image-resolutions#generating-missing-image-resolutions) 
 section for details). 
 
 ![Figure 1: Adaptive Media's image resolutions are listed in a table.](../../../images/adaptive-media-image-resolutions.png)

--- a/user/articles/110-collaboration/04-adaptive-media/05-creating-content-adapted-images.markdown
+++ b/user/articles/110-collaboration/04-adaptive-media/05-creating-content-adapted-images.markdown
@@ -23,9 +23,9 @@ prior to those images.
 
 Since Adaptive Media delivers the adapted images behind the scenes, content 
 creators should add images to 
-[blog entries](/discover/portal/-/knowledge_base/7-2/publishing-blogs) 
+[blog entries](/docs/7-2/user/-/knowledge_base/u/publishing-blogs) 
 and 
-[web content](/discover/portal/-/knowledge_base/7-2/creating-web-content) 
+[web content](/docs/7-2/user/-/knowledge_base/u/creating-web-content) 
 as usual: by clicking the image button in the editor and then selecting the 
 image in the file selector. 
 
@@ -76,7 +76,7 @@ is used as a fallback in case the adapted images aren't available.
 ## Using Adapted Images in Structured Web Content
 
 To use adapted images in 
-[structured web content](/discover/portal/-/knowledge_base/7-2/designing-uniform-content), 
+[structured web content](/docs/7-2/user/-/knowledge_base/u/designing-uniform-content), 
 content creators must manually include an image field in the web content's 
 structure. Then they can reference that image field in the matching template by 
 selecting it on the left side of the editor. Here's an example snippet of an 
@@ -102,9 +102,9 @@ resolution (see the `<picture>` example above).
 ## Staging Adapted Images
 
 Adaptive Media is fully integrated with @product@'s 
-[content staging](/discover/portal/-/knowledge_base/7-2/staging-content-for-publication) 
+[content staging](/docs/7-2/user/-/knowledge_base/u/staging-content-for-publication) 
 and 
-[export/import](/discover/portal/-/knowledge_base/7-2/exporting-importing-widget-data) 
+[export/import](/docs/7-2/user/-/knowledge_base/u/exporting-importing-widget-data) 
 functionality. Adaptive Media includes adapted images in staged content when 
 published, and can update those images to match any new resolutions. 
 

--- a/user/articles/110-collaboration/04-adaptive-media/06-migrating-dm-thumbnails.markdown
+++ b/user/articles/110-collaboration/04-adaptive-media/06-migrating-dm-thumbnails.markdown
@@ -39,7 +39,7 @@ that match the values specified in the following portal properties:
 | image resolutions in Adaptive Media for the enabled properties. 
 
 To create the new Image Resolutions, follow the instructions found in the 
-[Adding Image Resolutions](/discover/portal/-/knowledge_base/7-2/adding-image-resolutions) 
+[Adding Image Resolutions](/docs/7-2/user/-/knowledge_base/u/adding-image-resolutions) 
 section of the Adaptive Media user guide. 
 
 Now you're ready to to create the Adaptive Media images. 
@@ -48,7 +48,7 @@ Now you're ready to to create the Adaptive Media images.
 
 Once the required image resolutions exist, you can convert the Documents and 
 Media thumbnails to Adaptive Media images. As mentioned in 
-[the Adaptive Media installation guide](/discover/portal/-/knowledge_base/7-2/installing-adaptive-media), 
+[the Adaptive Media installation guide](/docs/7-2/user/-/knowledge_base/u/installing-adaptive-media), 
 the module *Liferay Adaptive Media Document Library Thumbnails* (which is 
 included in the Adaptive Media app) enables this functionality. 
 
@@ -60,7 +60,7 @@ existing thumbnails to the values in the Adaptive Media image resolutions, which
 can take time depending on the number of images. We only recommend this approach 
 when there isn't a large number of thumbnails to process, or if you prefer to 
 generate your images from scratch. This approach is covered in more detail in 
-[Generating Missing Adapted Images](/discover/portal/-/knowledge_base/7-1/managing-image-resolutions#generating-missing-image-resolutions). 
+[Generating Missing Adapted Images](/docs/7-2/user/-/knowledge_base/u/managing-image-resolutions#generating-missing-image-resolutions). 
 
 **Execute a migrate process that reuses the existing thumbnails:** This copies 
 the existing thumbnails to Adaptive Media, which performs better because it 
@@ -71,7 +71,7 @@ describes the steps to run this process.
 
 The migration process is a set of Gogo console commands. You can learn more
 about using the Gogo console in 
-[the Felix Gogo Shell tutorial](/develop/reference/-/knowledge_base/7-2/using-the-felix-gogo-shell). 
+[the Felix Gogo Shell tutorial](/docs/7-2/reference/-/knowledge_base/r/using-the-felix-gogo-shell). 
 
 Follow these steps to migrate your thumbnails from the Gogo console:
 

--- a/user/articles/110-collaboration/05-collaborating/02-blogs/02-adding-blog-entries.markdown
+++ b/user/articles/110-collaboration/05-collaborating/02-blogs/02-adding-blog-entries.markdown
@@ -25,7 +25,7 @@ Follow these steps to add a blog entry in Site Administration:
 
 3.  The first input field, *Drag \& Drop to Upload*, is for optionally adding 
     a cover image for your entry. By default, an 
-    [Asset Publisher](/discover/portal/-/knowledge_base/7-2/publishing-assets)
+    [Asset Publisher](/docs/7-2/user/-/knowledge_base/u/publishing-assets)
     shows this cover image as part of the blog entry's abstract. You can insert 
     any image you like in this field, either via drag and drop or the *Select 
     File* button. The latter lets you choose an existing image in the blog, an
@@ -34,7 +34,7 @@ Follow these steps to add a blog entry in Site Administration:
 
     If you select an image from Documents and Media, you can make changes to it
     with the 
-    [Image Editor](/discover/portal/-/knowledge_base/7-2/editing-images). 
+    [Image Editor](/docs/7-2/user/-/knowledge_base/u/editing-images). 
     Edits you make are applied automatically to a copy of the image, which you
     can then use as your cover photo. 
 
@@ -53,11 +53,11 @@ Follow these steps to add a blog entry in Site Administration:
     editing controls appears. This keeps your canvas uncluttered so you can
     focus on writing. You can also add images, videos, and tables in your blog
     entry's content. See 
-    [Using the Blog Entry Editor](/discover/portal/-/knowledge_base/7-2/using-the-blog-entry-editor)
+    [Using the Blog Entry Editor](/docs/7-2/user/-/knowledge_base/u/using-the-blog-entry-editor)
     for instructions on creating your blog entry's content. 
 
 6.  Expand the *Categorization* panel and associate your blog entry with 
-    [tags and/or categories](/discover/portal/-/knowledge_base/7-2/organizing-content-with-tags-and-categories). 
+    [tags and/or categories](/docs/7-2/user/-/knowledge_base/u/organizing-content-with-tags-and-categories). 
     Although this is optional, it improves search results for blog entries and 
     gives your users more navigation options. For example, you can add the Tags
     Navigation app to another column on your blogs page, which lets users browse 
@@ -69,7 +69,7 @@ Follow these steps to add a blog entry in Site Administration:
     might want to write a blog entry about a discussion that happened on the 
     forums. To link those two assets together, select the forum thread under 
     Related Assets. For more information, see the 
-    [related assets documentation](/discover/portal/-/knowledge_base/7-2/defining-content-relationships).
+    [related assets documentation](/docs/7-2/user/-/knowledge_base/u/defining-content-relationships).
 
 8.  Expand the *Configuration* panel if you want to customize your blog entry's 
     URL, abstract, or display date. You can also set whether to allow pingbacks 
@@ -89,7 +89,7 @@ Follow these steps to add a blog entry in Site Administration:
     Updated* toggle appears. Setting this to *YES* sends an email to any
     subscribers when the blog entry is updated. You can customize this email
     when 
-    [configuring the Blogs app](/discover/portal/-/knowledge_base/7-2/configuring-the-blogs-app). 
+    [configuring the Blogs app](/docs/7-2/user/-/knowledge_base/u/configuring-the-blogs-app). 
 
     Finally, you can allow *pingbacks* for the blog entry. Pingbacks are XML-RPC
     requests that are sent automatically when you link to another site. If you
@@ -101,7 +101,7 @@ Follow these steps to add a blog entry in Site Administration:
     ![Figure 2: When creating a blog entry, the Configuration panel lets you control when and where the blog entry appears, and what to use for the entry's abstract.](../../../../images/blog-entry-configuration.png)
 
 9.  Expand the *Display Page Template* panel if you want to select a 
-    [display page template](/discover/portal/-/knowledge_base/7-2/display-pages-for-web-content) 
+    [display page template](/docs/7-2/user/-/knowledge_base/u/display-pages-for-web-content) 
     for displaying your blog entry. The following options are available: 
 
     **Default Display Page Template:** Use the default display page template.
@@ -126,7 +126,7 @@ Follow these steps to add a blog entry in Site Administration:
     **Update Discussion**: Edit another user's comment on the blog entry.
 
     **Delete**: Move the blog entry to the 
-    [Recycle Bin](/discover/portal/-/knowledge_base/7-2/using-the-recycle-bin).
+    [Recycle Bin](/docs/7-2/user/-/knowledge_base/u/using-the-recycle-bin).
 
     **Permissions**: View and modify the blog entry's permissions.
 

--- a/user/articles/110-collaboration/05-collaborating/02-blogs/03-blog-entry-editor.markdown
+++ b/user/articles/110-collaboration/05-collaborating/02-blogs/03-blog-entry-editor.markdown
@@ -7,7 +7,7 @@ header-id: using-the-blog-entry-editor
 [TOC levels=1-4]
 
 When you 
-[create a new blog entry](/discover/portal/-/knowledge_base/7-2/adding-blog-entries), 
+[create a new blog entry](/docs/7-2/user/-/knowledge_base/u/adding-blog-entries), 
 you create its content with the blog entry editor. This editor is simple yet 
 powerful. Its editing tools are context-aware, only appearing when you need 
 them. They aren't visible while you're writing, which lets you focus on the task 
@@ -57,7 +57,7 @@ instructions to insert each:
 **Image:** Click the mountain icon, then select or upload an image in the image 
 file selector screen that appears. Alternatively, you can drag-and-drop image 
 files into the content area. You can also use the 
-[built-in Image Editor](/discover/portal/-/knowledge_base/7-2/editing-images) 
+[built-in Image Editor](/docs/7-2/user/-/knowledge_base/u/editing-images) 
 to apply simple edits to an image. Any edits you make are automatically applied 
 to a copy of the image. After you add an image to the blog entry, clicking the 
 image brings up controls for justifying it to the right or left side of the 

--- a/user/articles/110-collaboration/05-collaborating/02-blogs/04-managing-blog-entries.markdown
+++ b/user/articles/110-collaboration/05-collaborating/02-blogs/04-managing-blog-entries.markdown
@@ -30,7 +30,7 @@ depends on the selected view type:
 card-like rendering of the blog entry, with the author's profile picture. If the 
 entry doesn't contain a cover image, a generic rendering of the entry is 
 displayed. Each card also contains the entry's timestamp, title, 
-[workflow](/discover/portal/-/knowledge_base/7-2/workflow) 
+[workflow](/docs/7-2/user/-/knowledge_base/u/workflow) 
 status (e.g., Approved, Draft, etc.), and an Actions menu 
 (![Actions](../../../../images/icon-actions.png)). 
 

--- a/user/articles/110-collaboration/05-collaborating/02-blogs/06-displaying-blogs.markdown
+++ b/user/articles/110-collaboration/05-collaborating/02-blogs/06-displaying-blogs.markdown
@@ -54,7 +54,7 @@ buttons on each blog entry. To move social networking sites between the
 *Current* and *Available* columns, select the sites and use the arrows between 
 those columns. Similarly, use the up/down arrows beneath the *Current* column to 
 reorder the sites as they appear on each blog entry. For more information, see 
-[the social bookmarks documentation](/discover/portal/-/knowledge_base/7-2/using-social-bookmarks). 
+[the social bookmarks documentation](/docs/7-2/user/-/knowledge_base/u/using-social-bookmarks). 
 
 **Display Style:** The display style for social bookmarks. *Inline* is the 
 default and displays the social bookmark icons in a row. *Menu* hides them 
@@ -78,7 +78,7 @@ choose the following:
 
 To select a different application display template (ADT) or create your own, 
 click *Manage Templates*. For more information, see the documentation on 
-[application display templates](/discover/portal/-/knowledge_base/7-2/using-page-fragments). 
+[application display templates](/docs/7-2/user/-/knowledge_base/u/using-page-fragments). 
 
 **Enable Report Inappropriate Content:** Whether to let users flag content as 
 inappropriate, which sends an email to administrators. 

--- a/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
+++ b/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
@@ -8,7 +8,7 @@ header-id: configuring-message-boards
 
 Before using a message board, configure it to your needs. First, open the
 Message Boards app in your scope's Site Administration menu, as described 
-[earlier](/discover/portal/-/knowledge_base/7-2/creating-message-boards). 
+[earlier](/docs/7-2/user/-/knowledge_base/u/creating-message-boards). 
 To open the message board's configuration screen, click the message board's 
 *Options* menu 
 (![Options](../../../../images/icon-options.png)) and select *Configuration*. 

--- a/user/articles/110-collaboration/05-collaborating/03-message-boards/04-message-board-permissions.markdown
+++ b/user/articles/110-collaboration/05-collaborating/03-message-boards/04-message-board-permissions.markdown
@@ -8,7 +8,7 @@ header-id: message-board-permissions
 
 Open the Message Boards app in your scope's Site Administration menu, as 
 described in 
-[the article on creating message boards](/discover/portal/-/knowledge_base/7-1/creating-message-boards). 
+[the article on creating message boards](/docs/7-2/user/-/knowledge_base/u/creating-message-boards). 
 Then click the *Options* icon 
 (![Options](../../../../images/icon-options.png)) 
 and select the *Home Category Permissions* option. This permissions screen is 

--- a/user/articles/110-collaboration/05-collaborating/03-message-boards/05-message-board-categories.markdown
+++ b/user/articles/110-collaboration/05-collaborating/03-message-boards/05-message-board-categories.markdown
@@ -19,7 +19,7 @@ Follow these steps to create a message board category:
 
 1.  Open the Message Boards app in your scope's Site Administration menu, as 
     described in 
-    [Creating Message Boards](/discover/portal/-/knowledge_base/7-2/creating-message-boards).
+    [Creating Message Boards](/docs/7-2/user/-/knowledge_base/u/creating-message-boards).
 
 2.  Click the *Add* icon
     (![Add](../../../../images/icon-add.png)) and select *Category*. This opens 
@@ -47,7 +47,7 @@ Follow these steps to create a message board category:
     to *YES*. To enable anonymous emails in the list, set the *Allow Anonymous 
     Emails* toggle to *YES*. The default for both toggles is *NO*. For an 
     explanation of these features, see 
-    [the documentation on mailing lists for Message Boards](/discover/portal/-/knowledge_base/7-2/user-subscriptions-and-mailing-lists#mailing-lists). 
+    [the documentation on mailing lists for Message Boards](/docs/7-2/user/-/knowledge_base/u/user-subscriptions-and-mailing-lists#mailing-lists). 
 
 6.  Open the *Permissions* section and set the category's permissions. The
     *Viewable by* selector lets you pick who can view the category: 

--- a/user/articles/110-collaboration/05-collaborating/03-message-boards/07-using-message-boards.markdown
+++ b/user/articles/110-collaboration/05-collaborating/03-message-boards/07-using-message-boards.markdown
@@ -49,9 +49,9 @@ Follow these steps to post a new thread:
 3.  Create your thread's content in the *Body* field. This field uses the same 
     editor as the Blogs app, except that it uses BBCode instead of HTML. For 
     further instructions, see the documentation on 
-    [using the editor](/discover/portal/-/knowledge_base/7-2/using-the-blog-entry-editor). 
+    [using the editor](/docs/7-2/user/-/knowledge_base/u/using-the-blog-entry-editor). 
     Also note that you can 
-    [mention](/discover/portal/-/knowledge_base/7-2/mentioning-users) 
+    [mention](/docs/7-2/user/-/knowledge_base/u/mentioning-users) 
     other users by entering the `@` character and their user name. 
 
 4.  If you want to add attachments, open the *Attachments* section and add them 
@@ -60,7 +60,7 @@ Follow these steps to post a new thread:
 5.  If you want to associate a tag with the message, open the *Categorization* 
     section and use the *Select* button to select an existing tag. You can also 
     create a new tag by entering it in the *Tags* field and clicking *Add*. See 
-    [the documentation on tags](/discover/portal/-/knowledge_base/7-2/tagging-content) 
+    [the documentation on tags](/docs/7-2/user/-/knowledge_base/u/tagging-content) 
     for more information. 
 
 6.  If you want to select an existing asset in the portal (e.g., a media file, 
@@ -79,7 +79,7 @@ Follow these steps to post a new thread:
     **Priority:** The thread's priority in the Message Board. By default, you 
     can choose *Urgent*, *Sticky*, or *Announcement*. Additional priorities can 
     also be 
-    [configured](/discover/portal/-/knowledge_base/7-2/configuring-message-boards) 
+    [configured](/docs/7-2/user/-/knowledge_base/u/configuring-message-boards) 
     in the Message Boards app in Site Administration. 
 
     **Allow Pingbacks:** Whether 

--- a/user/articles/110-collaboration/05-collaborating/03-message-boards/08-managing-message-boards.markdown
+++ b/user/articles/110-collaboration/05-collaborating/03-message-boards/08-managing-message-boards.markdown
@@ -9,7 +9,7 @@ header-id: managing-message-boards
 Message boards can become unwieldy if left unmanaged. The Message Boards in Site 
 Administration facilitates day-to-day thread administration. You may wish to 
 assign this function to a 
-[Role](/discover/portal/-/knowledge_base/7-2/roles-and-permissions) 
+[Role](/docs/7-2/user/-/knowledge_base/u/roles-and-permissions) 
 that you give to one or more users. This frees you to concentrate on other areas 
 of your Site. For example, you can create a Role called 
 *Message Board Administrator* scoped to the portal (globally), an Organization,

--- a/user/articles/110-collaboration/05-collaborating/05-wiki/01-intro.markdown
+++ b/user/articles/110-collaboration/05-collaborating/05-wiki/01-intro.markdown
@@ -21,9 +21,9 @@ does these things:
 
 As you can see, @product@'s wiki is flexible and can be configured to fit 
 nearly any use case. What's more, it's completely integrated with the portal's 
-[user management](/discover/portal/-/knowledge_base/7-2/managing-users), 
-[tagging](/discover/portal/-/knowledge_base/7-2/tagging-content), and
-[security](/discover/deployment/-/knowledge_base/7-2/securing-product) 
+[user management](/docs/7-2/user/-/knowledge_base/u/managing-users), 
+[tagging](/docs/7-2/user/-/knowledge_base/u/tagging-content), and
+[security](/docs/7-2/deploy/-/knowledge_base/d/securing-product) 
 features. 
 
 ![Figure 1: The Wiki widget displays your wiki on a Site page.](../../../../images/wiki-page-full.png)

--- a/user/articles/110-collaboration/05-collaborating/05-wiki/02-getting-started-wiki.markdown
+++ b/user/articles/110-collaboration/05-collaborating/05-wiki/02-getting-started-wiki.markdown
@@ -30,7 +30,7 @@ templates are accessible from the Options menu. Click the
 The following options are available in this menu: 
 
 **Wikis Permissions**: Specify which
-[Roles](/discover/portal/-/knowledge_base/7-2/roles-and-permissions) can create
+[Roles](/docs/7-2/user/-/knowledge_base/u/roles-and-permissions) can create
 wiki nodes and access the Wikis Permissions screen. For example, if you've
 created a specific Role for creating wiki nodes and want to enable that Role to
 create new wiki nodes in this wiki application instance, select the Role's
@@ -38,7 +38,7 @@ check box in the *Add Node* column and then click *Save*.
 
 **Export / Import**: Import existing wiki content into your wiki app instance,
 or export wiki content to a file. For details, refer to 
-[Importing/Exporting Pages and Content](/discover/portal/-/knowledge_base/7-2/importing-exporting-pages-and-content).
+[Importing/Exporting Pages and Content](/docs/7-2/user/-/knowledge_base/u/importing-exporting-pages-and-content).
 
 **Configuration**: Configure email notifications and RSS feeds. The *Email
 From*, *Page Added Email*, and *Page Updated Email* tabs are similar to other
@@ -100,7 +100,7 @@ updated, the portal sends you an email notification.
 the wiki node. 
 
 **Move to Recycle Bin**: Moves the wiki node to the 
-[Recycle Bin](/discover/portal/-/knowledge_base/7-2/restoring-deleted-assets). 
+[Recycle Bin](/docs/7-2/user/-/knowledge_base/u/restoring-deleted-assets). 
 
 ![Figure 3: Each wiki node's Actions menu lists actions you can perform.](../../../../images/wiki-options.png)
 
@@ -110,4 +110,4 @@ requires an administrator's approval to publish a wiki page modification (add,
 update, or delete). You can access your site's default *Wiki Page* workflow from
 within the Site Administration Menu, by navigating to *Configuration* &rarr; 
 *Workflow* for your site. To learn how to use workflow, see the
-[Workflow](/discover/portal/-/knowledge_base/7-2/workflow) section. 
+[Workflow](/docs/7-2/user/-/knowledge_base/u/workflow) section. 

--- a/user/articles/110-collaboration/05-collaborating/05-wiki/03-add-edit-wiki.markdown
+++ b/user/articles/110-collaboration/05-collaborating/05-wiki/03-add-edit-wiki.markdown
@@ -14,7 +14,7 @@ content. That message is a link; click it to start editing the page. The wiki
 page editing form then appears. 
 
 | **Note:** See the 
-| [getting started article](/discover/portal/-/knowledge_base/7-2/getting-started-with-wikis) 
+| [getting started article](/docs/7-2/user/-/knowledge_base/u/getting-started-with-wikis) 
 | for instructions on accessing your wiki nodes. 
 
 ![Figure 1: Each empty wiki page presents a default message link you can click to edit the page.](../../../../images/wiki-empty-frontpage.png)
@@ -30,14 +30,14 @@ Follow these steps to use the wiki page editing form:
     Help* if you need help with Creole syntax (e.g., syntax for text styling,
     header formatting, link creation, etc.). For a detailed explanation of the
     rest of the editor, see the 
-    [Blogs documentation](/discover/portal/-/knowledge_base/7-2/using-the-blog-entry-editor). 
+    [Blogs documentation](/docs/7-2/user/-/knowledge_base/u/using-the-blog-entry-editor). 
 
 2.  If you want to attach files to the page, open the *Attachments* section of 
     the form and add them via drag and drop or the *Select Files* button. 
 
 3.  If you want to associate a tag with the page, open the *Categorization* 
     section and enter a new or existing tag in the *Tags* field. See 
-    [the documentation on tags](/discover/portal/-/knowledge_base/7-2/tagging-content) 
+    [the documentation on tags](/docs/7-2/user/-/knowledge_base/u/tagging-content) 
     for more information. 
 
 4.  If you want to select an existing asset in the portal (e.g., a media file, 
@@ -111,7 +111,7 @@ type:
 **List** (![List](../../../../images/icon-view-type-list.png)): Shows the pages
 in a list with an icon representing each page. Each page's entry contains the
 name of its author, when it was last modified, and its
-[workflow](/discover/portal/-/knowledge_base/7-2/workflow) status (e.g.,
+[workflow](/docs/7-2/user/-/knowledge_base/u/workflow) status (e.g.,
 Approved, Draft, etc.). 
 
 **Table** (![Table](../../../../images/icon-view-type-table.png)): Shows the

--- a/user/articles/110-collaboration/05-collaborating/05-wiki/04-using-wiki-site-pages.markdown
+++ b/user/articles/110-collaboration/05-collaborating/05-wiki/04-using-wiki-site-pages.markdown
@@ -29,7 +29,7 @@ Comments*, *Enable Ratings for Comments*, and *Enable Highlighting* check boxes
 enable or disable those features for the Wiki. You can set how you want users
 to interact with wiki documents. The *Display Template* selector menu lets you
 choose the Wiki's 
-[Application Display Template](/discover/portal/-/knowledge_base/7-2/styling-widgets-with-application-display-templates).
+[Application Display Template](/docs/7-2/user/-/knowledge_base/u/styling-widgets-with-application-display-templates).
 Below this, you can set which wiki nodes are visible. For example, you might
 host two wikis on a given site, exposing one to the public and keeping the
 other private for site members.
@@ -76,14 +76,14 @@ Once you set the wiki's configuration options the way you want them, click
 The Wiki's Options menu also contains the usual widget options: 
 
 **Look and Feel Configuration:** Set the widget's [look and
-feel](/discover/portal/-/knowledge_base/7-2/look-and-feel-configuration).
+feel](/docs/7-2/user/-/knowledge_base/u/look-and-feel-configuration).
 
-**Export/Import:** [Export or import widget data](/discover/portal/-/knowledge_base/7-2/exporting-importing-widget-data).
+**Export/Import:** [Export or import widget data](/docs/7-2/user/-/knowledge_base/u/exporting-importing-widget-data).
 
 **Permissions:** Set the widget's permissions.
 
 **Configuration Templates:** Use 
-[configuration templates](/discover/portal/-/knowledge_base/7-2/configuration-templates) to
+[configuration templates](/docs/7-2/user/-/knowledge_base/u/configuration-templates) to
 store the widget's current setup or apply an existing archived setup.
 
 **Remove:** Remove the widget from the page. 
@@ -120,7 +120,7 @@ are enabled and your permissions:
 
 **Details:** View the wiki page's details (if you have sufficient permissions). 
 This is explained further in 
-[the documentation on page details](/discover/portal/-/knowledge_base/7-2/wiki-page-details). 
+[the documentation on page details](/docs/7-2/user/-/knowledge_base/u/wiki-page-details). 
 
 **Print:** Print the wiki page.
 

--- a/user/articles/110-collaboration/05-collaborating/06-alerts-announcements.markdown
+++ b/user/articles/110-collaboration/05-collaborating/06-alerts-announcements.markdown
@@ -53,7 +53,7 @@ it is the same. Follow these steps to complete the form:
 1.  Use the *Title* field to give the alert or announcement a title. Then create 
     your content in the field *Write your content here...*. For a detailed 
     explanation of the editor, see the 
-    [Blogs documentation](/discover/portal/-/knowledge_base/7-2/using-the-blog-entry-editor). 
+    [Blogs documentation](/docs/7-2/user/-/knowledge_base/u/using-the-blog-entry-editor). 
 
     ![Figure 2: Enter your alert or announcement's title and content.](../../../images/alerts-new-alert.png)
 

--- a/user/articles/110-collaboration/05-collaborating/11-invite-members.markdown
+++ b/user/articles/110-collaboration/05-collaborating/11-invite-members.markdown
@@ -23,7 +23,7 @@ Roles for your site by selecting that Role under the *Invite to Role* heading.
 Once you've added all the Users you want to invite and have selected their
 Roles, click the *Send Invitations* button to invite them. For more information
 on roles, see the 
-[Roles and Permissions documentation](/discover/portal/-/knowledge_base/7-2/roles-and-permissions). 
+[Roles and Permissions documentation](/docs/7-2/user/-/knowledge_base/u/roles-and-permissions). 
 
 The Site invitation shows up under the *Requests List* tab on the User's 
 *Notifications* page. The User can then choose to *Confirm* or *Ignore* the 


### PR DESCRIPTION
Ran ant convert-links on existing (already merged) collab user docs. No content was changed. 