### PR TITLE
Script: migrate.py

### DIFF
--- a/bin/migrate.py
+++ b/bin/migrate.py
@@ -28,7 +28,7 @@ def write_and_reset_string(line, newFile):
 if __name__ == "__main__":
 
     if (len(sys.argv) < 2):
-        print("Usage:\n\tpython migrate.py article [dest_folder]\n\nDescription:\n\tMigrates the article to an .md file and converts the content to liferay-learn Markdown/RST syntax. The converted article destination folder [dest_folder] is the current folder by default but is typically set to a liferay-learn folder.\n\n\tIMPORTANT: Run this script in the liferay-docs article's folder so that the script can use the image file paths found in the article to copy the image files to the [dest_folder]/images/ folder.")
+        print("Usage:\n\tpython migrate.py article [dest_folder]\n\nDescription:\n\tMigrates the article to an .md file and converts the content to liferay-learn Markdown/RST syntax. The converted article destination folder [dest_folder] is the current folder by default but is typically set to a liferay-learn folder.\n\n\tIMPORTANT: Run this script in the liferay-docs article's folder so that the script can use the image file paths found in the article to copy the image files to the [dest_folder]/[article_name]/images/ folder.")
         sys.exit()
 
     article = sys.argv[1]
@@ -40,9 +40,11 @@ if __name__ == "__main__":
     if not (os.path.isdir(dest_folder)):
         os.mkdir(dest_folder)
 
-    new_article_path = dest_folder + "/" + article.split('.markdown')[0] + ".md"
+    article_name = article.split('.markdown')[0]
 
-    # Copy referenced image files to [article destination folder]/images
+    new_article_path = dest_folder + "/" + article_name + ".md"
+
+    # Copy referenced image files to [article destination folder]/[article_name]/images
 
     file = open(article)
     content = file.read()
@@ -64,17 +66,21 @@ if __name__ == "__main__":
 
         ii = ii + 1
 
-    image_folder = dest_folder + "/images"
+    article_name_folder = dest_folder + "/" + article_name
+    images_folder = article_name_folder + "/images"
 
     if (len(images) > 0):
 
-        if not os.path.isdir(image_folder):
-            os.mkdir(image_folder)
+        if not os.path.isdir(article_name_folder):
+            os.mkdir(article_name_folder)
 
-        print("Writing images to folder: " + image_folder)
+        if not os.path.isdir(images_folder):
+            os.mkdir(images_folder)
+
+        print("Writing images to folder: " + images_folder)
 
     for ff in images:
-        shutil.copy(ff, image_folder)
+        shutil.copy(ff, images_folder)
 
     # Process the text
 
@@ -106,10 +112,12 @@ if __name__ == "__main__":
     in_code = False
     in_header_id = False
 
+    images_folder_path = "](./" + article_name + "/images/"
+
     for line in lines:
 
-        # Set all image file locations to the ./images/ folder
-        line = re.sub("\]\((../)+images/", "](./images/", line)
+        # Set all image file locations to the ./[article_name]/images/ folder
+        line = re.sub("\]\((../)+images/", images_folder_path, line)
 
         # Replace legacy tokens
         line = re.sub("@product@", "Liferay DXP", line)

--- a/bin/migrate.py
+++ b/bin/migrate.py
@@ -227,6 +227,9 @@ if __name__ == "__main__":
                         if "**Note:**" in stripped_line:
                             newFile.write("```note::\n")
                             stripped_line = stripped_line.replace("**Note:**", "", 1)
+                        elif "**Tip:**" in stripped_line:
+                            newFile.write("```tip::\n")
+                            stripped_line = stripped_line.replace("**Tip:**", "", 1)
                         elif "**Warning:**" in stripped_line:
                             newFile.write("```warning::\n")
                             stripped_line = stripped_line.replace("**Warning:**", "", 1)
@@ -236,12 +239,15 @@ if __name__ == "__main__":
                         elif "**Note**:" in stripped_line:
                             newFile.write("```note::\n")
                             stripped_line = stripped_line.replace("**Note**:", "", 1)
