### PR TITLE
7.2 Developer | USM, Correcting some Metatype Information | LRDOCS-7102

### DIFF
--- a/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
+++ b/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
@@ -78,7 +78,7 @@ This automatically scopes your configuration to `SYSTEM`.
 | Because runtime availability is necessary for some of the Liferay-specific features
 | described below, we recommend defaulting to the bnd annotations.
 
-| **Also Note:** Your project depends on the `-metatype: *` line in it's
+| **Also Note:** Your project depends on the `-metatype: *` line in its
 | `MANIFEST.MF` file. If you're in a [Liferay
 | Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace) or using
 | the [Bundle Support plugin](/docs/7-2/reference/-/knowledge_base/r/), it's added

--- a/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
+++ b/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
@@ -78,8 +78,8 @@ This automatically scopes your configuration to `SYSTEM`.
 | Because runtime availability is necessary for some of the Liferay-specific features
 | described below, we recommend defaulting to the bnd annotations.
 
-| **Also Note:** Your project depends on the `-metatype: *` line in its
-| `MANIFEST.MF` file. If you're in a [Liferay
+| **Also Note:** Your project depends on a `-metatype: *` declaration in its
+| metadata. If you're in a [Liferay
 | Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace) or using
 | the [Bundle Support plugin](/docs/7-2/reference/-/knowledge_base/r/), it's added
 | automatically at build time. Otherwise, add it manually in your module's

--- a/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
+++ b/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
@@ -80,8 +80,9 @@ This automatically scopes your configuration to `SYSTEM`.
 
 | **Also Note:** Your project depends on a `-metatype: *` declaration in its
 | metadata. If you're in a [Liferay
-| Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace) or using
-| the [Bundle Support plugin](/docs/7-2/reference/-/knowledge_base/r/), it's added
+| Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace)(or
+| otherwise applying the [workspace plugin to your
+| build](/docs/7-2/reference/-/knowledge_base/r/gradle-plugins)), it's added
 | automatically at build time. Otherwise, add it manually in your module's
 | `bnd.bnd`. It's required to provide information about your app's configuration
 | options so that a configuration UI can be generated.

--- a/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
+++ b/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
@@ -14,8 +14,7 @@ This automatically scopes your configuration to `SYSTEM`.
     configuration option. Here is the configuration interface for the Liferay
     Forms application:
 
-```java
-
+    ```java
     @Meta.OCD(
         id = "com.liferay.dynamic.data.mapping.form.web.configuration.DDMFormWebConfiguration",
         localization = "content/Language", name = "ddm-form-web-configuration-name"
@@ -37,8 +36,7 @@ This automatically scopes your configuration to `SYSTEM`.
 
 
     }
-
-```
+    ```
 
     This defines two configuration options, the autosave interval (with a default
     of one minute) and the default display view, which can be descriptive or
@@ -81,9 +79,12 @@ This automatically scopes your configuration to `SYSTEM`.
 | described below, we recommend defaulting to the bnd annotations.
 
 | **Also Note:** Your project depends on the `-metatype: *` line in it's
-| `bnd.bnd` file. This line is generated automatically from your bundle's
-| `.build.properties` file, and is required to provide information about your
-| app's configuration options so that a configuration UI can be generated.
+| `MANIFEST.MF` file. If you're in a [Liferay
+| Workspace](/docs/7-2/reference/-/knowledge_base/r/liferay-workspace) or using
+| the [Bundle Support plugin](/docs/7-2/reference/-/knowledge_base/r/), it's added
+| automatically at build time. Otherwise, add it manually in your module's
+| `bnd.bnd`. It's required to provide information about your app's configuration
+| options so that a configuration UI can be generated.
 
 When you register a configuration interface, a UI is auto-generated for it in
 *System Settings* &rarr; *Platform* &rarr; *Third Party*. That's the default


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7102, Basically, Ray found a typo, and I noticed that the information around it seemed incorrect. We've moved it closer to the truth, though there may be another edit when Greg gets back to us about whether the Bundle Support plugin really applies the metatype instruction to the bundle metadata. cc @pei-jung, @codyhoag