### PR TITLE
LRDOCS 9640 Update incorrect and risky link [7.1]

### DIFF
--- a/en/develop/tutorials/articles/210-front-end-taglibs/04-clay-taglibs/00-using-clay-taglibs-intro.markdown
+++ b/en/develop/tutorials/articles/210-front-end-taglibs/04-clay-taglibs/00-using-clay-taglibs-intro.markdown
@@ -7,7 +7,7 @@ header-id: using-the-clay-taglib-in-your-portlets
 [TOC levels=1-4]
 
 The Liferay Clay tag library provides a set of tags for creating 
-[Clay](https://claycss.com/docs/clay/) 
+[Clay](https://clayui.com/) 
 UI components in your app. 
 
 | **Note:** AUI taglibs are deprecated as of @product-ver@. We recommend that you


### PR DESCRIPTION
From JIRA ticket [LRDOCS-9640](https://issues.liferay.com/browse/LRDOCS-9640).

The first link in the 'Using the Clay Taglib in Your portlets' is invalid and should be removed.

This change affects the 7.1 branch in the liferay-docs repository.