-                        elif "**Important**:" in stripped_line:
-                            newFile.write("```important::\n")
-                            stripped_line = stripped_line.replace("**Important**:", "", 1)
+                        elif "**Tip**:" in stripped_line:
+                            newFile.write("```tip::\n")
+                            stripped_line = stripped_line.replace("**Tip**:", "", 1)
                         elif "**Warning**:" in stripped_line:
                             newFile.write("```warning::\n")
                             stripped_line = stripped_line.replace("**Warning**:", "", 1)
+                        elif "**Important**:" in stripped_line:
+                            newFile.write("```important::\n")
+                            stripped_line = stripped_line.replace("**Important**:", "", 1)
                         else:
                             newFile.write("```note::\n")
 

--- a/bin/migrate.py
+++ b/bin/migrate.py
@@ -1,0 +1,379 @@
+import os
+import re
+import shutil
+import sys
+
+
+def append_to_line(line, new_line):
+    line = line.replace("\r","")
+    line = line.replace("\n", "")
+    line = line + " " + new_line.lstrip()
+    return line
+
+def end_sidebar(sidebar_line, newFile):
+    if sidebar_line not in "":
+        newFile.write(sidebar_line)
+        newFile.write("```\n")
+        sidebar_line = ""
+    return sidebar_line
+
+def write_and_reset_string(line, newFile):
+    if line not in "":
+        newFile.write(line)
+        line = ""
+
+    return line
+
+
+if __name__ == "__main__":
+
+    if (len(sys.argv) < 2):
+        print("Usage:\n\tpython migrate.py article [dest_folder]\n\nDescription:\n\tMigrates the article to an .md file and converts the content to liferay-learn Markdown/RST syntax. The converted article destination folder [dest_folder] is the current folder by default but is typically set to a liferay-learn folder.\n\n\tIMPORTANT: Run this script in the liferay-docs article's folder so that the script can use the image file paths found in the article to copy the image files to the [dest_folder]/images/ folder.")
+        sys.exit()
+
+    article = sys.argv[1]
+
+    dest_folder = "."
+    if (len(sys.argv)) > 2:
+        dest_folder = sys.argv[2]
+
+    if not (os.path.isdir(dest_folder)):
+        os.mkdir(dest_folder)
+
+    new_article_path = dest_folder + "/" + article.split('.markdown')[0] + ".md"
+
+    # Copy referenced image files
+
+    file = open(article)
+    content = file.read()
+    file.close()
+
+    png_split = content.split('.png)')
+
+    images = []
+
+    png_split_len = len(png_split) - 1
+    ii = 0;
+
+    while (ii < png_split_len):
+        paran_split = png_split[ii].split('(')
+
+        if (len(paran_split) > 1):
+            image = paran_split[len(paran_split) - 1] + '.png'
+            images.append(image)
+
+        ii = ii + 1
+
+    image_folder = dest_folder + "/images"
+
+    if (len(images) > 0):
+
+        if not os.path.isdir(image_folder):
+            os.mkdir(image_folder)
+
+        print("Writing images to folder: " + image_folder)
+
+    for ff in images:
+        shutil.copy(ff, image_folder)
+
+    # Process the text
+
+    file = open(article)
+    lines = file.readlines()
+    file.close()
+
+    newFile = open(new_article_path, 'w')
+
+    print("Migrating to article: " + new_article_path)
+
+    # Track the last significant line's first non-space character column index
+    prev_index = -1
+
+    list_item_line = ""
+    para_line = ""
+    sidebar_line = ""
+
+    done_header_id = False
+    done_title = False
+    in_code = False
+    in_header_id = False
+
+    for line in lines:
+
+        # Set all image file locations to the ./images/ folder
+        line = re.sub("\]\((../)+images/", "](./images/", line)
+
+        # Replace legacy tokens
+        line = re.sub("@product@", "Liferay DXP", line)
+        line = re.sub("@commerce@", "Liferay Commerce", line)
+        line = re.sub("@ide@", "Dev Studio DXP", line)
+        line = re.sub("@app-ref@", "https://docs.liferay.com/dxp/apps", line)
+        line = re.sub("@platform-ref@", "https://docs.liferay.com/dxp/portal", line)
+
+        trimmed_line = line.lstrip()
+
+        if not (done_header_id):
+
+            if not (in_header_id):
+                if (trimmed_line.startswith("---")):
+                    in_header_id = True
+            elif (trimmed_line.startswith("---")):
+                    done_header_id = True
+                    in_header_id = False
+        elif not (done_title):
+            if (line.startswith("#")):
+                newFile.write(line)
+                done_title = True
+        elif (trimmed_line.startswith("[TOC")):
+            # Don't write anything for the legacy TOC line
+            continue
+        elif (trimmed_line.startswith("```")):
+            # Toggle whether we're in code
+
+            # Write any saved text
+            para_line = write_and_reset_string(para_line, newFile)
+            sidebar_line = end_sidebar(sidebar_line, newFile)
+            list_item_line = write_and_reset_string(list_item_line, newFile)
+
+            # Write the current line as is
+            newFile.write(line)
+
+            # Track whether code block has started or ended
+            if (in_code):
+                in_code = False
+            else:
+                in_code = True
+        elif re.search("^\d.", trimmed_line):
+            # Handle an ordered list item
+
+            # Write any saved text
+            para_line = write_and_reset_string(para_line, newFile)
+            sidebar_line = end_sidebar(sidebar_line, newFile)
+            list_item_line = write_and_reset_string(list_item_line, newFile)
+
+            # Start all ordered list items with 1.
+            list_item_line = re.sub("\d+.\s*", "1. ", line, 1)
+
+            prev_index = re.search("\S", line).start()
+        elif trimmed_line.startswith("-"):
+            # Handle an unordered-list item starting with -
+
+            # Write any saved text
+            para_line = write_and_reset_string(para_line, newFile)
+            sidebar_line = end_sidebar(sidebar_line, newFile)
+            list_item_line = write_and_reset_string(list_item_line, newFile)
+
+            # Start list items with '*' instead of '-', followed by a single space
+            list_item_line = re.sub("-\s*", "* ", line, 1)
+
+            prev_index = re.search("\S", line).start()
+        elif trimmed_line.startswith("* "):
+            # Handle an unordered-list item starting with *
+
+            # Write any saved text
+            para_line = write_and_reset_string(para_line, newFile)
+            sidebar_line = end_sidebar(sidebar_line, newFile)
+            list_item_line = write_and_reset_string(list_item_line, newFile)
+
+            # Start list items with '*', followed by a single space
+            list_item_line = re.sub("\*\s*", "* ", line, 1)
+
+            prev_index = re.search("\S", line).start()
+        elif re.search("^\|", line.strip()):
+
+            if not re.search("^\|.*\|$", line.strip()):
+
+                # Handle a sidebar line
+
+                # Write any saved text
+                para_line = write_and_reset_string(para_line, newFile)
+                list_item_line = write_and_reset_string(list_item_line, newFile)
+
+                # Replace the leading pipe with a space
+                stripped_line = line.replace("| ", "", 1)
+
+                # Use double-back ticks for all code markup
+                stripped_line = stripped_line.replace("`", "``")
+
+                if sidebar_line in "":
+
+                    # Start the sidebar
+                    if "**Note:**" in stripped_line:
+                        newFile.write("```note::\n   ")
+                        stripped_line = stripped_line.replace("**Note:**", "", 1)
+                    elif "**Warning:**" in stripped_line:
+                        newFile.write("```warning::\n   ")
+                        stripped_line = stripped_line.replace("**Warning:**", "", 1)
+                    elif "**Important:**" in stripped_line:
+                        newFile.write("```important::\n   ")
+                        stripped_line = stripped_line.replace("**Important:**", "", 1)
+                    elif "**Note**:" in stripped_line:
+                        newFile.write("```note::\n   ")
+                        stripped_line = stripped_line.replace("**Note**:", "", 1)
+                    elif "**Important**:" in stripped_line:
+                        newFile.write("```important::\n   ")
+                        stripped_line = stripped_line.replace("**Important**:", "", 1)
+                    elif "**Warning**:" in stripped_line:
+                        newFile.write("```warning::\n   ")
+                        stripped_line = stripped_line.replace("**Warning**:", "", 1)
+                    else:
+                        newFile.write("```note::\n   ")
+
+                # Process the sidebar line, creating a new line that uses RST links in place of Markdown links
+                new_line = ""
+                caption_link_index = -1
+                while True:
+                    stripped_line_len = len(stripped_line)
+
+                    caption_link = re.search("\[[\w\s\.\/\-\_\`\'@]*\]\([\w\s:\.\/:\-\_\`]*\)", stripped_line)
+
+                    link_len = 0
+                    if caption_link:
+
+                        link_len = len(caption_link.group());
+                        caption_link_index = stripped_line.index(caption_link.group());
+                        if caption_link_index > 0:
+                            # Add text that precedes the caption
+                            text_before_caption = stripped_line[0:caption_link_index]
+                            new_line += text_before_caption;
+
+                        # Split the caption and link parts of the Markdown
+                        caption_link_split = caption_link.group().split("](");
+                        caption_half = caption_link_split[0]
+                        link_half = caption_link_split[1]
+
+                        caption = ""
+                        link = ""
+
+                        # Write the caption and link in RST format
+                        if len(caption_link_split) > 1 and len(caption_half) > 1 and len(link_half) > 1:
+                            caption = (caption_half)[1:]
+                            caption = caption.replace("``", "`")
+                            print("caption: " + caption)
+                            link = (link_half)[:-1]
+                            print("link: " + link)
+                            new_line += "`"
+                            new_line += caption
+                            new_line += " <"
+                            new_line += link
+                            new_line += ">`_"
+
+                        else:
+                            print("Unable to convert link: " + caption_link)
+
+                    else:
+                        # Does not contain a link
+                        new_line += stripped_line
+                        break;
+
+                    if (caption_link_index + link_len) > stripped_line_len :
+                        # The link ends the line
+                        break;
+                    else:
+                        # Continue processing the rest of the line
+                        stripped_line = stripped_line[caption_link_index + link_len:]
+
+                # Done the while loop that processes the sidebar line
+
+                sidebar_line = append_to_line(sidebar_line, new_line)
+
+                prev_index = re.search("\S", line).start()
+            else:
+                # Handle table line
+
+                para_line = write_and_reset_string(para_line, newFile)
+                sidebar_line = end_sidebar(sidebar_line, newFile)
+                list_item_line = write_and_reset_string(list_item_line, newFile)
+
+                # Write the table line
+                newFile.write(line)
+
+        elif (in_code):
+
+            # Write code line
+            newFile.write(line)
+        elif (para_line != ""):
+
+            if (re.search("^[\d\-]", trimmed_line)):
+                # Write the existing paragraph and start a list item
+                list_item_line = line
+
+                para_line = write_and_reset_string(para_line, newFile)
+
+                prev_index = re.search("\S", line).start()
+            elif (re.search("^[\:]", trimmed_line)):
+
+                # Write definition term
+                newFile.write(para_line)
+
+                # Start the term definition
+                para_line = line
+
+                prev_index = re.search("\S", line).start()
+            elif (re.search("^[\w\*\@\!\(\&\.\[\`\s(\w\*\@\!\(\&\.\[\`)]", trimmed_line)):
+
+                para_line = append_to_line(para_line, trimmed_line)
+            else:
+
+                # Write the existing paragraph and the current line
+                para_line = write_and_reset_string(para_line, newFile)
+                newFile.write(line)
+
+                if re.search("\S", line):
+                    prev_index = re.search("\S", line).start()
+        elif (re.search("^[\w\*\@\!\(\&\.\[\`\s\:(\w\*\@\!\(\&\.\[\`)]", trimmed_line)):
+
+            sidebar_line = end_sidebar(sidebar_line, newFile)
+
+            if re.search("\S", line):
+                index = re.search("\S", line).start()
+
+                if index > prev_index:
+
+                    if (list_item_line != ""):
+                        list_item_line = append_to_line(list_item_line, line)
+                    elif (para_line != ""):
+                        para_line = append_to_line(para_line, line)
+                    else:
+                        para_line = line
+                        prev_index = index
+                else:
+                    para_line = write_and_reset_string(para_line, newFile)
+                    sidebar_line = end_sidebar(sidebar_line, newFile)
+                    list_item_line = write_and_reset_string(list_item_line, newFile)
+
+                    para_line = line
+                    prev_index = index
+            else:
+                # Empty line
+
+                para_line = write_and_reset_string(para_line, newFile)
+                sidebar_line = end_sidebar(sidebar_line, newFile)
+                list_item_line = write_and_reset_string(list_item_line, newFile)
+
+                # Write the current line
+                newFile.write(line)
+        else:
+            # Set index to first non-space character
+            if re.search("\S", line):
+                prev_index = re.search("\S", line).start()
+
+            para_line = write_and_reset_string(para_line, newFile)
+            sidebar_line = end_sidebar(sidebar_line, newFile)
+            list_item_line = write_and_reset_string(list_item_line, newFile)
+
+            # Write the current line
+            newFile.write(line)
+
+    # Done looping through the lines
+
+    # Finish writing the current paragraph, list item, or sidebar
+
+    if (para_line != ""):
+        newFile.write(para_line)
+    elif (list_item_line != ""):
+        newFile.write(list_item_line)
+    elif (sidebar_line != ""):
+        newFile.write(sidebar_line)
+
+    newFile.close()

