### PR TITLE
LRDOCS-7293 Custom Fields aren't deleted on the Live env after publishing (7.1.x) 

### DIFF
--- a/en/discover/portal/articles/100-web-experience-management/07-staging-content-for-publication/03-using-the-staging-environment/02-advanced-publication-with-staging.markdown
+++ b/en/discover/portal/articles/100-web-experience-management/07-staging-content-for-publication/03-using-the-staging-environment/02-advanced-publication-with-staging.markdown
@@ -78,8 +78,9 @@ Content label. Otherwise, the Web Content section is absent.
 The *Categories* content type is not dependent on the date range and is always
 shown in the list.
 
-| **Note:** Since comments and ratings are meant for the end user, they are not
-| supported in staging and can only be added to the live site.
+| **Note:** Since some content types are meant for the end user and aren't
+| supported in staging (e.g. comments, ratings, and custom fields), they can
+| only be added to the live site and cannot be removed.
 
 Unchecking the checkbox next to a certain content type excludes it from the
 current publication to the live site.
@@ -98,10 +99,10 @@ article for more information on managing content during the publication process.
 
 ## Deletions
 
-This portion of the menu lets you delete two things: 
+This portion of the menu lets you delete two things:
 
-- portlet metadata before publishing 
-- operations performed for content types. 
+- portlet metadata before publishing
+- operations performed for content types.
 
 You have two options to manage for deletions:
 


### PR DESCRIPTION
Jira ticket: https://liferay.atlassian.net/browse/LRDOCS-7293
Related article: https://help.liferay.com/hc/en-us/articles/360018172331-Advanced-Publication-with-Staging

When using the Staging function in Liferay Portal, some types of content (in this case, Custom Fields) aren't supported for staging and will only be added in the Live server. That means that it will not be deleted by using Staging after being added to the Live enviroment, except by doing it directly.

This PR adds this information in the 7.1 version of the article.

Changes made: 
- Modify note to include Custom Fields; and
- Remove trailing spaces.

___

Thanks, @abhnerramos, for [reviewing](https://github.com/abhnerramos/liferay-docs/pull/11) this PR.