### PR TITLE
LRDOCS-8913 corrects Creating a Sharepoint Application article

### DIFF
--- a/en/discover/portal/articles-dxp/110-collaboration/01-managing-documents-and-media/05-sharepoint/01-creating-a-sharepoint-application.markdown
+++ b/en/discover/portal/articles-dxp/110-collaboration/01-managing-documents-and-media/05-sharepoint/01-creating-a-sharepoint-application.markdown
@@ -45,11 +45,11 @@ instance:
 
         <AppPermissionRequests>
             <AppPermissionRequest
-                scope="http://sharepoint/content/sitecollection/web/list"
+                Scope="http://sharepoint/content/sitecollection/web/list"
                 Right="Write" 
             />
             <AppPermissionRequest
-                scope="http://sharepoint/search"
+                Scope="http://sharepoint/search"
                 Right="QueryAsUserIgnoreAppPrincipal" 
             />
         </AppPermissionRequests>


### PR DESCRIPTION
This PR capitalizes the `Scope` attribute in the Creating a Sharepoint Application article, per [LRDOCS-8913](https://issues.liferay.com/browse/LRDOCS-8913).