### PR TITLE
LRDOCS-2768 Remove old link

### DIFF
--- a/discover/deployment/articles/06-upgrading-liferay/05-upgrading-social-office.markdown
+++ b/discover/deployment/articles/06-upgrading-liferay/05-upgrading-social-office.markdown
@@ -6,15 +6,15 @@ header-id: upgrading-social-office
 
 [TOC levels=1-4]
 
-Liferay Social Office, Liferay's social collaboration product for the 
-enterprise, was an add-on product for Liferay Portal versions prior to 
-@product-ver@. Social Office is no longer available because @product-ver@ 
-contains its features. When upgrading from a previous version of Liferay Portal 
-that contains Social Office, 
-[the standard upgrade procedure](/docs/7-0/deploy/-/knowledge_base/d/upgrading-to-liferay-7) 
-handles most things for you. You must, however, perform a few additional steps 
-to ensure that Social Office's features work as intended in @product-ver@. This 
-article takes you through these steps. 
+Liferay Social Office, Liferay's social collaboration product for the
+enterprise, was an add-on product for Liferay Portal versions prior to
+@product-ver@. Social Office is no longer available because @product-ver@
+contains its features. When upgrading from a previous version of Liferay Portal
+that contains Social Office,
+[the standard upgrade procedure](/docs/7-0/deploy/-/knowledge_base/d/upgrading-to-liferay-7)
+handles most things for you. You must, however, perform a few additional steps
+to ensure that Social Office's features work as intended in @product-ver@. This
+article takes you through these steps.
 
 | **Note:** Before upgrading your Social Office installation, you must first
 | upgrade your Liferay Portal installation to @product-ver@. The steps for this
@@ -25,19 +25,19 @@ article takes you through these steps.
 | Social Office installation.
 
 First, you'll learn how Social Office's unique components map to @product-ver@
-features. 
+features.
 
 ## Social Office Components
 
-Social Office contained the following components: 
+Social Office contained the following components:
 
 - A unique theme and site template
 - Customized Liferay Portal applications
 - Applications unique to Social Office
 - User experience (UX) enhancements
 
-The following sections describe the components and how they work in 
-@product-ver@. 
+The following sections describe the components and how they work in
+@product-ver@.
 
 ### Themes and Templates
 
@@ -45,27 +45,27 @@ Social Office's unique look and feel was defined by its theme and site template.
 These don't exist in @product-ver@. In @product-ver@, however, you can build
 themes and templates to fit your requirements. The ability to customize the
 look, feel, and page layout of @product-ver@ is one of its most powerful
-capabilities. 
+capabilities.
 
-This table shows how Social Office's theme and template components map to 
-@product-ver@. 
+This table shows how Social Office's theme and template components map to
+@product-ver@.
 
-Component | &nbsp;Social Office 3.x | &nbsp;@product-ver@ | 
---------- | ----------------------- | ------------------- | 
+Component | &nbsp;Social Office 3.x | &nbsp;@product-ver@ |
+--------- | ----------------------- | ------------------- |
 Social Office Theme | Uses Social Office theme | Uses default @product-ver@ theme, or a custom theme |
 Site Template | Uses Social Office site template | The Social Office site template is upgraded to @product-ver@. A custom site template can also be used. |
 Page Templates | Doesn't use page templates | Page templates can be used |
 
 ### Liferay Apps
 
-Social Office improved many out-of-the-box apps in previous versions of Liferay 
-Portal. Many of those improvements are now in @product-ver@. 
+Social Office improved many out-of-the-box apps in previous versions of Liferay
+Portal. Many of those improvements are now in @product-ver@.
 
-This table shows how the apps modified by Social Office in previous versions of 
-Liferay Portal map to @product-ver@. 
+This table shows how the apps modified by Social Office in previous versions of
+Liferay Portal map to @product-ver@.
 
