### PR TITLE
LRDOCS-9642 Update incorrect and risky link [7.2]

### DIFF
--- a/en/developer/reference/articles/02-front-end/03-front-end-taglibs/07-clay-taglibs/01-using-clay-taglibs-intro.markdown
+++ b/en/developer/reference/articles/02-front-end/03-front-end-taglibs/07-clay-taglibs/01-using-clay-taglibs-intro.markdown
@@ -7,7 +7,7 @@ header-id: using-the-clay-taglib-in-your-portlets
 [TOC levels=1-4]
 
 The Liferay Clay tag library provides a set of tags for creating 
-[Clay](https://claycss.com/docs/clay/) 
+[Clay](https://clayui.com/) 
 UI components in your app. 
 
 | **Note:** AUI taglibs are deprecated as of @product-ver@. We recommend that you


### PR DESCRIPTION
From JIRA ticket [LRDOCS-9642](https://issues.liferay.com/browse/LRDOCS-9642).

The first link in the 'Using the Clay Taglib in Your portlets' is invalid and should be removed.

This change affects the 7.2 branch in the liferay-docs repository.