--- a/bin/migrate.py
+++ b/bin/migrate.py
@@ -100,6 +100,7 @@ if __name__ == "__main__":
     done_header_id = False
     done_title = False
     done_toc = False
+    prev_sidebar_line_empty = False
 
     # Variables for markup context
     in_code = False
@@ -206,95 +207,110 @@ if __name__ == "__main__":
                 para_line = write_and_reset_string(para_line, newFile)
                 list_item_line = write_and_reset_string(list_item_line, newFile)
 
-                # Replace the leading pipe with a space
-                stripped_line = line.replace("| ", "", 1)
+                pipe_index = re.search("|", line).start()
 
-                # Use double-back ticks for all code markup
-                stripped_line = stripped_line.replace("`", "``")
+                tmp_line = line.replace("| ", "", 1).strip()
+                if tmp_line in "":
+                    prev_sidebar_line_empty = True
+                    sidebar_line += "\n"
+                else:
 
-                if sidebar_line in "":
+                    # Use double-back ticks for all code markup
+                    stripped_line = line.replace("`", "``")\
+                    # Replace the leading pipe with a space
+                    stripped_line = stripped_line.replace("| ", "", 1)
 
-                    # Start the sidebar
-                    if "**Note:**" in stripped_line:
-                        newFile.write("```note::\n   ")
-                        stripped_line = stripped_line.replace("**Note:**", "", 1)
-                    elif "**Warning:**" in stripped_line:
-                        newFile.write("```warning::\n   ")
-                        stripped_line = stripped_line.replace("**Warning:**", "", 1)
-                    elif "**Important:**" in stripped_line:
-                        newFile.write("```important::\n   ")
-                        stripped_line = stripped_line.replace("**Important:**", "", 1)
-                    elif "**Note**:" in stripped_line:
-                        newFile.write("```note::\n   ")
-                        stripped_line = stripped_line.replace("**Note**:", "", 1)
-                    elif "**Important**:" in stripped_line:
-                        newFile.write("```important::\n   ")
-                        stripped_line = stripped_line.replace("**Important**:", "", 1)
-                    elif "**Warning**:" in stripped_line:
-                        newFile.write("```warning::\n   ")
-                        stripped_line = stripped_line.replace("**Warning**:", "", 1)
-                    else:
-                        newFile.write("```note::\n   ")
+                    if sidebar_line in "":
 
