### PR TITLE
USM 7.2 Developer, Configuration | LRDOCS-7298

### DIFF
--- a/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
+++ b/developer/frameworks/articles/configuration/02-creating-a-configuration-interface.markdown
@@ -44,7 +44,7 @@ This automatically scopes your configuration to `SYSTEM`.
     the above snippet do:
 
     **Meta.OCD:** Registers this class as a configuration with a specific
-    id. The ID must be the fully qualified configuration class name.
+    id. **The ID must be the fully qualified configuration class name.**
 
     **Meta.AD:** Specifies [optional metadata](http://bnd.bndtools.org/chapters/210-metatype.html) 
     about the field, such as whether it's a required field or if it has


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7298, the Meta.OCD annotation's ID property must be the FQCN of the confiugration class. cc @drewbrokke