### PR TITLE
LRDOCS-10127 Fix attribute name

### DIFF
--- a/develop/tutorials/articles/310-troubleshooting/10-js-css-changes.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/10-js-css-changes.markdown
@@ -6,20 +6,20 @@ header-id: why-arent-my-modules-javascript-and-css-changes-showing
 
 [TOC levels=1-4]
 
-To determine why JavaScript and CSS updates to your module aren't having an 
-effect in your browser, perform these checks: 
+To determine why JavaScript and CSS updates to your module aren't having an
+effect in your browser, perform these checks:
 
-1.  If you're developing a portlet module, check that your portlet class has the 
-    correct properties specified in its `@Component` annotation: 
+1.  If you're developing a portlet module, check that your portlet class has the
+    correct properties specified in its `@Component` annotation:
 
-    - Make sure the resources referred to by the properties of your portlet 
-      class's `@Component` annotation exist in the correct location in your module 
-      project. 
-    - Make sure that you're using a portlet CSS wrapper class to prevent 
+    - Make sure the resources referred to by the properties of your portlet
+      class's `@Component` annotation exist in the correct location in your module
+      project.
+    - Make sure that you're using a portlet CSS wrapper class to prevent
       potential CSS ID and class name conflicts with other applications on the
-      page. 
+      page.
 
-    For example, consider this sample portlet class: 
+    For example, consider this sample portlet class:
 
         @Component(
             immediate = true,
@@ -28,7 +28,7 @@ effect in your browser, perform these checks:
                 "com.liferay.portlet.display-category=category.sample",
                 "com.liferay.portlet.instanceable=true",
                 "com.liferay.portlet.header-portlet-css=/css/main.css",
-                "com.liferay.portlet.header-portlet-js=/css/main.js",
+                "com.liferay.portlet.header-portlet-javascript=/css/main.js",
                 "javax.portlet.display-name=Example Portlet",
                 "javax.portlet.init-param.template-path=/",
                 "javax.portlet.init-param.view-template=/view.jsp",
@@ -42,20 +42,20 @@ effect in your browser, perform these checks:
 
         }
 
-    As described in the first item above, the portlet's CSS file is specified by 
-    the property `com.liferay.portlet.header-portlet-css`. Paths specified as 
-    values of this property are relative to the module's 
-    `src/main/resources/META-INF/resources` folder. So if you specify a value 
-    of `css/main.css`, the actual path to the CSS file in the module is 
-    `src/main/resources/META-INF/resources/css/main.css`. The path to your 
-    portlet's JavaScript file is specified by the property 
-    `com.liferay.portlet.header-portlet-js`. Values for this property work the 
-    same as the values for the CSS property. 
+    As described in the first item above, the portlet's CSS file is specified by
+    the property `com.liferay.portlet.header-portlet-css`. Paths specified as
+    values of this property are relative to the module's
+    `src/main/resources/META-INF/resources` folder. So if you specify a value
+    of `css/main.css`, the actual path to the CSS file in the module is
+    `src/main/resources/META-INF/resources/css/main.css`. The path to your
+    portlet's JavaScript file is specified by the property
+    `com.liferay.portlet.header-portlet-javascript`. Values for this property work the
+    same as the values for the CSS property.
 
-    Also note that the property `com.liferay.portlet.css-class-wrapper` 
-    specifies the CSS class wrapper `example-portlet`. Thus, you should use 
-    subclasses of `example-portlet` in your portlet's actual CSS file. For 
-    example, in `main.css` you'd do this to change the background to green: 
+    Also note that the property `com.liferay.portlet.css-class-wrapper`
+    specifies the CSS class wrapper `example-portlet`. Thus, you should use
+    subclasses of `example-portlet` in your portlet's actual CSS file. For
+    example, in `main.css` you'd do this to change the background to green:
 
         .example-portlet {
             .greenBackground {
@@ -68,19 +68,19 @@ effect in your browser, perform these checks:
 
     In other words, to avoid CSS class and ID name conflicts, all the CSS
     properties you specify must be subclasses of the class specified via the
-    `com.liferay.portlet.css-class-wrapper` property. @product@ wraps your 
-    portlet's HTML content with a `<div>`. The class specified by 
-    `com.liferay.portlet.css-class-wrapper` (`example-portlet`, in this example) 
-    has been applied to this `<div>`. 
+    `com.liferay.portlet.css-class-wrapper` property. @product@ wraps your
+    portlet's HTML content with a `<div>`. The class specified by
+    `com.liferay.portlet.css-class-wrapper` (`example-portlet`, in this example)
+    has been applied to this `<div>`.
 
-2.  Check that caching isn't preventing JS and CSS updates to your module from 
-    appearing in your browser: 
+2.  Check that caching isn't preventing JS and CSS updates to your module from
+    appearing in your browser:
 
     - Clear your browser's cache.
-    - During development, enable developer mode to turn off @product@'s resource 
-    caching. 
-    [Click here](/docs/7-0/tutorials/-/knowledge_base/t/using-developer-mode-with-themes) 
-    to learn how to enable @product@'s developer mode. 
+    - During development, enable developer mode to turn off @product@'s resource
+    caching.
+    [Click here](/docs/7-0/tutorials/-/knowledge_base/t/using-developer-mode-with-themes)
+    to learn how to enable @product@'s developer mode.
 
 ## Related Topics
 


### PR DESCRIPTION
Related issue: [LRDOCS-10127](https://liferay.atlassian.net/browse/LRDOCS-10127)

Example uses com.liferay.portlet.header-portlet-js when it should use com.liferay.portlet.header-portlet-javascript

What was changed :mage_man::
- Changed js to javascript

Article in question - [Why Aren't My Module's JavaScript and CSS Changes Showing?](https://help.liferay.com/hc/en-us/articles/360018162731-Why-Aren-t-my-Module-s-JavaScript-and-CSS-Changes-Showing-?source=search)