-                # Process the sidebar line, creating a new line that uses RST links in place of Markdown links
-                new_line = ""
-                caption_link_index = -1
-                while True:
-                    stripped_line_len = len(stripped_line)
+                        # Start the sidebar
 
-                    caption_link = re.search("\[[\w\s\.\/\-\_\`\'@]*\]\([\w\s:\.\/:\-\_\`]*\)", stripped_line)
+                        if "**Note:**" in stripped_line:
+                            newFile.write("```note::\n")
+                            stripped_line = stripped_line.replace("**Note:**", "", 1)
+                        elif "**Warning:**" in stripped_line:
+                            newFile.write("```warning::\n")
+                            stripped_line = stripped_line.replace("**Warning:**", "", 1)
+                        elif "**Important:**" in stripped_line:
+                            newFile.write("```important::\n")
+                            stripped_line = stripped_line.replace("**Important:**", "", 1)
+                        elif "**Note**:" in stripped_line:
+                            newFile.write("```note::\n")
+                            stripped_line = stripped_line.replace("**Note**:", "", 1)
+                        elif "**Important**:" in stripped_line:
+                            newFile.write("```important::\n")
+                            stripped_line = stripped_line.replace("**Important**:", "", 1)
+                        elif "**Warning**:" in stripped_line:
+                            newFile.write("```warning::\n")
+                            stripped_line = stripped_line.replace("**Warning**:", "", 1)
+                        else:
+                            newFile.write("```note::\n")
 
