### PR TITLE
LRDOCS-7377 Section is called Audience Targeting

### DIFF
--- a/en/discover/portal/articles-dxp/160-targeting-content-to-your-audience/08-audience-targeting-system-settings.markdown
+++ b/en/discover/portal/articles-dxp/160-targeting-content-to-your-audience/08-audience-targeting-system-settings.markdown
@@ -10,7 +10,7 @@ Audience Targeting's configuration options are provided in [System
 Settings](/docs/7-1/user/-/knowledge_base/u/system-settings). Configurations
 made here take effect system-wide. You can find Audience Targeting system
 settings by navigating to the Control Panel &rarr; *Configuration* &rarr;
-*System Settings* &rarr; *Web Experience*. The following options are available
+*System Settings* &rarr; *Audience Targeting*. The following options are available
 for the Audience Targeting apps:
 
 - [Audience Targeting Analytics Service](#audience-targeting-analytics-service)


### PR DESCRIPTION
Related issue: [LRDOCS-7377](https://liferay.atlassian.net/browse/LRDOCS-7377)

The HC article says Web Experience, but in 7.1 it's called Audience Targeting

What was changed :mage_man::
- Corrected the name

Article in question - [Audience Targeting System Settings](https://help.liferay.com/hc/en-us/articles/360017895092-Audience-Targeting-System-Settings-)