### PR TITLE
LRDOCS-8298 Fixes Theme Article Links

### DIFF
--- a/en/developer/customization/articles/03-architecture/06-ui-concepts/02-theme-components.markdown
+++ b/en/developer/customization/articles/03-architecture/06-ui-concepts/02-theme-components.markdown
@@ -111,7 +111,7 @@ The following extensions and mechanisms are available for themes:
 - **Context Contributor:** Exposes Java variables and functionality for use in
   FreeMarker templates. This allows non-JSP templating languages in themes,
   widget templates, and any other templates. See the 
-  [Context Contributors tutorial](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
+  [Context Contributors tutorial](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-templates)
   or more information.
 - **Theme Contributor:** A package containing UI resources, not attached to a 
   theme, that you want to include on every page. See the 

--- a/en/developer/frameworks/articles/front-end-development/01-front-end-dev-intro.markdown
+++ b/en/developer/frameworks/articles/front-end-development/01-front-end-dev-intro.markdown
@@ -44,10 +44,10 @@ to use in your JavaScript applications.
 ## Lexicon and Clay
 
 Liferay uses its own design language, called 
-[Lexicon](https://lexicondesign.io/docs/lexicon/), to provide a common framework 
+[Lexicon](https://liferay.design/lexicon), to provide a common framework 
 for building consistent UIs and user experiences across the Liferay product 
 ecosystem. The web implementation of Lexicon (CSS, JS, and HTML) is called 
-[Clay](https://clayui.com/docs/get-started/introduction.html). 
+[Clay](https://clayui.com/). 
 It is automatically available to application developers through a set of CSS 
 classes or our 
 [tag library](/docs/7-2/reference/-/knowledge_base/r/using-the-clay-taglib-in-your-portlets). 

--- a/en/developer/frameworks/articles/front-end-development/01-front-end-dev-intro.markdown
+++ b/en/developer/frameworks/articles/front-end-development/01-front-end-dev-intro.markdown
@@ -85,7 +85,7 @@ the stability, conformity, and future evolution of your applications.
 Below are some of the available front-end extensions:
 
 - [Theme Contributors](/docs/7-2/frameworks/-/knowledge_base/f/packaging-independent-ui-resources-for-your-site)
-- [Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
+- [Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-templates)
 - [Dynamic Includes](/docs/7-2/customization/-/knowledge_base/c/dynamic-includes)
 
 See 

--- a/en/developer/frameworks/articles/front-end-development/02-themes/04-extending-themes/02-installing-themelets-in-your-theme.markdown
+++ b/en/developer/frameworks/articles/front-end-development/02-themes/04-extending-themes/02-installing-themelets-in-your-theme.markdown
@@ -37,5 +37,5 @@ your theme, the themelet will be bundled along with it.
 ## Related Topics
 
 -[Generating Themelets with the Theme Generator](/docs/7-2/reference/-/knowledge_base/r/creating-themelets-with-the-themes-generator)
--[Injecting Additional Context Variables and Functionality into Your Theme Templates](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
+-[Injecting Additional Context Variables and Functionality into Your Theme Templates](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-templates)
 -[Packaging Independent UI Resources for Your Site](/docs/7-2/frameworks/-/knowledge_base/f/packaging-independent-ui-resources-for-your-site)

--- a/en/developer/frameworks/articles/front-end-development/02-themes/04-extending-themes/03-injecting-additional-context-variables-into-your-templates.markdown
+++ b/en/developer/frameworks/articles/front-end-development/02-themes/04-extending-themes/03-injecting-additional-context-variables-into-your-templates.markdown
@@ -1,5 +1,5 @@
 ---
-header-id: injecting-additional-context-variables-and-functionality-into-your-theme-te
+header-id: injecting-additional-context-variables-and-functionality-into-your-theme-templates
 ---
 
 # Injecting Additional Context Variables and Functionality into Your Theme Templates

--- a/en/developer/reference/articles/02-project-templates/template-context-contributor-template.markdown
+++ b/en/developer/reference/articles/02-project-templates/template-context-contributor-template.markdown
@@ -83,5 +83,5 @@ files to the folders outlined above. You can visit the
 [template-context-contributor](https://github.com/liferay/liferay-blade-samples/tree/master/gradle/themes/template-context-contributor)
 sample project for a more expanded sample of a template context contributor.
 Likewise, see the
-[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
+[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-templates)
 tutorial for instructions on customizing a template context contributor project.

--- a/en/developer/reference/articles/02-sample-projects/05-themes/template-context-contributor.markdown
+++ b/en/developer/reference/articles/02-sample-projects/05-themes/template-context-contributor.markdown
@@ -45,7 +45,7 @@ fit your needs, see the Javadoc listed in this sample's
 `com.liferay.blade.samples.theme.contributorBladeTemplateContextContributor`
 class. For more information on context contributors and how to create them in
 @product@, visit the
-[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-te)
+[Context Contributors](/docs/7-2/frameworks/-/knowledge_base/f/injecting-additional-context-variables-and-functionality-into-your-theme-templates)
 tutorial.
 
 ## Where Is This Sample?


### PR DESCRIPTION
[LRDOCS-8298](https://issues.liferay.com/browse/LRDOCS-8298)

This PR contains two commits.
* 03cc09a : This PR fixes broken two links
* 1c3ebb6 : I am unsure if this fixes the broken links to [this article](https://help.liferay.com/hc/en-us/articles/360017887492-Injecting-Additional-Context-Variables-and-Functionality-into-Your-Templates)--I couldn't see what was wrong with the links, since I'm unfamiliar with liferay-docs url conventions.