-                    link_len = 0
-                    if caption_link:
+                    # Process the sidebar line, creating a new line that uses RST links in place of Markdown links
+                    new_line = ""
+                    caption_link_index = -1
+                    while True:
+                        stripped_line_len = len(stripped_line)
 
-                        link_len = len(caption_link.group());
-                        caption_link_index = stripped_line.index(caption_link.group());
-                        if caption_link_index > 0:
-                            # Add text that precedes the caption
-                            text_before_caption = stripped_line[0:caption_link_index]
-                            new_line += text_before_caption;
+                        caption_link = re.search("\[[\w\s\.\/\-\_\`\'@]*\]\([\w\s:\.\/:\-\_\`]*\)", stripped_line)
 
-                        # Split the caption and link parts of the Markdown
-                        caption_link_split = caption_link.group().split("](");
-                        caption_half = caption_link_split[0]
-                        link_half = caption_link_split[1]
+                        link_len = 0
+                        if caption_link:
 
-                        caption = ""
-                        link = ""
+                            link_len = len(caption_link.group());
+                            caption_link_index = stripped_line.index(caption_link.group());
+                            if caption_link_index > 0:
+                                # Add text that precedes the caption
+                                text_before_caption = stripped_line[0:caption_link_index]
+                                new_line += text_before_caption;
 
