### PR TITLE
LRDOCS-7854 Adding information about superseded article.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ properties/
 .directory 
 .gradle
 .nb-gradle
+.vscode
 
 node_modules/
 

--- a/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
+++ b/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
@@ -6,6 +6,10 @@ header-id: creating-contributed-fragment-collection
 
 [TOC levels=1-4]
 
+<aside class="alert alert-info">
+	<span class="wysiwyg-color-blue120">This document has been updated and ported to <a href="https://learn.liferay.com/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/creating-a-contributed-fragment-collection.html">Liferay Learn</a> and is no longer maintained here.</span>
+</aside>
+
 To create a Contributed Fragment Collection, a developer must,
 
 1.  Create a module which will contain the necessary logic and the fragments.


### PR DESCRIPTION
Includes information at the beginning of the Liferay Help Center article liking to the updated version in Liferay Learn.

Article updated:

[Creating a Contributed Fragment Collection (doc repo)](https://help.liferay.com/hc/en-us/articles/360028726872-Creating-a-Contributed-Fragment-Collection?flash_digest=cdd6073268e611831855ec6d4926b05865c52e9b)

Article linked to:

[Creating a Contributed Fragment Collection (learn repo)](https://learn.liferay.com/dxp/7.x/en/site-building/developer-guide/developing-page-fragments/creating-a-contributed-fragment-collection.html)