### PR TITLE
LRDOCS-7500 LRDOCS-7518 7.2: Fix and improve Cluster Link instructions

### DIFF
--- a/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
+++ b/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
@@ -194,7 +194,7 @@ You're now set up for Unicast over TCP clustering! Repeat either TCPPING process
 
 ### JDBC Ping
 
-Rather than use TCP Ping to discover cluster members, you can use a central database accessible by all the nodes to help them find each other. Cluster members write their own and read the other members' addresses from this database. To enable this configuration, replace the `TCPPING` tag with the corresponding `JDBCPING` tag: 
+Rather than use TCP Ping to discover cluster members, you can use a central database accessible by all the nodes to help them find each other. Cluster members write their own and read the other members' addresses from this database. To enable this configuration, replace the `TCPPING` tag with the corresponding `JDBC_PING` tag: 
 
 ```xml
 <JDBC_PING

--- a/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
+++ b/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
@@ -25,6 +25,17 @@ database and store it in its local cache.
 
 ![Figure 1: @product@'s cache algorithm is extremely efficient. ](../../../images/clustering-cache-efficient-algorithm.png)
 
+Here are the Cluster Link topics: 
+
+- [Enabling Cluster Link](#enabling-cluster-link)
+- [Multicast Over UDP](#multicast-over-udp)
+- [Unicast Over TCP](#unicast-over-tcp)
+- [Using Different Control and Transport Channel Ports](#using-different-control-and-transport-channel-ports)
+- [Modifying the Cache Configuration with a Module](#modifying-the-cache-configuration-with-a-module)
+
+
+## Enabling Cluster Link 
+
 To enable Cluster Link, add this [portal
 property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties) to a
 `portal-ext.properties` file: 
@@ -33,9 +44,24 @@ property](/docs/7-2/deploy/-/knowledge_base/d/portal-properties) to a
 cluster.link.enabled=true
 ```
 
