### PR TITLE
7.1 .x - LRDOCS-7603 Remove war from the osgi folder list

### DIFF
--- a/en/discover/deployment/articles-dxp/01-deploying-liferay/06-installing-liferay-portal-on-jboss-eap.markdown
+++ b/en/discover/deployment/articles-dxp/01-deploying-liferay/06-installing-liferay-portal-on-jboss-eap.markdown
@@ -19,7 +19,7 @@ Before proceeding, download these files from the
 - Dependencies ZIP file
 - OSGi JARs ZIP file
 
-[*Liferay Home*](/docs/7-0/deploy/-/knowledge_base/d/installing-liferay#liferay-home)
+[*Liferay Home*](/docs/7-1/deploy/-/knowledge_base/d/installing-liferay#liferay-home)
 is the folder containing your JBoss server folder. After installing and
 deploying @product@, the Liferay Home folder contains the JBoss server folder as
 well as `data`, `deploy`, `logs`, and `osgi` folders. `$JBOSS_HOME` refers to
@@ -31,27 +31,10 @@ your JBoss server folder. This folder is usually named `jboss-eap-[version]`.
 Download and install the required JARs as described below.
 
 1.  Create the folder `$JBOSS_HOME/modules/com/liferay/portal/main` if it
-    doesn't exist and extract the JARs from the dependencies ZIP to it: 
+    doesn't exist and extract the dependencies ZIP JARs to it.
 
-        - `com.liferay.petra.concurrent.jar`
-        - `com.liferay.petra.executor.jar` 
-        - `com.liferay.petra.function.jar` 
-        - `com.liferay.petra.io.jar` 
-        - `com.liferay.petra.lang.jar` 
-        - `com.liferay.petra.memory.jar` 
-        - `com.liferay.petra.nio.jar` 
-        - `com.liferay.petra.process.jar` 
-        - `com.liferay.petra.reflect.jar` 
-        - `com.liferay.petra.string.jar` 
-        - `com.liferay.registry.api.jar`
-        - `hsql.jar`
-        - `portal-kernel.jar`
-        - `portlet.jar`
-
-2.  Download your database driver `.jar` file and copy it into the same folder.
-    For example
-    [copy MySQL's driver](http://dev.mysql.com/downloads/connector/j/)
-    into the `$JBOSS_HOME/modules/com/liferay/portal/main` folder.
+2.  Download your database driver `.jar` file and copy it into the
+    same folder. Please see the [compatibility matrix](https://web.liferay.com/documents/14/21598941/Liferay+DXP+7.1+Compatibility+Matrix/9f9c917a-c620-427b-865d-5c4b4a00be85) for a list of supported databases.
 
 3.  Create the file `module.xml` in the
     `$JBOSS_HOME/modules/com/liferay/portal/main` folder and insert this
@@ -73,7 +56,7 @@ Download and install the required JARs as described below.
                 <resource-root path="com.liferay.petra.string.jar" />
                 <resource-root path="com.liferay.registry.api.jar" />
                 <resource-root path="hsql.jar" />
-                <resource-root path="mysql.jar" />
+                <resource-root path="[place your database driver here]" />
                 <resource-root path="portal-kernel.jar" />
                 <resource-root path="portlet.jar" />
             </resources>
@@ -86,8 +69,7 @@ Download and install the required JARs as described below.
             </dependencies>
         </module>
 
-    If you use a different database, replace the MySQL `.jar` with the driver
-    JAR for your database (e.g., HSQL, PostgreSQL, etc.).
+    Replace the indicated `resource-root` element with the driver JAR for your database.
 
 4.  Create an `osgi` folder in your Liferay Home folder. Extract the OSGi ZIP
     file that you downloaded into the `osgi` folder.
@@ -97,38 +79,9 @@ Download and install the required JARs as described below.
 
 **Checkpoint:**
 
-1.  Verify the `$JBOSS_HOME/modules/com/liferay/portal/main` folder has the
-    following files: 
-
-    - `com.liferay.petra.concurrent`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
-    - a database JAR such as the MySQL Connector.
-
-2.  The `module.xml` has listed all JARs in the `<resource-root-path>` elements.
-
-3.  The `osgi` folder has the following subfolders:
-
-    - `configs`
-    - `core`
-    - `marketplace`
-    - `modules`
-    - `portal`
-    - `static`
-    - `test`
-    - `war`
-
-Great! You have your `.jar` files ready.
+1. The dependencies files have been unzipped into the `$JBOSS_HOME/modules/com/liferay/portal/main` folder and a database jar.
+1. The `module.xml` contains all JARs in the `<resource-root-path>` elements.
+1. The `osgi` dependencies have been unzipped into the `osgi` folder.
 
 ## Running @product@ on JBoss EAP in Standalone Mode vs. Domain Mode
 
@@ -322,55 +275,56 @@ your data source. The
 page lets you configure @product@'s built-in data source. If you want to use the
 built-in data source, skip this section.
 
-This section demonstrates configuring a MySQL database. If you're using a
-different database, modify the data source and driver snippets as necessary.
-
 If you want JBoss to manage your data source, follow these steps:
 
-1.  Add your data source inside the `<datasources>` element.
+1. Add the data source inside the `$JBOSS_HOME/standalone/configuration/standalone.xml` file's the `<datasources>` element.
 
-        <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
-            <connection-url>jdbc:mysql://localhost/lportal</connection-url>
-            <driver>mysql</driver>
-            <security>
-                <user-name>root</user-name>
-                <password>root</password>
-            </security>
-        </datasource>
+    ```xml
+    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
+        <connection-url>[place the URL to your database here]</connection-url>
+        <driver>[place the driver name here]</driver>
+        <security>
+            <user-name>[place your user name here]</user-name>
+            <password>[place your password here]</password>
+        </security>
+    </datasource>
+    ```
 
-    Be sure to replace the database name (i.e., `lportal`), user name, and
-    password with the appropriate values. 
+    Make sure to replace the database URL, user name, and password with the appropriate values.
 
     | **Note:** If you must change your datasource `jndi-name` to something
     | different, you must also edit the `datasource` element in the
     | `<default-bindings>` tag.
 
-2.  Add your driver to the `standalone.xml` file's `<drivers>` element also
-    found within the `<datasources>` element.
+2. Add the driver to the `standalone.xml` file's `<drivers>` element also found within the `<datasources>` element.
 
-        <drivers>
-            <driver name="mysql" module="com.liferay.portal">
-                <driver-class>com.mysql.jdbc.Driver</driver-class>
-            </driver>
-        </drivers>
+    ```xml
+    <drivers>
+        <driver name="[name of driver must match name above]" module="com.liferay.portal">
+            <driver-class>[place your JDBC driver class here]</driver-class>
+        </driver>
+    </drivers>
+    ```
 
-    Your final data sources subsystem should look like this:
+    A final data source subsystem that uses MySQL should look like this:
 
-        <subsystem xmlns="urn:jboss:domain:datasources:5.0">
-            <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
-                    <connection-url>jdbc:mysql://localhost/lportal</connection-url>
-                    <driver>mysql</driver>
-                    <security>
-                        <user-name>root</user-name>
-                        <password>root</password>
-                    </security>
-                </datasource>
-                <drivers>
-                    <driver name="mysql" module="com.liferay.portal"/>
-                </drivers>
-            </datasources>
-        </subsystem>
+    ```xml
+    <subsystem xmlns="urn:jboss:domain:datasources:5.0">
+        <datasources>
+            <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
+                <connection-url>jdbc:mysql://localhost/lportal</connection-url>
+                <driver>mysql</driver>
+                <security>
+                    <user-name>root</user-name>
+                    <password>root</password>
+                </security>
+            </datasource>
+            <drivers>
+                <driver name="mysql" module="com.liferay.portal"/>
+            </drivers>
+        </datasources>
+    </subsystem>
+    ```
 
 3.  In a `portal-ext.properties` file in your Liferay Home, specify your data
     source:

--- a/en/discover/deployment/articles-dxp/01-deploying-liferay/07-installing-liferay-on-tc-server.markdown
+++ b/en/discover/deployment/articles-dxp/01-deploying-liferay/07-installing-liferay-on-tc-server.markdown
@@ -14,7 +14,6 @@ these *Additional Files*:
 - Dependencies ZIP file
 - OSGi Dependencies ZIP file
 
-
 Here are the basic steps for installing @product@ on tc Server: 
 
 - Installing @product@ dependencies to your application server
@@ -84,23 +83,7 @@ download the required JARs from third parties, as described below.
 | quickly, using one of these sources might save you time.
 
 1.  Extract the JARs from the dependencies ZIP to the 
-    `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/lib` folder. The JARs are 
-    listed below:
-
-    - `com.liferay.petra.concurrent.jar`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `hsql.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
+    `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/lib` folder.
 
 2.  Download the following JARs or copy them from a @product@ bundle to the 
     `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/lib` folder:
@@ -114,60 +97,13 @@ download the required JARs from third parties, as described below.
     - [`persistence.jar`](http://mvnrepository.com/artifact/org.eclipse.persistence/javax.persistence/2.1.1)
     - [`support-tomcat.jar`](http://mvnrepository.com/artifact/com.liferay.portal/com.liferay.support.tomcat)
 
-3.  Copy the JDBC driver for your database to the 
-    `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/lib` folder. Here are some 
-    common drivers: 
-    
-    - [`mariadb.jar`](https://downloads.mariadb.org/)
-    - [`mysql.jar`](http://dev.mysql.com/downloads/connector/j)
-    - [`postgresql.jar`](https://jdbc.postgresql.org/download/postgresql-42.0.0.jar)
+3.  Download a database driver `.jar` file and copy it to the 
+    `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/lib` folder. For a list of supported databases, see Liferay's [compatibility matrix](https://web.liferay.com/documents/14/21598941/Liferay+DXP+7.1+Compatibility+Matrix/9f9c917a-c620-427b-865d-5c4b4a00be85)
 
 4.  Create an `osgi` folder in your *Liferay Home*. Extract the folders 
     (i.e., `configs`, `core`, and more) from OSGi ZIP file to the `osgi` folder.
     The `osgi` folder provides the necessary modules for @product@'s OSGi
     runtime.
-
-**Checkpoint:**
-
-1.  Your `[TCSERVER_INSTANCE_HOME]/servers/dxp-server/lib` folder has these 
-    JARs:
-
-    - `activation.jar`
-    - `ccpp.jar`
-    - `com.liferay.petra.concurrent.jar`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `hsql.jar`
-    - `jms.jar`
-    - `jta.jar`
-    - `jutf7.jar`
-    - `mail.jar`
-    - `mariadb.jar`
-    - `mysql.jar`
-    - `persistence.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
-    - `postgresql.jar`
-    - `support-tomcat.jar`
-
-2. Your `[Liferay Home]/osgi` folder has these subfolders:
-
-    - `configs`
-    - `core`
-    - `marketplace`
-    - `modules`
-    - `portal`
-    - `static`
-    - `test`
-    - `war`
 
 ## Configuring tc Server
 

--- a/en/discover/deployment/articles-dxp/01-deploying-liferay/08-installing-liferay-on-weblogic.markdown
+++ b/en/discover/deployment/articles-dxp/01-deploying-liferay/08-installing-liferay-on-weblogic.markdown
@@ -32,37 +32,6 @@ these *Additional Files*:
 - Dependencies ZIP file
 - OSGi Dependencies ZIP file
 
-**Checkpoint**
-
-The following jars should be present within the Dependencies ZIP file:
-
-1. `com.liferay.petra.concurrent.jar`
-2. `com.liferay.petra.executor.jar`
-3. `com.liferay.petra.function.jar`
-4. `com.liferay.petra.io.jar`
-5. `com.liferay.petra.lang.jar`
-6. `com.liferay.petra.memory.jar`
-7. `com.liferay.petra.nio.jar`
-8. `com.liferay.petra.process.jar`
-9. `com.liferay.petra.reflect.jar`
-10. `com.liferay.petra.string.jar`
-11. `com.liferay.registry.api.jar`
-12. `hsql.jar`
-13. `portal-kernel.jar`
-14. `portlet.jar`
-
-The following folders should be present within the `/liferay/osgi` folder: 
-
-1. `Configs`
-2. `Core`
-3. `Marketplace`
-4. `Modules`
-5. `Portal`
-6. `Static`
-7. `Test`
-8. `War`
-
-
 Without any further ado, get ready to install @product@ in WebLogic! 
 
 ## Configuring WebLogic's Node Manager
@@ -186,49 +155,10 @@ now:
     and place its contents in your WebLogic domain's `lib` folder. 
 
 2.  `liferay-dxp-digital-enterprise-osgi-[version].zip`: Unzip this file and 
-    place its contents in the `Liferay_Home/osgi` folder (create this folder if
+    place its contents in the `[Liferay Home]/osgi` folder (create this folder if
     it doesn't exist).
 
-You must also add your database's driver JAR file to your domain's `lib` folder.
-Note that although Hypersonic is fine for testing purposes, you **should not**
-use it for production @product@ instances. 
-
-**Checkpoint**
-
-Your domain `lib` folder has these jars:
-
-* `com.liferay.petra.concurrent.jar`
-* `com.liferay.petra.executor.jar`
-* `com.liferay.petra.function.jar`
-* `com.liferay.petra.io.jar`
-* `com.liferay.petra.lang.jar`
-* `com.liferay.petra.memory.jar`
-* `com.liferay.petra.nio.jar`
-* `com.liferay.petra.process.jar`
-* `com.liferay.petra.reflect.jar`
-* `com.liferay.petra.string.jar`
-* `com.liferay.registry.api.jar`
-* `hsql.jar`
-* `portal-kernel.jar`
-* `portlet.jar`
-
-A JDBC driver for your database has been added to your domain's `lib` folder.
-Here are some common JDBC drivers:
-
-* [`mariadb.jar`](https://downloads.mariadb.org/) 
-* [`mysql.jar`](http://dev.mysql.com/downloads/connector/j)
-* [`postgres.jar`](https://jdbc.postgresql.org/download/postgresql-42.0.0.jar)
-
-Your `[Liferay Home]/osgi` folder has these subfolders:
-
-* `Configs`
-* `Core`
-* `Marketplace`
-* `Modules`
-* `Portal`
-* `Static`
-* `Test`
-* `War`
+3.  Download your database driver `.jar` file and copy it to your domain's `lib` folder. Please see the [compatibility matrix](https://web.liferay.com/documents/14/21598941/Liferay+DXP+7.1+Compatibility+Matrix/9f9c917a-c620-427b-865d-5c4b4a00be85) for a list of supported databases.
 
 Next, you'll configure your database. 
 

--- a/en/discover/deployment/articles-dxp/01-deploying-liferay/09-installing-liferay-on-websphere.markdown
+++ b/en/discover/deployment/articles-dxp/01-deploying-liferay/09-installing-liferay-on-websphere.markdown
@@ -192,33 +192,6 @@ now:
     if it doesn't exist). This is typically `[Install
     Location]/WebSphere/AppServer/profiles/your-profile/liferay/osgi`. 
 
-Before starting the server, verify that all the following jars have been copied 
-to the correct folders. Optional jars are available (italics) and are used to 
-optimize Liferay performance which must be added to this folder. Required jars 
-in bold are from the `liferay-digital-enterprise-dependencies-[version] zip`. The 
-following files should be present within the `lib/ext` (WebSphere Application) 
-folder: 
-
-1. `activation.jar`
-2. `com.liferay.registry.api.jar`
-3. `hsql.jar`
-4. A JDBC database jar (e.g. MySQL, MariaDB, IBM DB2, Postgres for production)
-5. `persistence.jar`
-6. `portal-kernel.jar`
-7. `portlet.jar`
-
-The following folders should be present within the `/liferay/osgi` folder: 
-
-1. `Configs`
-2. `Core`
-3. `Marketplace`
-4. `Modules`
-5. `Portal`
-6. `Static`
-7. `Test`
-8. `War`
-
-
 ### Ensuring that @product@'s portlet.jar is loaded first
 
 In addition to placing the `portlet.jar` in the correct folder, you must

--- a/en/discover/deployment/articles/01-deploying-liferay/04-installing-liferay-portal-on-tomcat.markdown
+++ b/en/discover/deployment/articles/01-deploying-liferay/04-installing-liferay-portal-on-tomcat.markdown
@@ -44,25 +44,11 @@ bundle's JARs are not strictly required but can still be useful. If you don't
 have a bundle, download the required JARs from third-parties, as described
 below.
 
-1.  Create the folder `$TOMCAT_HOME/lib/ext` if it doesn't exist and extract the
-    JARs from the dependencies ZIP to it. Here are the JARs:
- 
-    - `com.liferay.petra.concurrent.jar`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `hsql.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
+1. Unzip the Dependencies ZIP file contents in the `$TOMCAT_HOME/lib/ext` folder (create this folder if it doesn't exist).
 
-2.  Download the following JARs or copy them from a @product@ Tomcat bundle to 
+2. Download a database driver `.jar` file and copy it to the `$CATALINA_BASE/lib/ext` folder. For a list of supported databases, see Liferay's [compatibility matrix](https://web.liferay.com/documents/14/21598941/Liferay+DXP+7.1+Compatibility+Matrix/9f9c917a-c620-427b-865d-5c4b4a00be85)
+
+3.  Download the following JARs or copy them from a @product@ Tomcat bundle to 
     the `$TOMCAT_HOME/lib/ext` folder:
 
     - [`activation.jar`](http://www.oracle.com/technetwork/java/javase/jaf-136260.html)
@@ -74,57 +60,7 @@ below.
     - [`persistence.jar`](http://mvnrepository.com/artifact/org.eclipse.persistence/javax.persistence/2.1.1)
     - [`support-tomcat.jar`](http://mvnrepository.com/artifact/com.liferay.portal/com.liferay.support.tomcat)
 
-3.  Copy the JDBC driver for your database to the `$CATALINA_BASE/lib/ext` 
-    folder. Here are some common drivers: 
-
-    - [`mariadb.jar`](https://downloads.mariadb.org/)
-    - [`mysql.jar`](http://dev.mysql.com/downloads/connector/j)
-    - [`postgresql.jar`](https://jdbc.postgresql.org/download/postgresql-42.0.0.jar)
-
-4.  Create an `osgi` folder in your Liferay Home. Extract the folders (i.e., 
-    `configs`, `core`, and more) from OSGi ZIP file to the `osgi` folder. The
-    `osgi` folder provides the necessary modules for @product@'s OSGi runtime.
-
-Checkpoint:
-
-1.  Your `$CATALINA_BASE/lib/ext` folder has these JARs:
-
-    - `activation.jar`
-    - `ccpp.jar`
-    - `com.liferay.petra.concurrent.jar`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `hsql.jar`
-    - `jms.jar`
-    - `jta.jar`
-    - `jutf7.jar`
-    - `mail.jar`
-    - `mariadb.jar`
-    - `mysql.jar`
-    - `persistence.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
-    - `postgresql.jar`
-    - `support-tomcat.jar`
-
-2. Your `[Liferay Home]/osgi` folder has these subfolders:
-
-    - `configs`
-    - `core`
-    - `marketplace`
-    - `modules`
-    - `portal`
-    - `static`
-    - `test`
-    - `war`
+4. Unzip the OSGi Dependencies ZIP file contents in the `[Liferay Home]/osgi` folder (create this folder if it doesn't exist).
 
 ## Configuring Tomcat
 

--- a/en/discover/deployment/articles/01-deploying-liferay/05-installing-liferay-portal-on-wildfly.markdown
+++ b/en/discover/deployment/articles/01-deploying-liferay/05-installing-liferay-portal-on-wildfly.markdown
@@ -42,29 +42,10 @@ useful. If you don't have a @product@ Wildfly bundle, download the required JARs
 from third-parties as described below.
 
 1.  Create the folder `$WILDFLY_HOME/modules/com/liferay/portal/main` if it
-    doesn't exist and extract the dependencies ZIP JARs to it:
-
-    - `com.liferay.petra.concurrent.jar`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `hsql.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
+    doesn't exist and extract the dependencies ZIP JARs to it.
 
 2.  Download your database driver `.jar` file and copy it into the
-    same folder. For example,
-    [copy MySQL's driver](http://dev.mysql.com/downloads/connector/j/)
-    into the `$WILDFLY_HOME/modules/com/liferay/portal/main` folder. The
-    `mariadb.jar`, `mysql.jar`, and `postgresql.jar` driver JARs are also
-    available in the Wildfly bundle.
+    same folder. Please see the [compatibility matrix](https://web.liferay.com/documents/14/21598941/Liferay+DXP+7.1+Compatibility+Matrix/9f9c917a-c620-427b-865d-5c4b4a00be85) for a list of supported databases.
 
 3.  Create the file `module.xml` in the
     `$WILDFLY_HOME/modules/com/liferay/portal/main` folder and insert this
@@ -86,7 +67,7 @@ from third-parties as described below.
                 <resource-root path="com.liferay.petra.string.jar" />
                 <resource-root path="com.liferay.registry.api.jar" />
                 <resource-root path="hsql.jar" />
-                <resource-root path="mysql.jar" />
+                <resource-root path="[place your database driver here]" />
                 <resource-root path="portal-kernel.jar" />
                 <resource-root path="portlet.jar" />
             </resources>
@@ -99,8 +80,7 @@ from third-parties as described below.
             </dependencies>
         </module>
 
-    If you use a different database, replace the MySQL `.jar` with the driver
-    JAR for your database (e.g., HSQL, PostgreSQL, etc.).
+    Replace the indicated `resource-root` element with the driver JAR for your database.
 
 4.  Create an `osgi` folder in your Liferay Home folder. Extract the OSGi ZIP
     file that you downloaded into the `osgi` folder.
@@ -110,38 +90,10 @@ from third-parties as described below.
 
 **Checkpoint:**
 
-1.  At this point, you should have the following files in the
-    `$WILDFLY_HOME/modules/com/liferay/portal/main` folder:
-
-    - `com.liferay.petra.concurrent`
-    - `com.liferay.petra.executor.jar`
-    - `com.liferay.petra.function.jar`
-    - `com.liferay.petra.io.jar`
-    - `com.liferay.petra.lang.jar`
-    - `com.liferay.petra.memory.jar`
-    - `com.liferay.petra.nio.jar`
-    - `com.liferay.petra.process.jar`
-    - `com.liferay.petra.reflect.jar`
-    - `com.liferay.petra.string.jar`
-    - `com.liferay.registry.api.jar`
-    - `portal-kernel.jar`
-    - `portlet.jar`
-    - a database JAR such as the MySQL Connector.
-
-2. The `module.xml` has listed all JARs in the `<resource-root-path>` elements.
-
-3. The `osgi` folder has the following subfolders:
-
-    - `configs`
-    - `core`
-    - `marketplace`
-    - `modules`
-    - `portal`
-    - `static`
-    - `test`
-    - `war`
-
-Great! You have your `.jar` files ready.
+1. The contents of the Dependencies zip have been placed in the `$WILDFLY_HOME/modules/com/liferay/portal/main` folder:
+1. Your database vendor's JDBC driver has been placed in `$WILDFLY_HOME/modules/com/liferay/portal/main` folder and listed as a dependency.
+1. The `module.xml` has listed all JARs in the `<resource-root>` elements.
+1. The OSGi dependencies have been unzipped in the `osgi` folder located inside the `${Liferay.home}` folder.
 
 ## Running @product@ on Wildfly in Standalone Mode vs. Domain Mode
 
@@ -332,59 +284,56 @@ data source. The
 page lets you configure @product@'s built-in data source. If you want to use the
 built-in data source, skip this section.
 
-MySQL is used as the example below. If you're using a different database, modify
-the data source and driver snippets as necessary.
-
 If you want Wildfly to manage your data source, follow these steps:
 
-1.  Add your data source inside
-    `$WILDFLY_HOME/standalone/configuration/standalone.xml` file's
-    `<datasources>` element:
+1.  Add the data source inside the `$WILDFLY_HOME/standalone/configuration/standalone.xml` file's the `<datasources>` element.
 
-        <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
-            <connection-url>jdbc:mysql://localhost/lportal</connection-url>
-            <driver>mysql</driver>
-            <security>
-                <user-name>root</user-name>
-                <password>root</password>
-            </security>
-        </datasource>
+    ```xml
+    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
+        <connection-url>[place the URL to your database here]</connection-url>
+        <driver>[place the driver name here]</driver>
+        <security>
+            <user-name>[place your user name here]</user-name>
+            <password>[place your password here]</password>
+        </security>
+    </datasource>
+    ```
 
-    Be sure to replace the database name (i.e., `lportal`), user name, and
-    password with the appropriate values.
+    Make sure to replace the database URL, user name, and password with the appropriate values.
 
     | **Note:** If you must change your datasource `jndi-name` to something
     | different, you must also edit the `datasource` element in the
     | `<default-bindings>` tag.
 
-2.  Add your driver to the `standalone.xml` file's `<drivers>` element also
-    found within the `<datasources>` element:
+2.  Add the driver to the `standalone.xml` file's `<drivers>` element also found within the `<datasources>` element.
 
-        <drivers>
-            <driver name="mysql" module="com.liferay.portal">
-                <driver-class>com.mysql.jdbc.Driver</driver-class>
-            </driver>
-        </drivers>
+    ```xml
+    <drivers>
+        <driver name="[name of driver must match name above]" module="com.liferay.portal">
+            <driver-class>[place your JDBC driver class here]</driver-class>
+        </driver>
+    </drivers>
+    ```
 
-    Your final data sources subsystem should look like this:
+    A final data source subsystem that uses MySQL should look like this:
 
-        <subsystem xmlns="urn:jboss:domain:datasources:1.0">
-            <datasources>
-                <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
-                    <connection-url>jdbc:mysql://localhost/lportal</connection-url>
-                    <driver>mysql</driver>
-                    <security>
-                        <user-name>root</user-name>
-                        <password>root</password>
-                    </security>
-                </datasource>
-                <drivers>
-                    <driver name="mysql" module="com.liferay.portal">
-                        <driver-class>com.mysql.jdbc.Driver</driver-class>
-                    </driver>
-                </drivers>
-            </datasources>
-        </subsystem>
+    ```xml
+    <subsystem xmlns="urn:jboss:domain:datasources:5.0">
+        <datasources>
+            <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" jta="true" use-java-context="true" use-ccm="true">
+                <connection-url>jdbc:mysql://localhost/lportal</connection-url>
+                <driver>mysql</driver>
+                <security>
+                    <user-name>root</user-name>
+                    <password>root</password>
+                </security>
+            </datasource>
+            <drivers>
+                <driver name="mysql" module="com.liferay.portal"/>
+            </drivers>
+        </datasources>
+    </subsystem>
+    ```
 
 3.  In a `portal-ext.properties` file in your Liferay Home, specify your data
     source:


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7603

1. Removed `war` folder from `osgi` subfolder list. In fact, I just removed the explicit subfolder listing. 
2. Simplify or remove dependency installation section checkpoints.
3. Replaced installing mysql.jar with generic instructions.

Thanks.