-                        # Write the caption and link in RST format
-                        if len(caption_link_split) > 1 and len(caption_half) > 1 and len(link_half) > 1:
-                            caption = (caption_half)[1:]
-                            caption = caption.replace("``", "`")
-                            print("caption: " + caption)
-                            link = (link_half)[:-1]
-                            print("link: " + link)
-                            new_line += "`"
-                            new_line += caption
-                            new_line += " <"
-                            new_line += link
-                            new_line += ">`_"
+                            # Split the caption and link parts of the Markdown
+                            caption_link_split = caption_link.group().split("](");
+                            caption_half = caption_link_split[0]
+                            link_half = caption_link_split[1]
+
+                            caption = ""
+                            link = ""
+
+                            # Write the caption and link in RST format
+                            if len(caption_link_split) > 1 and len(caption_half) > 1 and len(link_half) > 1:
+                                caption = (caption_half)[1:]
+                                caption = caption.replace("``", "`")
+                                print("caption: " + caption)
+                                link = (link_half)[:-1]
+                                print("link: " + link)
+                                new_line += "`"
+                                new_line += caption
+                                new_line += " <"
+                                new_line += link
+                                new_line += ">`_"
+
+                            else:
+                                print("Unable to convert link: " + caption_link)
 
                         else:
-                            print("Unable to convert link: " + caption_link)
+                            # Does not contain a link
+                            new_line += stripped_line
+                            break;
 