-| **Note:** See the
-| [Cluster Link portal property definitions](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Cluster%20Link)
-| for details. 
+The
+[Cluster Link portal properties](@platform-ref@/7.2-latest/propertiesdoc/portal.properties.html#Cluster%20Link)
+provide a default configuration that you can override to fit your needs. 
+
+Many of the defaults use `localhost`, instead of a real address. In some
+configurations, however, `localhost` is bound to the internal loopback network
+(`127.0.0.1` or `::1`), rather than the host's real address. If for some reason
+you need this configuration, you can make DXP auto detect the real address with
+this property: 
+
+```properties
+cluster.link.autodetect.address=www.google.com:80
+```
+
+Set it to connect to some other host that's contactable by your server. By
+default, it points to Google, but this may not work if your server is behind a
+firewall. If you use each host's real address, you don't need to set the
+auto-detect address. 
 
 Cluster Link depends on 
 [JGroups](http://www.jgroups.org) 
@@ -45,13 +71,6 @@ and provides an API for nodes to communicate. It can
 - Send messages to a specific node
 - Invoke methods and retrieve values from all, some, or specific nodes
 - Detect membership and notify when nodes join or leave
-
-When you start @portal@ in a cluster, a log file message shows your cluster's 
-name (e.g., `cluster=liferay-channel-control`): 
-
-    ------------------------------------------------------------------- 
-    GMS: address=oz-52865, cluster=liferay-channel-control, physical address=192.168.1.10:50643 
-    -------------------------------------------------------------------
 
 Cluster Link contains an enhanced algorithm that provides one-to-many type
 communication between the nodes. This is implemented by default with JGroups's
@@ -156,7 +175,7 @@ If your network configuration or the geographical distance between nodes prevent
     <TCP bind_port="7800"/> 
     ```
 
-5.  In the `tcp.xml` file, make each node discoverable to TCPPing by specifying the node's IP address and an unused port on that node. Building off of the previous step, here's an example `<TCPPing>` element: 
+5.  In the `tcp.xml` file, make each node discoverable to TCPPing by specifying its IP address and an unused port on that node. Building off of the previous step, here's an example `<TCPPing>` element: 
 
     ```xml 
     <TCP bind_port="7800"/> 
@@ -165,9 +184,10 @@ If your network configuration or the geographical distance between nodes prevent
         port_range="0"/> 
     ```
 
-    > **Important:** Make sure your `initial_hosts` attribute accounts for all nodes.
-
-    > **Note:** An alternative to specifying initial hosts in a TCP XML file is to specify them to your app server using a JVM argument like this: `-Djgroups.tcpping.initial_hosts=192.168.224.154[7800],192.168.224.155[7800]`
+    **Regarding Initial Hosts:**
+    
+    - Make sure the initial hosts value accounts for all your nodes. If `initial_hosts` is not specified in a TCP XML file or in a JVM argument, `localhost` is the initial host.
+    - An alternative to specifying initial hosts in a TCP XML file is to specify them to your app server using a JVM argument like this: `-Djgroups.tcpping.initial_hosts=192.168.224.154[7800],192.168.224.155[7800]`.
 
 6.  Copy your `tcp.xml` file to each node, making sure to set the TCP bind port to the node's bind port. On the node with IP address `192.168.224.155`, for example, configure TCPPing like this:
 
@@ -322,3 +342,16 @@ You can install the module on each node and change the settings without taking
 down the cluster. This is a great benefit, but beware: since Ehcache doesn't
 allow for changes to cache settings while the cache is alive, reconfiguring a
 cache while the server is running flushes the cache. 
+
+## Conclusion 
+
+Once you've configured your cluster, you can start it. A log file message shows
+your cluster's  name (e.g., `cluster=liferay-channel-control`): 
+
+```bash
+------------------------------------------------------------------- 
+GMS: address=oz-52865, cluster=liferay-channel-control, physical address=192.168.1.10:50643 
+-------------------------------------------------------------------
+```
+
+Congratulations! Your cluster is using Cluster Link. 

--- a/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
+++ b/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
@@ -125,16 +125,15 @@ methods are all provided by JGroups.
 
 ## Unicast over TCP
 
-If your network configuration or the sheer distance between nodes prevents you
-from using UDP Multicast clustering, you can configure TCP Unicast. You must use
-this if you have a firewall separating any of your nodes or if your nodes are in
-different geographical locations.
+If your network configuration or the geographical distance between nodes prevents you from using UDP Multicast clustering, you can configure TCP Unicast. You must use this if you have a firewall separating any of your nodes or if your nodes are in different geographical locations.
 
 1.  Add a parameter to your app server's JVM on each node:
 
     ```bash
     -Djgroups.bind_addr=[node_ip_address]
     ```
+ 
+    Use the node's IP address.
 
 2.  Select a discovery protocol for the nodes to use to find each other. Here are the protocol choices: 
 
@@ -145,11 +144,102 @@ different geographical locations.
 
     If you aren't sure which one to choose, use TCPPing. The rest of these steps use TCPPing
 
-3.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `ehcache` in the DXP web application's `WEB-INF/classes` folder.  
+3.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `ehcache` in the DXP web application's `WEB-INF/classes` folder. 
 
-4.  Using separate control and transport channel ports lets you monitor control and transport traffic and helps you isolate information to diagnose problems. 
+    ```
+    WEB-INF/classes/ehcache/tcp.xml
+    ```
 
-    Make a copy of the `tcp.xml` in the same location and rename both files, designating one for the control channel and the other for the transport channel. For example, you could use these file names:
+4.  In the `tcp.xml` file, set the TCP bind port to an unused port on your node. Here's an example:
+
+    ```xml 
+    <TCP bind_port="7800"/> 
+    ```
+
+5.  In the `tcp.xml` file, make each node discoverable to TCPPing by specifying the node's IP address and an unused port on that node. Building off of the previous step, here's an example `<TCPPing>` element: 
+
+    ```xml 
+    <TCP bind_port="7800"/> 
+    <TCPPING async_discovery="true"
+        initial_hosts="192.168.224.154[7800],192.168.224.155[7800]"
+        port_range="1"/> 
+    ```
+
+    > **Important:** Make sure your `initial_hosts` attribute accounts for all nodes.
+
+    > **Note:** An alternative to specifying initial hosts in a TCP XML file is to specify them to your app server using a JVM argument like this: `-Djgroups.tcpping.initial_hosts=192.168.224.154[7800],192.168.224.155[7800]`
+
+6.  Copy your `tcp.xml` file to each node, making sure to set the TCP bind port to the node's bind port. On the node with IP address `192.168.224.155`, for example, configure TCPPing like this:
+
+    ```xml 
+    <TCP bind_port="7800"/> 
+    <TCPPING async_discovery="true"
+        initial_hosts="192.168.224.154[7800],192.168.224.155[7800]"
+        port_range="1"/> 
+    ```
+
+7. Modify the [Cluster Link properties](https://docs.liferay.com/portal/7.2-latest/propertiesdoc/portal.properties.html#Cluster%20Link) in the node's `portal-ext.properties` file to enable Cluster Link and point to the TCP XML file for each Cluster Link channel: 
+
+```properties
+cluster.link.enabled=true
+cluster.link.channel.properties.control=/ehcache/tcp.xml
+cluster.link.channel.properties.transport.0=/ehcache/tcp.xml
+```
+
+The JGroups configuration demonstrated above is typically all that Unicast over TCP requires. However, in a very specific case, if *(and only if)* cluster nodes are deployed across multiple networks, then the parameter `external_addr` must be set on each host to the external (public IP) address of the firewall. This kind of configuration is usually only necessary when nodes are geographically separated. By setting this, clustered nodes deployed to separate networks (e.g. separated by different firewalls) can communicate together. This configuration may be flagged in security audits of your system. See [JGroups documentation](http://www.jgroups.org/manual4/index.html#_transport_protocols) for more information.
+
+> **Note:** The `singleton_name` TCP attribute was deprecated in JGroups v4.0.0 and has therefore been removed since Liferay DXP 7.2 SP1 and Liferay Portal CE GA2 which use JGroups v 4.1.1-Final.
+
+You're now set up for Unicast over TCP clustering! Repeat either TCPPING process for each node you want to add to the cluster.
+
+### JDBC Ping
+
+Rather than use TCP Ping to discover cluster members, you can use a central database accessible by all the nodes to help them find each other. Cluster members write their own and read the other members' addresses from this database. To enable this configuration, replace the `TCPPING` tag with the corresponding `JDBCPING` tag: 
+
+```xml
+<JDBC_PING
+    connection_url="jdbc:mysql://[DATABASE_IP]/[DATABASE_NAME]?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false"
+    connection_username="[DATABASE_USER]"
+    connection_password="[DATABASE_PASSWORD]"
+    connection_driver="com.mysql.jdbc.Driver"/>
+```
+
+The above example uses MySQL as the database. For further information about JDBC Ping, please see the [JGroups Documentation](http://www.jgroups.org/manual4/index.html#DiscoveryProtocols).
+
+### S3 Ping
+
+Amazon S3 Ping can be used for servers running on Amazon's EC2 cloud service. Each node uploads a small file to an S3 bucket, and all the other nodes read the files from this bucket to discover the other nodes. When a node leaves, its file is deleted.
+
+To configure S3 Ping, replace the `TCPPING` tag with the corresponding `S3_PING` tag: 
+
+```xml
+<S3_PING 
+    secret_access_key="[SECRETKEY]" 
+    access_key="[ACCESSKEY]"
+    location="ControlBucket"/>
+```
+
+Supply your Amazon keys as values for the parameters above. For further information about S3 Ping, please see the [JGroups Documentation](http://www.jgroups.org/manual4/index.html#_s3_ping).
+
+### Other Pings
+
+JGroups supplies other means for cluster members to discover each other, including Rackspace Ping, BPing, File Ping, and others. Please see the [JGroups Documentation](http://www.jgroups.org/manual4/index.html#DiscoveryProtocols) for information about these discovery methods.
+
+The control and transport channels can be configured to use different ports. 
+
+## Using Different Control and Transport Channel Ports 
+
+Using separate control and transport channel ports lets you monitor control and transport traffic and helps you isolate information to diagnose problems. These steps use Unicast over TCPPing to demonstrate the approach. 
+
+1.  Add a parameter to your app server's JVM on each node:
+
+    ```bash
+    -Djgroups.bind_addr=[node_ip_address]
+    ```
+
+2.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `ehcache` in the DXP web application's `WEB-INF/classes` folder.  
+
+3.  Make a copy of the `tcp.xml` in the same location and rename both files, designating one for the control channel and the other for the transport channel. For example, you could use these file names:
 
     -   `tcp-control.xml`
 
@@ -214,55 +304,7 @@ different geographical locations.
         port_range="1"/> 
     ```
 
-You're now set up for Unicast over TCP clustering! 
-
-### JDBC Ping
-
-Rather than use TCP Ping to discover cluster members, you can use a central
-database accessible by all the nodes to help them find each other. Cluster
-members write their own and read the other members' addresses from this
-database. To enable this configuration, replace the `TCPPING` tag with the
-corresponding `JDBCPING` tag: 
-
-```xml
-<JDBC_PING
-    connection_url="jdbc:mysql://[DATABASE_IP]/[DATABASE_NAME]?useUnicode=true&amp;characterEncoding=UTF-8&amp;useFastDateParsing=false"
-    connection_username="[DATABASE_USER]"
-    connection_password="[DATABASE_PASSWORD]"
-    connection_driver="com.mysql.jdbc.Driver"/>
-```
-
-The above example uses MySQL as the database. For further information about
-JDBC Ping, please see the 
-[JGroups Documentation](http://www.jgroups.org/manual4/index.html#DiscoveryProtocols). 
-
-### S3 Ping
-
-Amazon S3 Ping can be used for servers running on Amazon's EC2 cloud service.
-Each node uploads a small file to an S3 bucket, and all the other nodes read the
-files from this bucket to discover the other nodes. When a node leaves, its file
-is deleted. 
-
-To configure S3 Ping, replace the `TCPPING` tag with the corresponding `S3_PING`
-tag: 
-
-```xml
-<S3_PING 
-    secret_access_key="[SECRETKEY]" 
-    access_key="[ACCESSKEY]"
-    location="ControlBucket"/>
-```
-
-Supply your Amazon keys as values for the parameters above. For further
-information about S3 Ping, please see the 
-[JGroups Documentation](http://www.jgroups.org/manual4/index.html#_s3_ping). 
-
-### Other Pings
-
-JGroups supplies other means for cluster members to discover each other,
-including Rackspace Ping, BPing, File Ping, and others. Please see the 
-[JGroups Documentation](http://www.jgroups.org/manual4/index.html#DiscoveryProtocols)
-for information about these discovery methods. 
+If you have added entities that can be cached or you want to tune the cache configuration for your system, you can do so using a module. 
 
 ## Modifying the Cache Configuration with a Module
 

--- a/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
+++ b/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
@@ -144,10 +144,10 @@ If your network configuration or the geographical distance between nodes prevent
 
     If you aren't sure which one to choose, use TCPPing. The rest of these steps use TCPPing
 
-3.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `ehcache` in the DXP web application's `WEB-INF/classes` folder. 
+3.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `jgroups` in the DXP web application's `WEB-INF/classes` folder. 
 
     ```
-    WEB-INF/classes/ehcache/tcp.xml
+    WEB-INF/classes/jgroups/tcp.xml
     ```
 
 4.  In the `tcp.xml` file, set the TCP bind port to an unused port on your node. Here's an example:
@@ -162,7 +162,7 @@ If your network configuration or the geographical distance between nodes prevent
     <TCP bind_port="7800"/> 
     <TCPPING async_discovery="true"
         initial_hosts="192.168.224.154[7800],192.168.224.155[7800]"
-        port_range="1"/> 
+        port_range="0"/> 
     ```
 
     > **Important:** Make sure your `initial_hosts` attribute accounts for all nodes.
@@ -175,15 +175,15 @@ If your network configuration or the geographical distance between nodes prevent
     <TCP bind_port="7800"/> 
     <TCPPING async_discovery="true"
         initial_hosts="192.168.224.154[7800],192.168.224.155[7800]"
-        port_range="1"/> 
+        port_range="0"/> 
     ```
 
 7. Modify the [Cluster Link properties](https://docs.liferay.com/portal/7.2-latest/propertiesdoc/portal.properties.html#Cluster%20Link) in the node's `portal-ext.properties` file to enable Cluster Link and point to the TCP XML file for each Cluster Link channel: 
 
 ```properties
 cluster.link.enabled=true
-cluster.link.channel.properties.control=/ehcache/tcp.xml
-cluster.link.channel.properties.transport.0=/ehcache/tcp.xml
+cluster.link.channel.properties.control=/jgroups/tcp.xml
+cluster.link.channel.properties.transport.0=/jgroups/tcp.xml
 ```
 
 The JGroups configuration demonstrated above is typically all that Unicast over TCP requires. However, in a very specific case, if *(and only if)* cluster nodes are deployed across multiple networks, then the parameter `external_addr` must be set on each host to the external (public IP) address of the firewall. This kind of configuration is usually only necessary when nodes are geographically separated. By setting this, clustered nodes deployed to separate networks (e.g. separated by different firewalls) can communicate together. This configuration may be flagged in security audits of your system. See [JGroups documentation](http://www.jgroups.org/manual4/index.html#_transport_protocols) for more information.
@@ -237,7 +237,7 @@ Using separate control and transport channel ports lets you monitor control and 
     -Djgroups.bind_addr=[node_ip_address]
     ```
 
-2.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `ehcache` in the DXP web application's `WEB-INF/classes` folder.  
+2.  Extract the `tcp.xml` file from `$LIFERAY.HOME/osgi/marketplace/Liferay Foundation - Liferay Portal - Impl.lpkg/com​.​liferay​.​portal​.​cluster​.​multiple​-​[version].​jar/lib​/​jgroups​-​[version].​Final​.​jar/tcp.xml` to a location accessible to DXP, such as a folder called `jgroups` in the DXP web application's `WEB-INF/classes` folder.  
 
 3.  Make a copy of the `tcp.xml` in the same location and rename both files, designating one for the control channel and the other for the transport channel. For example, you could use these file names:
 
@@ -249,8 +249,8 @@ Using separate control and transport channel ports lets you monitor control and 
 
     ```properties
     cluster.link.enabled=true
-    cluster.link.channel.properties.control=/ehcache/tcp-control.xml
-    cluster.link.channel.properties.transport.0=/ehcache/tcp-transport.xml
+    cluster.link.channel.properties.control=/jgroups/tcp-control.xml
+    cluster.link.channel.properties.transport.0=/jgroups/tcp-transport.xml
     ```
 
 6.  Modify each `tcp-*.xml` file's the TCP and TCPPing elements to account for each node's IP address and bind port. 
@@ -274,7 +274,7 @@ Using separate control and transport channel ports lets you monitor control and 
     <TCP bind_port="7800"/> 
     <TCPPING async_discovery="true"
         initial_hosts="192.168.224.154[7800],192.168.224.154[7802]"
-        port_range="1"/> 
+        port_range="0"/> 
     ```
 
     **Node 1 `tcp-transport.xml`**
@@ -283,7 +283,7 @@ Using separate control and transport channel ports lets you monitor control and 
     <TCP bind_port="7801"/> 
     <TCPPING async_discovery="true"
         initial_hosts="192.168.224.154[7801],192.168.224.154[7803]"
-        port_range="1"/> 
+        port_range="0"/> 
     ```
 
     **Node 2 `tcp-control.xml`**
@@ -292,7 +292,7 @@ Using separate control and transport channel ports lets you monitor control and 
     <TCP bind_port="7802"/> 
     <TCPPING async_discovery="true"
         initial_hosts="192.168.224.154[7800],192.168.224.154[7802]"
-        port_range="1"/> 
+        port_range="0"/> 
     ```
 
     **Node 2 `tcp-transport.xml`**
@@ -301,7 +301,7 @@ Using separate control and transport channel ports lets you monitor control and 
     <TCP bind_port="7803"/> 
     <TCPPING async_discovery="true"
         initial_hosts="192.168.224.154[7801],192.168.224.154[7803]"
-        port_range="1"/> 
+        port_range="0"/> 
     ```
 
 If you have added entities that can be cached or you want to tune the cache configuration for your system, you can do so using a module. 

--- a/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
+++ b/en/deployment/articles/02-configuring-liferay/04-liferay-portal-clustering/05-enabling-cluster-link.markdown
@@ -32,6 +32,7 @@ Here are the Cluster Link topics:
 - [Unicast Over TCP](#unicast-over-tcp)
 - [Using Different Control and Transport Channel Ports](#using-different-control-and-transport-channel-ports)
 - [Modifying the Cache Configuration with a Module](#modifying-the-cache-configuration-with-a-module)
+- [Conclusion](#conclusion)
 
 
 ## Enabling Cluster Link 
@@ -185,9 +186,9 @@ If your network configuration or the geographical distance between nodes prevent
     ```
 
     **Regarding Initial Hosts:**
-    
-    - Make sure the initial hosts value accounts for all your nodes. If `initial_hosts` is not specified in a TCP XML file or in a JVM argument, `localhost` is the initial host.
+
     - An alternative to specifying initial hosts in a TCP XML file is to specify them to your app server using a JVM argument like this: `-Djgroups.tcpping.initial_hosts=192.168.224.154[7800],192.168.224.155[7800]`.
+    - Make sure the initial hosts value accounts for all your nodes. If `initial_hosts` is not specified in a TCP XML file or in a JVM argument, `localhost` is the initial host.
 
 6.  Copy your `tcp.xml` file to each node, making sure to set the TCP bind port to the node's bind port. On the node with IP address `192.168.224.155`, for example, configure TCPPing like this:
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7500 Improve JGroups Unicast TCPPing instructions.

https://issues.liferay.com/browse/LRDOCS-7518 Explain localhost value and real addresses at the start. Note using initial hosts in a JVM arg.