### PR TITLE
Search 7.2 Developer | LRDOCS-7943 | SearchRequestBuilder must be instantiated with its factory's `builder` method

### DIFF
--- a/en/developer/frameworks/articles/search/02-aggregations/02-base-search-aggregations-code.markdown
+++ b/en/developer/frameworks/articles/search/02-aggregations/02-base-search-aggregations-code.markdown
@@ -48,7 +48,7 @@ Once the aggregation itself is in good shape, feed it to the search query.
 
     ```java
     SearchRequestBuilder searchRequestBuilder = 
-        searchRequestBuilderFactory.getSearchRequestBuilder();
+        searchRequestBuilderFactory.builder();
     ```
 
 2.  Get a `com.liferay.portal.search.searcher.SearchRequest` instance from the

--- a/en/developer/frameworks/articles/search/02-aggregations/03-statistical-aggregations.markdown
+++ b/en/developer/frameworks/articles/search/02-aggregations/03-statistical-aggregations.markdown
@@ -44,7 +44,7 @@ that are to be computed for each field.
 2.  Get an instance of `com.liferay.portal.search.searcher.SearchRequestBuilder`:
 
     ```java
-    SearchRequestBuilder searchRequestBuilder = searchRequestBuilderFactory.getSearchRequestBuilder();
+    SearchRequestBuilder searchRequestBuilder = searchRequestBuilderFactory.builder();
     ```
 
 3.  Get a `com.liferay.portal.search.searcher.SearchRequest` instance from the builder:

--- a/en/developer/frameworks/articles/search/03-queries-and-filters/02-building-search-queries-and-filters.markdown
+++ b/en/developer/frameworks/articles/search/03-queries-and-filters/02-building-search-queries-and-filters.markdown
@@ -91,7 +91,7 @@ Once the query itself is in good shape, feed it to the search request.
 
     ```java
     SearchRequestBuilder searchRequestBuilder =
-        searchRequestBuilderFactory.getSearchRequestBuilder();
+        searchRequestBuilderFactory.builder();
     ```
 
     If not setting search keywords into the `SearchContext` (covered below), make


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7943, cc @lipusz. Changed 3 incorrect instances that were calling a now non-existent method to instantiate the SearchRequestBuilder.