### PR TITLE
LRDOCS-7401 Remove references to "test@liferay.com" email

### DIFF
--- a/en/deployment/articles/04-securing-liferay/08-openam-authentication.markdown
+++ b/en/deployment/articles/04-securing-liferay/08-openam-authentication.markdown
@@ -38,12 +38,12 @@ OpenAM.
 Once you have it installed, create the @product@
 administrative user in it. Users are mapped back and forth by screen names. By
 default, the @product@ administrative user has a screen name of *test*, so if
-you were to use that account, register the user with the ID of *test*
-and an email address of *test@liferay.com* in OpenAM. Once you have the user set
-up, log in to OpenAM using this user.
+you were to use that account, register the user in OpenAM with the ID of *test*
+and the email address specified in [`admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+Once you have the user set up, log in to OpenAM using this user.
 
 In the same browser window, log in to @product@ as the administrative user (using
-the email address *test@liferay.com*). Go to the Control Panel and click
+the previous admin email address). Go to the Control Panel and click
 *Configuration* &rarr; *Instance Settings* &rarr; *Security* &rarr;
 *SSO*. Then choose *OpenSSO* in the list on the left.
 

--- a/en/deployment/articles/04-securing-liferay/08-openam-authentication.markdown
+++ b/en/deployment/articles/04-securing-liferay/08-openam-authentication.markdown
@@ -39,7 +39,7 @@ Once you have it installed, create the @product@
 administrative user in it. Users are mapped back and forth by screen names. By
 default, the @product@ administrative user has a screen name of *test*, so if
 you were to use that account, register the user in OpenAM with the ID of *test*
-and the email address specified in [`admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+and the email address specified in the [`admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
 Once you have the user set up, log in to OpenAM using this user.
 
 In the same browser window, log in to @product@ as the administrative user (using
@@ -79,4 +79,3 @@ Property Label | Property Key | Description | Type
 To override these default settings for a particular portal instance, navigate
 to the Control Panel and click *Configuration* &rarr; *Instance Settings* &rarr;
 *Security* &rarr; *SSO*. Then choose *OpenSSO* in the list on the left.
-

--- a/en/developer/frameworks/articles/service-context/01-understanding-service-context-intro.markdown
+++ b/en/developer/frameworks/articles/service-context/01-understanding-service-context-intro.markdown
@@ -140,7 +140,7 @@ Liferay.Service(
     '/user/get-user-by-email-address`,
     {
         companyId: 20101,
-        emailAddress: 'test@liferay.com`
+        emailAddress: 'test@example.com`
     },
     function(obj) {
         console.log(obj);
@@ -148,7 +148,7 @@ Liferay.Service(
 );
 ```
 
-If you run this code, the *test@liferay.com* user (JSON object) is logged to the
+If you run this code, the *test@example.com* user (JSON object) is logged to the
 JavaScript console.
 
 The `Liferay.Service(...)` function takes three arguments:

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/02-discover-api.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/02-discover-api.markdown
@@ -40,7 +40,7 @@ send requests to a @product@ instance running locally on port `8080`.
 
 Run this `curl` command to access the home URL: 
 
-    curl http://localhost:8080/o/headless-delivery/v1.0/openapi.yaml -u test@liferay.com:test
+    curl http://localhost:8080/o/headless-delivery/v1.0/openapi.yaml -u test@example.com:test
 
 You should get a response like this: 
 

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/03-invoke-service.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/03-invoke-service.markdown
@@ -62,7 +62,7 @@ request gets the site's blog postings by providing the site ID (`20124`) in the
 URL: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/" -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/" -u 'test@example.com:test'
 ```
 
 If you send such a request to a site that contains some blog entries, the 

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/04-authenticated-requests.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/04-authenticated-requests.markdown
@@ -27,21 +27,21 @@ Basic authentication requires that you send an HTTP `Authorization` header
 containing the encoded user name and password. You must first get that encoded 
 value. To do so, you can use `openssl` or a `Base64` encoder. Either way, you 
 must encode the `user:password` string. Here's an example of the `openssl` 
-command for encoding the `user:password` string for a user `test@liferay.com` 
+command for encoding the `user:password` string for a user `test@example.com` 
 with the password `Liferay`: 
 
 ```bash
-openssl base64 <<< test@liferay.com:Liferay
+openssl base64 <<< test@example.com:Liferay
 ```
 
 This returns the encoded value: 
 
-    dGVzdEBsaWZlcmF5LmNvbTpMaWZlcmF5Cg==
+    dGVzdEBleGFtcGxlLmNvbTpMaWZlcmF5Cg==
 
 If you don't have `openssl` installed, try the `base64` command: 
 
 ```bash
-base64 <<< test@liferay.com:Liferay
+base64 <<< test@example.com:Liferay
 ```
 
 | **Warning:** Encoding a string as shown here does not encrypt the resulting 
@@ -57,7 +57,7 @@ Use the encoded value for the HTTP Authorization header when sending the
 request: 
 
 ```bash
-curl -H "Authorization: Basic dGVzdEBsaWZlcmF5LmNvbTpMaWZlcmF5Cg==" http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/
+curl -H "Authorization: Basic dGVzdEBleGFtcGxlLmNvbTpMaWZlcmF5Cg==" http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/
 ```
 
 The response contains data instead of the 403 error that an unauthenticated 

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/05-collections/02-getting-collections.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/05-collections/02-getting-collections.markdown
@@ -14,7 +14,7 @@ users. When sending this request, use the credentials of an administrative user
 who has permission to view other portal users: 
 
 ```bash
-curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts"  -u 'test@example.com:test'
 ```
 
 The response (below) has two main parts: 
@@ -40,7 +40,7 @@ This response is in JSON, which is the default response format for web APIs in
       "dashboardURL": "/user/test",
       "dateCreated": "2019-04-17T20:37:19Z",
       "dateModified": "2019-04-22T09:56:35Z",
-      "emailAddress": "test@liferay.com",
+      "emailAddress": "test@example.com",
       "familyName": "Test",
       "givenName": "Test",
       "id": 20130,

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/05-collections/03-pagination.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/05-collections/03-pagination.markdown
@@ -17,7 +17,7 @@ information on them. To do this, send an
 to the UserAccount URL: 
 
 ```bash
-curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts"  -u 'test@example.com:test'
 ```
 
 The response contains the first 30 users and IDs for navigating the rest of the 
@@ -50,7 +50,7 @@ specific page. This example gets the second page (`?page=2`) of documents that
 exist on the site with the ID `20124`: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/documents?page=2"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/documents?page=2"  -u 'test@example.com:test'
 ```
 
 Similarly, you can customize the number of elements per page via the optional 

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/05-collections/04-collection-to-elements.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/05-collections/04-collection-to-elements.markdown
@@ -16,7 +16,7 @@ steps to do so:
     to the `user-accounts` collection: 
 
     ```bash
-    curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts"  -u 'test@liferay.com:test'
+    curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts"  -u 'test@example.com:test'
     ```
 
     Recall from 
@@ -38,7 +38,7 @@ steps to do so:
                   "dashboardURL": "/user/test",
                   "dateCreated": "2019-04-17T20:37:19Z",
                   "dateModified": "2019-04-22T09:56:35Z",
-                  "emailAddress": "test@liferay.com",
+                  "emailAddress": "test@example.com",
                   "familyName": "Test",
                   "givenName": "Test",
                   "id": 20130,
@@ -113,7 +113,7 @@ steps to do so:
     information for the user with the ID `59347` (Javier Gamarra): 
 
     ```bash
-    curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/59347"  -u 'test@liferay.com:test'
+    curl "http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/59347"  -u 'test@example.com:test'
     ```
 
 ## Related Topics

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/06-api-formats.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/06-api-formats.markdown
@@ -29,7 +29,7 @@ with the default JSON. For example, here's such a request for a list of folders
 from the Site with the ID `20124`: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/document-folders" -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/document-folders" -u 'test@example.com:test'
 ```
 
 ```json
@@ -64,7 +64,7 @@ content type's format (JSON, in this case):
 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/document-folders" -u 'test@liferay.com:test' --head
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/document-folders" -u 'test@example.com:test' --head
 ```
 
     HTTP/1.1 200 
@@ -86,7 +86,7 @@ To get the response in XML instead, specify `application/xml` in the request's
 JSON, but is structured differently: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/documents/59203"  -H 'Accept: application/xml'  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/documents/59203"  -H 'Accept: application/xml'  -u 'test@example.com:test'
 ```
 
 ```xml
@@ -120,7 +120,7 @@ Requesting the headers, you can see that the response is in XML
 (`application/xml`): 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/documents/59203"  -H 'Accept: application/xml'  -u 'test@liferay.com:test' --head
+curl "http://localhost:8080/o/headless-delivery/v1.0/documents/59203"  -H 'Accept: application/xml'  -u 'test@example.com:test' --head
 ```
 
     HTTP/1.1 200 
@@ -190,7 +190,7 @@ To request the content in another language, specify your desired locale in the
 request's `Accept-Language` header: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/structured-contents/59325"  -H 'Accept-Language: es-ES'  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/structured-contents/59325"  -H 'Accept-Language: es-ES'  -u 'test@example.com:test'
 ```
 
 ```json

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/08-filter-and-sort.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/08-filter-and-sort.markdown
@@ -81,7 +81,7 @@ append this filter string to the request URL:
 Here's an example of the full request: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/?filter=headline%20eq%20%27New%20Headless%20APIs%27"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/?filter=headline%20eq%20%27New%20Headless%20APIs%27"  -u 'test@example.com:test'
 ```
 
 ```json
@@ -132,7 +132,7 @@ the optional parameter `search` followed by the search terms. For example, this
 request searches for all the `BlogEntry` fields containing OAuth: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/?search=OAuth"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/?search=OAuth"  -u 'test@example.com:test'
 ```
 
 ```json

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/09-restrict-properties.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/09-restrict-properties.markdown
@@ -16,7 +16,7 @@ For example, this request doesn't use sparse fieldsets and therefore returns all
 the fields of a blog posting: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/59301"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/59301"  -u 'test@example.com:test'
 ```
 
 ```json
@@ -46,7 +46,7 @@ To get only the headline, creation date, and creator, append the `fields`
 parameter to the URL with the fields `headline`, `dateCreated`, and `creator`: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/59301?fields=headline,dateCreated,creator"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/59301?fields=headline,dateCreated,creator"  -u 'test@example.com:test'
 ```
 
 ```json
@@ -67,7 +67,7 @@ In the response, the `creator` attribute is a nested JSON object. To return only
 the creator's name, specify that nested field via dot notation (`creator.name`): 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/59301?fields=headline,dateCreated,creator.name"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/59301?fields=headline,dateCreated,creator.name"  -u 'test@example.com:test'
 ```
 
 ```json
@@ -85,7 +85,7 @@ specified attributes for every collection item. For example, this request gets
 the headlines for all the blog postings in the Site with the ID `20124`: 
 
 ```bash
-curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/?fields=headline"  -u 'test@liferay.com:test'
+curl "http://localhost:8080/o/headless-delivery/v1.0/sites/20124/blog-postings/?fields=headline"  -u 'test@example.com:test'
 ```
 
 ```json

--- a/en/developer/frameworks/articles/web-services/02-headless-apis/10-multipart.markdown
+++ b/en/developer/frameworks/articles/web-services/02-headless-apis/10-multipart.markdown
@@ -59,7 +59,7 @@ the folder with the ID `38549`:
     curl -X "POST" "http://localhost:8080/o/headless-delivery/v1.0/document-folders/38549/documents" \
          -H 'Accept: application/json' \
          -H 'Content-Type: multipart/form-data; boundary=PART' \
-         -u 'test@liferay.com:test' \
+         -u 'test@example.com:test' \
          -F "file=" \
          -F "document={\"title\": \"podcast\"}"
 

--- a/en/developer/reference/articles/02-front-end/05-liferay-js-apis/05-invoking-liferay-services.markdown
+++ b/en/developer/reference/articles/02-front-end/05-liferay-js-apis/05-invoking-liferay-services.markdown
@@ -53,7 +53,7 @@ Liferay.Service(
         '/user/get-user-by-email-address',
         {
                 companyId: Liferay.ThemeDisplay.getCompanyId(),
-                emailAddress: 'test@liferay.com'
+                emailAddress: 'test@example.com'
         },
         function(obj) {
                 console.log(obj);
@@ -72,7 +72,7 @@ and `emailAddress`. The response data resembles the following JSON object:
         "contactId": "20157",
         "createDate": 1471990639779,
         "defaultUser": false,
-        "emailAddress": "test@liferay.com",
+        "emailAddress": "test@example.com",
         "emailAddressVerified": true,
         "facebookId": "0",
         "failedLoginAttempts": 0,
@@ -122,7 +122,7 @@ Liferay.Service(
         {
                 '/user/get-user-by-email-address': {
                         companyId: Liferay.ThemeDisplay.getCompanyId(),
-                        emailAddress: 'test@liferay.com'
+                        emailAddress: 'test@example.com'
                 }
         },
         function(obj) {
@@ -140,7 +140,7 @@ Liferay.Service(
                 {
                         '/user/get-user-by-email-address': {
                                 companyId: Liferay.ThemeDisplay.getCompanyId(),
-                                emailAddress: 'test@liferay.com'
+                                emailAddress: 'test@example.com'
                         }
                 },
                 {
@@ -205,7 +205,7 @@ Here is what the response data would look like for the request above:
         "contactId": "20157",
         "createDate": 1471990639779,
         "defaultUser": false,
-        "emailAddress": "test@liferay.com",
+        "emailAddress": "test@example.com",
         "emailAddressVerified": true,
         "facebookId": "0",
         "failedLoginAttempts": 0,
@@ -229,7 +229,7 @@ Here is what the response data would look like for the request above:
                 "birthday": 0,
                 [...]
                 "createDate": 1471990639779,
-                "emailAddress": "test@liferay.com",
+                "emailAddress": "test@example.com",
                 "employeeNumber": "",
                 "employeeStatusId": "",
                 "facebookSn": "",
@@ -277,7 +277,7 @@ Below is the filtered response:
 ```json
 {
         "firstName": "Test",
-        "emailAddress": "test@liferay.com"
+        "emailAddress": "test@example.com"
 }
 ```
 

--- a/en/user/articles/05-setting-up/02-instance-settings/02-configuring-virtual-instance-settings/02-email-instance-settings.markdown
+++ b/en/user/articles/05-setting-up/02-instance-settings/02-configuring-virtual-instance-settings/02-email-instance-settings.markdown
@@ -35,8 +35,8 @@ the "Definition of Terms" heading to help build your email template.
 The Email Sender entry specifies the virtual instance's administrative Name and 
 Address for email notifications, declared as the `[$FROM_NAME$]` and 
 `[$FROM_ADDRESS$]` variables respectively in the email templates. By default, 
-these are `Test Test` and `test@liferay.com`. This name and email address appear 
-in the *From* field in all email messages sent by the virtual instance. 
+they are got from [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+This name and email address appear in the *From* field in all email messages sent by the virtual instance. 
 
 ![Figure 1: Customize the email template for the email messages sent to new Users.](../../../../images/instance-settings-account-created.png)
 

--- a/en/user/articles/05-setting-up/02-instance-settings/02-configuring-virtual-instance-settings/02-email-instance-settings.markdown
+++ b/en/user/articles/05-setting-up/02-instance-settings/02-configuring-virtual-instance-settings/02-email-instance-settings.markdown
@@ -35,7 +35,7 @@ the "Definition of Terms" heading to help build your email template.
 The Email Sender entry specifies the virtual instance's administrative Name and 
 Address for email notifications, declared as the `[$FROM_NAME$]` and 
 `[$FROM_ADDRESS$]` variables respectively in the email templates. By default, 
-they are got from [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+they are from the [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal properties](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
 This name and email address appear in the *From* field in all email messages sent by the virtual instance. 
 
 ![Figure 1: Customize the email template for the email messages sent to new Users.](../../../../images/instance-settings-account-created.png)

--- a/en/user/articles/05-setting-up/03-script-console/04-script-examples.markdown
+++ b/en/user/articles/05-setting-up/03-script-console/04-script-examples.markdown
@@ -7,7 +7,7 @@ header-id: script-examples
 [TOC levels=1-4]
 
 Here are some examples to help you use Liferay's script console. Note: Most of
-these originated from a [Liferay blog post](https://www.liferay.com/web/sebastien.lemarchand/blog/-/blogs/5-tips-to-improve-usage-of-the-liferay-script-console).
+these originated from a [Liferay blog post](https://liferay.dev/blogs/-/blogs/5-tips-to-improve-usage-of-the-liferay-script-console).
 
 The following scripts are Groovy scripts but they can be adapted to other
 languages.
@@ -57,10 +57,11 @@ agree to the terms of use again before they can sign in.
     userCount = UserLocalServiceUtil.getUsersCount()
     users = UserLocalServiceUtil.getUsers(0, userCount)
 
+    long currentUserId = Long.parseLong(userInfo.get("liferay.user.id"))
+
     for (user in users){
 
-        if(!user.isDefaultUser() && 
-            !user.getEmailAddress().equalsIgnoreCase("test@liferay.com")) {
+        if(!user.isDefaultUser() && (user.getUserId() != currentUserId)) {
 
                 user.setAgreedToTermsOfUse(false)
                 UserLocalServiceUtil.updateUser(user)
@@ -72,8 +73,7 @@ agree to the terms of use again before they can sign in.
 
     This sets each user's `agreedToTermsOfUse` attribute to `false`. It skips
     the default user as well as the default admin user that's currently signed
-    in and running the script. If you're signed in as someone other than
-    `test@liferay.com`, update the script with your email address.
+    in and running the script.
 
 3.  Click *Execute*.
  

--- a/en/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
+++ b/en/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
@@ -59,10 +59,10 @@ Use these tabs to configure how the Message Boards app handles email
 notifications:
 
 **Email From**: The name and email address that sends email notifications. 
-The default administrator account's name and email address (e.g., 
-*Test Test* and *test@liferay.com*) are used by default. These were set in 
-the Basic Configuration Wizard when installing @product@. Make sure to 
-update this email address to a valid one that can be dedicated to 
+The default administrator account's name and email address. Default values, 
+are got from [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+ These were set in the Basic Configuration Wizard when installing @product@.
+Make sure to update this email address to a valid one that can be dedicated to 
 notifications. 
 
 **HTML Format:** Support HTML in these emails. 

--- a/en/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
+++ b/en/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
@@ -60,7 +60,7 @@ notifications:
 
 **Email From**: The name and email address that sends email notifications. 
 The default administrator account's name and email address. Default values, 
-are from [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) the [portal properties](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+are from the [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal properties](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
 These were set in the Basic Configuration Wizard when installing @product@.
 Make sure to update this email address to a valid one that can be dedicated to 
 notifications. 

--- a/en/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
+++ b/en/user/articles/110-collaboration/05-collaborating/03-message-boards/03-configuring-message-boards.markdown
@@ -60,8 +60,8 @@ notifications:
 
 **Email From**: The name and email address that sends email notifications. 
 The default administrator account's name and email address. Default values, 
-are got from [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) [portal property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
- These were set in the Basic Configuration Wizard when installing @product@.
+are from [`admin.email.from.name` and `admin.email.from.address`](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Admin%20Portlet) the [portal properties](/docs/7-2/deploy/-/knowledge_base/d/portal-properties)).
+These were set in the Basic Configuration Wizard when installing @product@.
 Make sure to update this email address to a valid one that can be dedicated to 
 notifications. 
 

--- a/en/user/articles/130-forms/16-form-notifications.markdown
+++ b/en/user/articles/130-forms/16-form-notifications.markdown
@@ -20,10 +20,9 @@ entry is submitted.
     name, or anything else informative to the recipient.
 
     **From Address:** The sender's email address. You can use something like 
-    `noreply@liferay-forms.com`, so that recipients don't try to reply. 
+    `noreply@example.com`, so that recipients don't try to reply. 
 
-    **To Address:** The recipient's email address (e.g., 
-    `test@liferay.com`). 
+    **To Address:** The recipient's email address (e.g., `test@example.com`).
 
     **Subject:** The email's subject. An informative subject line tells the
     recipient what happened. For example, An application for employment was


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7401

These updates are from @jorgediaz-lr, who's described the changes...

> After [LPS-84320](https://issues.liferay.com/browse/LPS-84320) and [LRDOCS-7395](https://issues.liferay.com/browse/LRDOCS-7395) changes, we should remove all references to "test@liferay.com" email.
> 
> I have done following changes:
> 
> - **First commit https://github.com/jhinkey/liferay-docs/commit/0b781a5ad56b0ce35667d6b4a0f24c68c1e0bb8d -** I have updated groovy script to avoid hardcoding "test@liferay.com"
> - **Second https://github.com/jhinkey/liferay-docs/commit/2212362cdaf4b1be34bceca736478346cc9a39f9 and third commit https://github.com/jhinkey/liferay-docs/commit/52542fdc4a8b1bf88af5dc64370e793c715ecf98** I have replaced "test@liferay.com" with "test@example.com". For more information about "example.com" domain, see tools.ietf.org/html/rfc6761#section-6.5
> - **Fourth commit https://github.com/jhinkey/liferay-docs/commit/24146ce69459fd79c124d1d70b1d62cedb45c394** I have replaced test@liferay.com with a reference to 'admin.email.from.address' portal-ext.properties property
> 


