### PR TITLE
LRDOCS-10121 Fix Links on REST Builder

### DIFF
--- a/en/developer/frameworks/articles/web-services/05-rest-builder/01-intro.markdown
+++ b/en/developer/frameworks/articles/web-services/05-rest-builder/01-intro.markdown
@@ -7,18 +7,18 @@ header-id: rest-builder
 [TOC levels=1-4]
 
 REST Builder is @product@'s tool to build REST and GraphQL APIs. It's based
-on OpenAPI, following an 
-[API-first approach](/docs/7-2/frameworks/-/knowledge_base/f/headless-rest-apis). 
+on OpenAPI, following an
+[API-first approach](/docs/7-2/frameworks/-/knowledge_base/f/headless-rest-apis).
 
-Using REST Builder takes only three steps: 
+Using REST Builder takes only three steps:
 
-1. Write the OpenAPI profile. 
+1. Write the OpenAPI profile.
 
-2. Use REST builder to generate the scaffolding. 
+2. Use REST builder to generate the scaffolding.
 
 3. Fill out the generated classes with your logic.
 
-A good overview of the process is detailed [here](https://portal.liferay.dev/docs/7-2/appdev/-/knowledge_base/a/generating-apis-with-rest-builder).
+A good overview of the process is detailed [here](https://help.liferay.com/hc/es/articles/360028748872-Generating-APIs-with-REST-Builder).
 
 We'll see each step in detail but first, let's talk about why we want to use
 REST Builder.
@@ -26,10 +26,10 @@ REST Builder.
 ## Why we should use REST Builder
 
 There are several reasons to prefer REST Builder over rolling our own [JAX-RS
-services](../03-jax/01-jaxrs-intro.markdown). Some of them are the following:
+services](https://help.liferay.com/hc/en-us/articles/360031902292-JAX-RS). Some of them are the following:
 
 * Development speed: you avoid writing JAX-RS annotations, converters, adding
-  support for multipart or layers to organize your code. Everything is generated. 
+  support for multipart or layers to organize your code. Everything is generated.
 * API scaffolding: pagination, filtering, searching, JSON writers, XML
   generation, even unit, and integration tests are generated.
 * GraphQL support out of the box: write your REST API and get a GraphQL endpoint
@@ -38,5 +38,5 @@ services](../03-jax/01-jaxrs-intro.markdown). Some of them are the following:
   CORS handling. You don't have to search manually for the user or the company;
   everything is already there.
 * JSON & XML support: APIs return whichever format the consumer prefers.
-* Consistency: all APIs follow the same rules and conventions, enforced by 
+* Consistency: all APIs follow the same rules and conventions, enforced by
   REST builder.


### PR DESCRIPTION
Related issue: [LRDOCS-10121](https://liferay.atlassian.net/browse/LRDOCS-10121)

The link to JAX-RS was wrong. I found that the other link in this page was also outdated.

What was changed :mage_man::
- Fixed both links

Article in question - [REST Builder](https://help.liferay.com/hc/es/articles/360036343312-REST-Builder)