+                        if (caption_link_index + link_len) > stripped_line_len :
+                            # The link ends the line
+                            break;
+                        else:
+                            # Continue processing the rest of the line
+                            stripped_line = stripped_line[caption_link_index + link_len:]
+
+                    # Done the while loop that processes the sidebar line
+
+                    if sidebar_line in "":
+                        sidebar_line = "   " + new_line.lstrip()
                     else:
-                        # Does not contain a link
-                        new_line += stripped_line
-                        break;
+                        if prev_sidebar_line_empty:
+                            sidebar_line = sidebar_line + "   " + new_line
+                            prev_sidebar_line_empty = False
+                        else:
+                            sidebar_line = sidebar_line.rstrip() + " " + new_line.lstrip()
 
-                    if (caption_link_index + link_len) > stripped_line_len :
-                        # The link ends the line
-                        break;
-                    else:
-                        # Continue processing the rest of the line
-                        stripped_line = stripped_line[caption_link_index + link_len:]
-
-                # Done the while loop that processes the sidebar line
-
-                sidebar_line = append_to_line(sidebar_line, new_line)
-
-                prev_index = re.search("\S", line).start()
+                    prev_index = re.search("\S", line).start()
             else:
                 # Handle table line
 

--- a/en/distribute/publish/articles/01-publishing-your-app/04-understanding-the-app-review-process/00-understanding-the-app-review-process-intro.markdown
+++ b/en/distribute/publish/articles/01-publishing-your-app/04-understanding-the-app-review-process/00-understanding-the-app-review-process-intro.markdown
@@ -178,32 +178,35 @@ table td {
         <td class="fifth-column">
             <strong>7.2.x</strong>
         </td>
+        <td class="sixth-column">
+            <strong>7.3.x</strong>
+        </td>
     </thead>
     <tbody>
         <tr>
             <td class="first-column"> Operating Systems </td>
-            <td class="second-column" colspan="4">Ubuntu 11x and Windows 10 x64</td>
+            <td class="second-column" colspan="5">Ubuntu 11x and Windows 10 x64</td>
         </tr>
         <tr>
             <td class="first-column"> Database </td>
             <td class="second-column">MySQL 5.5.x</td>
             <td class="third-column">MySQL 5.6.x</td>
-            <td class="fourth-column" colspan="2">MySQL 5.7.x</td>
+            <td class="fourth-column" colspan="3">MySQL 5.7.x</td>
         </tr>
         <tr>
             <td class="first-column"> Application Server * </td>
             <td class="second-column">Tomcat 7</td>
             <td class="third-column">Tomcat 8</td>
-            <td class="fourth-column" colspan="2">Tomcat 9</td> 
+            <td class="fourth-column" colspan="3">Tomcat 9</td> 
         </tr>
         <tr>
             <td class="first-column"> JDK </td>
             <td class="second-column">Oracle JDK 6, 7</td>
-            <td class="third-column" colspan="3">Oracle JDK 8</td>
+            <td class="third-column" colspan="3">Oracle JDK 8 / JDK 11 (7.1 and higher)</td>
         </tr>
         <tr>
             <td class="first-column"> Browser </td>
-            <td class="second-column" colspan="4">Chrome</td>
+            <td class="second-column" colspan="5">Chrome</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Here's the much improved script!

Example:
`$ python ~/git/liferay-docs/bin/migrate.py 01-importing-packages-intro.markdown`

Features:
- "Unwraps" (removes hard returns) from paragraphs. Yaye!
- Copies images to `[article destination]/images/` and updates the article links to that folder. (If you don't specify a destination, the article .md and and images/ folder are created locally--you can copy them manually to liferay-learn)
- Removes legacy metadata: `header-id` and `[TOC ...]`
- Converts legacy sidebars ` | **Note:** ...` to 
```
```note::
   Text here ... `Caption text <url>`_ and ``inline code``
```
\`\`\`
- Converts ordered list items from `2.    Text...` to `1. Text...` (notice single space after number).
- Converts unordered list items from `-     Text...` to `* Text...`