-App | &nbsp;Social Office 3.x | &nbsp;@product-ver@ | 
---- | ----------------------- | ------------------- | 
+App | &nbsp;Social Office 3.x | &nbsp;@product-ver@ |
+--- | ----------------------- | ------------------- |
 Announcements | UI enhancements | Although the Announcements app is included in @product-ver@, the UI enhancements from Social Office 3.x aren't. See [the Announcements app's documentation](/docs/7-0/user/-/knowledge_base/u/sending-alerts-and-announcements) for instructions on using the app in @product-ver@. |
 Document Library File Version Comments | Versioning Improvements | Provided as an add-on module. The [*Module Installation* section below](/docs/7-0/deploy/-/knowledge_base/d/upgrading-social-office#module-installation) contains a link to this module. |
 Notifications | Various enhancements | Included |
@@ -75,135 +75,135 @@ Activities | Various enhancements | Included |
 
 ### Social Office Apps
 
-Several apps were unique to Social Office. With the exception of the Tasks 
-portlet, these apps are now in @product-ver@. 
+Several apps were unique to Social Office. With the exception of the Tasks
+portlet, these apps are now in @product-ver@.
 
-This table shows how apps unique to Social Office map to @product-ver@. 
+This table shows how apps unique to Social Office map to @product-ver@.
 
-App | &nbsp;@product-ver@ | 
---- | ------------------- | 
-Microblogs | Included | 
-Contacts Center | Included | 
-Private Messaging | Provided as an add-on module. The [*Module Installation* section below](/docs/7-0/deploy/-/knowledge_base/d/upgrading-social-office#module-installation) contains more information. | 
-Social Office User Profile | Included | 
-Events List | Provided as an add-on module. [Click here](https://web.liferay.com/marketplace/-/mp/application/83511066) to get it for Liferay Portal CE [or here](https://web.liferay.com/marketplace/-/mp/application/83511153) for Liferay DXP. | 
-WYSIWYG | Provided as an add-on module. [Click here](https://web.liferay.com/marketplace/-/mp/application/15502123) to get it for Liferay Portal CE [or here](https://web.liferay.com/marketplace/-/mp/application/15503342) for Liferay DXP. | 
+App | &nbsp;@product-ver@ |
+--- | ------------------- |
+Microblogs | Included |
+Contacts Center | Included |
+Private Messaging | Provided as an add-on module. The [*Module Installation* section below](/docs/7-0/deploy/-/knowledge_base/d/upgrading-social-office#module-installation) contains more information. |
+Social Office User Profile | Included |
+Events List | Provided as an add-on module. [Click here](https://web.liferay.com/marketplace/-/mp/application/83511066) to get it for Liferay Portal CE [or here](https://web.liferay.com/marketplace/-/mp/application/83511153) for Liferay DXP. |
+WYSIWYG | Provided as an add-on module. [Click here](https://web.liferay.com/marketplace/-/mp/application/15502123) to get it for Liferay Portal CE. |
 
 ### UX Enhancements
 
 The UX in @product-ver@ is different than previous versions. It's the first
-version to use [Lexicon](https://liferay.github.io/clay/), a web implementation 
-of Liferay's new [Lexicon Experience Language](https://lexicondesign.io/). 
-Social Office components in @product-ver@ use Lexicon for a consistent UX. This 
-also means that certain Social Office components may not be where you expect 
-them in @product-ver@. 
+version to use [Lexicon](https://liferay.github.io/clay/), a web implementation
+of Liferay's new [Lexicon Experience Language](https://lexicondesign.io/).
+Social Office components in @product-ver@ use Lexicon for a consistent UX. This
+also means that certain Social Office components may not be where you expect
+them in @product-ver@.
 
-This table shows where to access Social Office components in @product-ver@. 
+This table shows where to access Social Office components in @product-ver@.
 
-Component | &nbsp;@product-ver@ | 
---------- | ------------------- | 
+Component | &nbsp;@product-ver@ |
+--------- | ------------------- |
 Dashboard | Control Panel |
 Profile | Control Panel |
 User Bar | Control Panel |
 Site Navigation | My Sites app |
 
-Here's a list of other Social Office functionality that has changed or is 
-missing in @product-ver@: 
+Here's a list of other Social Office functionality that has changed or is
+missing in @product-ver@:
 
-- **Tasks application:** not available for @product-ver@. If you need it, you 
-  must upgrade its source code. 
+- **Tasks application:** not available for @product-ver@. If you need it, you
+  must upgrade its source code.
 
-- **Site Creation Wizard:** not available for @product-ver@. Use site and page 
-  templates instead. An administrator should create the most commonly used site 
-  templates and let site administrators use them as an initial layout for their 
-  sites. 
+- **Site Creation Wizard:** not available for @product-ver@. Use site and page
+  templates instead. An administrator should create the most commonly used site
+  templates and let site administrators use them as an initial layout for their
+  sites.
 
-- **Site Navigation:** available, but modified in @product-ver@. Social Office's 
-  customized My Sites app let Social Office users manage their favorite sites 
-  and site memberships. You can configure @product-ver@'s My Sites app to let 
-  users manage site memberships, but not favorites. 
+- **Site Navigation:** available, but modified in @product-ver@. Social Office's
+  customized My Sites app let Social Office users manage their favorite sites
+  and site memberships. You can configure @product-ver@'s My Sites app to let
+  users manage site memberships, but not favorites.
 
-Great! Now you know what Social Office functionality is and isn't in 
-@product-ver@. Next, you'll install a few modules in preparation for the Social 
-Office upgrade steps. 
+Great! Now you know what Social Office functionality is and isn't in
+@product-ver@. Next, you'll install a few modules in preparation for the Social
+Office upgrade steps.
 
 ## Module Installation
 
-To enable Social Office functionality in your @product-ver@ installation, you 
-should first install a few extra modules. Deploy these modules as you would any 
-other @product-ver@ module: 
+To enable Social Office functionality in your @product-ver@ installation, you
+should first install a few extra modules. Deploy these modules as you would any
+other @product-ver@ module:
 
--   **Social Office Upgrade module:** Provides a set of actions that you can run 
-    to upgrade your Social Office installation. The next section shows you how 
-    to run these actions. 
-    [Click here](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.social.office.upgrade/) 
-    to get this module. This module is the same for Liferay Portal CE and Liferay 
-    DXP. 
+-   **Social Office Upgrade module:** Provides a set of actions that you can run
+    to upgrade your Social Office installation. The next section shows you how
+    to run these actions.
+    [Click here](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.social.office.upgrade/)
+    to get this module. This module is the same for Liferay Portal CE and Liferay
+    DXP.
 
--   **Social Office Upgrade Association module (optional):** When the Social 
-    Office User role was granted to a user in previous versions of Liferay 
-    Portal, Social Office automatically used a site template to create public 
-    and private pages for that user. The Social Office Upgrade Association 
-    module retains this behavior (the upgrade retains the Social Office User 
-    role). 
-    [Click here](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.social.office.upgrade.association/) 
-    to get this module. This module is the same for Liferay Portal CE and 
-    Liferay DXP. 
+-   **Social Office Upgrade Association module (optional):** When the Social
+    Office User role was granted to a user in previous versions of Liferay
+    Portal, Social Office automatically used a site template to create public
+    and private pages for that user. The Social Office Upgrade Association
+    module retains this behavior (the upgrade retains the Social Office User
+    role).
+    [Click here](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.social.office.upgrade.association/)
+    to get this module. This module is the same for Liferay Portal CE and
+    Liferay DXP.
 
--   **Document Library File Version Comments module:** By default, @product-ver@ 
-    users can only comment on documents in a Documents and Media repository. In 
-    Social Office, however, users could also comment on document versions. This 
-    module retains the Social Office behavior. 
-    [Click here](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.document.library.file.version.discussion.web/) 
-    to get this module. This module is the same for Liferay Portal CE and 
-    Liferay DXP. 
+-   **Document Library File Version Comments module:** By default, @product-ver@
+    users can only comment on documents in a Documents and Media repository. In
+    Social Office, however, users could also comment on document versions. This
+    module retains the Social Office behavior.
+    [Click here](https://repository.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.document.library.file.version.discussion.web/)
+    to get this module. This module is the same for Liferay Portal CE and
+    Liferay DXP.
 
--   **Chat:** Enables Social Office chat. This app is available for 
-    [Liferay DXP](https://web.liferay.com/marketplace/-/mp/application/15184463) 
-    and 
-    [Liferay Portal CE](https://web.liferay.com/marketplace/-/mp/application/15392476). 
+-   **Chat:** Enables Social Office chat. This app is available for
+    [Liferay DXP](https://web.liferay.com/marketplace/-/mp/application/15184463)
+    and
+    [Liferay Portal CE](https://web.liferay.com/marketplace/-/mp/application/15392476).
 
--   **Private Messaging:** Enables Social Office Private Messaging in 
-    @product-ver@. Although the first three GA releases (GA1, GA2, GA3) of 
-    Liferay Portal 7.0 CE contain this app, it will be removed in GA4 and 
-    instead released on Liferay Marketplace. To get this app for Liferay DXP, 
-    which doesn't contain it, 
-    [click here](https://web.liferay.com/marketplace/-/mp/application/83559411). 
+-   **Private Messaging:** Enables Social Office Private Messaging in
+    @product-ver@. Although the first three GA releases (GA1, GA2, GA3) of
+    Liferay Portal 7.0 CE contain this app, it will be removed in GA4 and
+    instead released on Liferay Marketplace. To get this app for Liferay DXP,
+    which doesn't contain it,
+    [click here](https://web.liferay.com/marketplace/-/mp/application/83559411).
 
--   **Events List:** Enables Social Office Events Display in @product-ver@. 
-    [Click here](https://web.liferay.com/marketplace/-/mp/application/83511066) 
-    to get this app for Liferay Portal CE 
-    [or here](https://web.liferay.com/marketplace/-/mp/application/83511153) 
-    for Liferay DXP. 
+-   **Events List:** Enables Social Office Events Display in @product-ver@.
+    [Click here](https://web.liferay.com/marketplace/-/mp/application/83511066)
+    to get this app for Liferay Portal CE
+    [or here](https://web.liferay.com/marketplace/-/mp/application/83511153)
+    for Liferay DXP.
 
--   **WYSIWYG:** Enables the Social Office WYSIWYG app. 
-    [Click here](https://web.liferay.com/marketplace/-/mp/application/15502123) 
-    to get this app for Liferay Portal CE 
-    [or here](https://web.liferay.com/marketplace/-/mp/application/15503342) 
-    for Liferay DXP. 
+-   **WYSIWYG:** Enables the Social Office WYSIWYG app.
+    [Click here](https://web.liferay.com/marketplace/-/mp/application/15502123)
+    to get this app for Liferay Portal CE
+    [or here](https://web.liferay.com/marketplace/-/mp/application/15503342)
+    for Liferay DXP.
 
-Once you've installed these modules, you're ready to proceed with the upgrade. 
-Onward! 
+Once you've installed these modules, you're ready to proceed with the upgrade.
+Onward!
 
 ## Upgrade
 
-Now that you're running @product-ver@ and the preceding modules, you're ready to 
-upgrade your Social Office installation. As mentioned earlier, you'll do this by 
-running a set of actions that the Social Office Upgrade modules provide. 
+Now that you're running @product-ver@ and the preceding modules, you're ready to
+upgrade your Social Office installation. As mentioned earlier, you'll do this by
+running a set of actions that the Social Office Upgrade modules provide.
 
 | **Warning:** Some of the Social Office upgrade actions may delete or alter
 | existing data in your database. It's essential that you backup your
 | system [properly](/docs/7-0/deploy/-/knowledge_base/d/backing-up-a-liferay-installation)
 | before running any of them.
 
-You'll run these actions from the 
-[Apache Felix Gogo shell](/docs/7-0/reference/-/knowledge_base/r/using-the-felix-gogo-shell) 
-built into @product-ver@. With @product-ver@ running, enter the Gogo shell by 
-running the following command in a terminal: 
+You'll run these actions from the
+[Apache Felix Gogo shell](/docs/7-0/reference/-/knowledge_base/r/using-the-felix-gogo-shell)
+built into @product-ver@. With @product-ver@ running, enter the Gogo shell by
+running the following command in a terminal:
 
     telnet localhost 11311
 
-The resulting `g!` is the Gogo shell command prompt. 
+The resulting `g!` is the Gogo shell command prompt.
 
 ![Figure 1: The Gogo shell lets you execute commands, including the Social Office upgrade commands, in the OSGi runtime that runs @product-ver@. This screenshot shows the `telnet` command that enters the shell, and the resulting Gogo shell command prompt.](../../images/gogo-prompt.png)
 
@@ -211,52 +211,52 @@ The resulting `g!` is the Gogo shell command prompt.
 | @product-ver@, unless you explicitly open port 11311. For security reasons,
 | **do not** expose the Gogo console to the outside world.
 
-Now you're ready to execute the Social Office upgrade actions. To run an action, 
-execute it on the Gogo shell prompt. Before doing so, however, be sure to 
-carefully read the action's description. Each action is listed here, along with 
-its description: 
+Now you're ready to execute the Social Office upgrade actions. To run an action,
+execute it on the Gogo shell prompt. Before doing so, however, be sure to
+carefully read the action's description. Each action is listed here, along with
+its description:
 
-- `socialOffice:executeAll`: runs all upgrade actions. Before running this 
-  action, be sure to read the descriptions for all actions. 
+- `socialOffice:executeAll`: runs all upgrade actions. Before running this
+  action, be sure to read the descriptions for all actions.
 
-- `socialOffice:removeTasksPortlet`: removes the Tasks portlet from all pages. 
-  Unless you manually upgrade the Tasks portlet's source code, this portlet is 
-  unavailable in @product-ver@. You should therefore remove it from all pages in 
-  your @product-ver@ installation. Note that doing so removes all references to 
-  it from all site pages; after executing this action, there's no way to restore 
-  it. 
+- `socialOffice:removeTasksPortlet`: removes the Tasks portlet from all pages.
+  Unless you manually upgrade the Tasks portlet's source code, this portlet is
+  unavailable in @product-ver@. You should therefore remove it from all pages in
+  your @product-ver@ installation. Note that doing so removes all references to
+  it from all site pages; after executing this action, there's no way to restore
+  it.
 
-- `socialOffice:hideTasksLayout`: hides all pages that contained the Tasks 
-  portlet. 
+- `socialOffice:hideTasksLayout`: hides all pages that contained the Tasks
+  portlet.
 
-- `socialOffice:updateTheme`: restores the default theme for all 
-  pages. Unless you customized the Social Office theme, you should use the 
-  default @product-ver@ theme. 
+- `socialOffice:updateTheme`: restores the default theme for all
+  pages. Unless you customized the Social Office theme, you should use the
+  default @product-ver@ theme.
 
-Next, you'll attend to some administrative tasks in your @product-ver@ instance. 
+Next, you'll attend to some administrative tasks in your @product-ver@ instance.
 
 ## Administration
 
-After running the upgrade actions, there are a few administrative tasks you 
-should complete in your @product-ver@ instance. These tasks help to retain 
-Social Office functionality in @product-ver@. 
+After running the upgrade actions, there are a few administrative tasks you
+should complete in your @product-ver@ instance. These tasks help to retain
+Social Office functionality in @product-ver@.
 
-- **Social Office User Role (optional):** The upgrade to @product-ver@ carries 
-  over the Social Office User role. If the optional Social Office Upgrade 
-  Association module is deployed, you can assign users to this role. Doing so 
-  gives users personal sites that function similarly to Social Office. 
+- **Social Office User Role (optional):** The upgrade to @product-ver@ carries
+  over the Social Office User role. If the optional Social Office Upgrade
+  Association module is deployed, you can assign users to this role. Doing so
+  gives users personal sites that function similarly to Social Office.
 
-- **Managing Social Sites in @product-ver@:** The upgrade to @product-ver@ 
-  carries over all Social Office sites and site templates. To create a new 
-  social site for collaboration in @product-ver@, create a new site using the 
-  default Social Office site template. For more information on building sites 
-  from templates, 
-  [click here](/docs/7-0/user/-/knowledge_base/u/building-sites-from-templates). 
+- **Managing Social Sites in @product-ver@:** The upgrade to @product-ver@
+  carries over all Social Office sites and site templates. To create a new
+  social site for collaboration in @product-ver@, create a new site using the
+  default Social Office site template. For more information on building sites
+  from templates,
+  [click here](/docs/7-0/user/-/knowledge_base/u/building-sites-from-templates).
 
-- **My Sites:** The Site Navigation app was Social Office's custom version of 
-  the My Sites app. It was integrated into Social Office's theme. Since the Site 
-  Navigation app isn't available for @product-ver@, you should use My Sites 
-  instead. As mentioned earlier, however, My Sites doesn't let users manage 
-  their site memberships by default. To enable this functionality, add My Sites 
-  to a custom theme or site template that enables it. For navigating sites, 
-  users can use the new @product-ver@ site navigator in the Product Menu. 
+- **My Sites:** The Site Navigation app was Social Office's custom version of
+  the My Sites app. It was integrated into Social Office's theme. Since the Site
+  Navigation app isn't available for @product-ver@, you should use My Sites
+  instead. As mentioned earlier, however, My Sites doesn't let users manage
+  their site memberships by default. To enable this functionality, add My Sites
+  to a custom theme or site template that enables it. For navigating sites,
+  users can use the new @product-ver@ site navigator in the Product Menu.


### PR DESCRIPTION
Related issue: [LRDOCS-2768](https://liferay.atlassian.net/browse/LRDOCS-2768)

The old dev.liferay page on upgrading to Liferay 7.0 had a couple of links that didn't work. I looked through Help Center to see if they did too and found one link that wasn't working. @mhartel said to remove it.

What was changed :mage_man::
- Removed broken link
- Trimmed white space

Article in question - [Upgrading Social Office](https://help.liferay.com/hc/en-us/articles/360018175591-Upgrading-Social-Office-)