### PR TITLE
LRDOCS-7541 Move OAuth 1.0a to Maintenance

### DIFF
--- a/en/deployment/articles/05-upgrading-to-liferay-7-2/98-deprecated-apps-in-7-2-what-to-do.markdown
+++ b/en/deployment/articles/05-upgrading-to-liferay-7-2/98-deprecated-apps-in-7-2-what-to-do.markdown
@@ -69,7 +69,6 @@ Here are the apps deprecated in @product-ver@.
 | Central Authentication Service | Bundled | Migrate to [SAML based authentication](https://help.liferay.com/hc/en-us/articles/360028711032-Introduction-to-Authenticating-Using-SAML). |
 | Google Login | Marketplace | Replaced by [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 | NTLM | Marketplace | Replaced by [Kerberos](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-kerberos). |
-| OAuth 1.0a | Marketplace | Replaced by OAuth 2.0, which is included in the bundle. |
 | OpenAM / OpenSSO | Bundled | Migrate to [SAML based authentication](https://help.liferay.com/hc/en-us/articles/360028711032-Introduction-to-Authenticating-Using-SAML). |
 | OpenID | Marketplace | Replaced by [OpenID Connect](/docs/7-2/deploy/-/knowledge_base/d/authenticating-with-openid-connect). |
 


### PR DESCRIPTION
The Liferay Connector to OAuth 1.0a should be in Maintenance mode and not deprecated. Added it to the maintenance mode page in https://github.com/sez11a/liferay-docs/pull/4752.