### PR TITLE
LRDOCS-10363 Fix link to similar article on learn.liferay.com

### DIFF
--- a/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
+++ b/en/developer/frameworks/articles/web-experience-management/02-page-fragments/06-creating-contributed-fragment-collection.markdown
@@ -7,7 +7,7 @@ header-id: creating-contributed-fragment-collection
 [TOC levels=1-4]
 
 <aside class="alert alert-info">
-	<span class="wysiwyg-color-blue120">This document has been updated and ported to <a href="https://learn.liferay.com/dxp/latest/en/site-building/developer-guide/developing-page-fragments/creating-a-contributed-fragment-collection.html">Liferay Learn</a> and is no longer maintained here.</span>
+	<span class="wysiwyg-color-blue120">This document has been updated and ported to <a href="https://learn.liferay.com/dxp/latest/en/site-building/developer-guide/developing-page-fragments/creating-a-contributed-fragment-set.html">Liferay Learn</a> and is no longer maintained here.</span>
 </aside>
 
 To create a Contributed Fragment Collection, a developer must,


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-10363

This is a simple link fix, to an article that was renamed. (Note that a redirect was not added for this article when it was renamed; however, given it's already been a year since it was, I'm not sure it's worth adding one now)

The complaint originally comes from content on an HC article (which is of course no longer maintained), which we have ported but then reorganized the relevant parts to handle them totally differently (no longer using such a specific example that has the issue). I was originally thinking about re-adding the way it was documented in the HC article, but after talking with James and seeing the way we are doing it now (without using such arbitrary examples), I don't think that would really add any extra value, and would just be a bit distracting. So I am just going ahead with simply fixing the link to the appropriate Learn article for this.

Please let me know if there are any questions or concerns about this. Thanks!