### PR TITLE
LRDOCS-7293 Custom Fields aren't deleted on the Live env after publishing (7.0.x)

### DIFF
--- a/discover/portal/articles/100-web-experience-management/03-staging-content-for-publication/03-using-the-staging-environment.markdown
+++ b/discover/portal/articles/100-web-experience-management/03-staging-content-for-publication/03-using-the-staging-environment.markdown
@@ -18,7 +18,7 @@ to make changes.
 ## Staging Content
 
 Click on the *Staging* button to view the staged area. Your management options
-are restored and you can access some new options related to staging. 
+are restored and you can access some new options related to staging.
 
 ![Figure 1: You can see the new staging options added to the top and left of your screen.](../../../images/staging-live-page.png)
 
@@ -121,6 +121,10 @@ the Web Content label. Otherwise, the Web Content section is absent.
 *Categories* and *Page Ratings* content types are not dependent on the date
 range, and are always shown in the list.
 
+| **Note:** Since some content types are meant for the end user and aren't
+| supported in staging (e.g. comments, ratings, and custom fields), they can
+| only be added to the live site and cannot be removed.
+
 Unchecking the checkbox next to a certain content type excludes it from the
 current publication to Live.
 
@@ -135,7 +139,7 @@ clicking the *Change* button next to the list.
 *Referenced Content* is represented by the Documents and Media files included in
 web content articles. Documents and Media content gets referenced when a user
 uses the editor to insert an image or if the article is based on a structure
-that has a field of the *Documents and Media* type. 
+that has a field of the *Documents and Media* type.
 
 Web content tends to be frequently updated, often more so than other kinds of
 content. Sometimes this can result in high numbers of versions, into the


### PR DESCRIPTION
Jira ticket: https://liferay.atlassian.net/browse/LRDOCS-7293
Related article: https://help.liferay.com/hc/en-us/articles/360018172331-Advanced-Publication-with-Staging

When using the Staging function in Liferay Portal, some types of content (in this case, Custom Fields) aren't supported for staging and will only be added in the Live server. That means that it will not be deleted by using Staging after being added to the Live enviroment, except by doing it directly.

This PR adds this information in the 7.0.x version of the article.

Changes made: 
- Add note about unsupported content for staging; and
- Remove trailing spaces.

___

Thanks, @abhnerramos, for [reviewing](https://github.com/abhnerramos/liferay-docs/pull/12) this PR.