### PR TITLE
LRDOCS-9690 removes incorrect admonition from 7.0 article

### DIFF
--- a/discover/portal/articles/100-web-experience-management/03-staging-content-for-publication/01-enabling-staging/02-enabling-remote-live-staging.markdown
+++ b/discover/portal/articles/100-web-experience-management/03-staging-content-for-publication/01-enabling-staging/02-enabling-remote-live-staging.markdown
@@ -213,8 +213,4 @@ have been completed. Otherwise, Remote Staging will fail.
     staging environments. In addition, the users must have the same credentials
     (e.g., screen name, email, roles, and password). 
 
-**Important:** Never clone your @product@ database; doing this can duplicate
-important data used by Staging (e.g., UUID), causing the Remote Publication
-process to fail.
-
 You should proceed only when all four major steps have been completed. 


### PR DESCRIPTION
This PR removes an inaccurate admonition from Remote Live Staging documentation, per [LRDOCS-9690](https://issues.liferay.com/browse/LRDOCS-9690).